### PR TITLE
fix: add community skills to skills/ directory for sync pipeline

### DIFF
--- a/skills/cross-border/cross-border-vat-gst.md
+++ b/skills/cross-border/cross-border-vat-gst.md
@@ -1,0 +1,320 @@
+---
+name: cross-border-vat-gst
+description: >
+  VAT, GST, and sales tax compliance for international digital businesses. Use when the user
+  asks about: VAT, GST, sales tax, value added tax, goods and services tax, EU VAT, UK VAT,
+  VAT OSS, One-Stop Shop, VAT registration, reverse charge, Merchant of Record, Paddle,
+  Lemon Squeezy, Stripe Tax, digital services tax, DST, IOSS, Import One-Stop Shop,
+  B2C digital VAT, B2B reverse charge, VIES validation, Australia GST, Singapore GST,
+  Japan JCT, consumption tax, Canada GST/HST, US sales tax, economic nexus, SaaS tax,
+  digital product tax, VAT compliance, VAT threshold, EU B2C sales, cross-border VAT,
+  international VAT, when to register for VAT, VAT penalties, late registration,
+  Mehrwertsteuer, TVA, IVA, 消費税, or any question about indirect tax compliance
+  for businesses selling digital products or services internationally.
+version: 1.0
+jurisdiction: INTL
+tax_year: 2025-2026
+category: international
+---
+
+# Cross-Border VAT/GST Compliance — International Digital Businesses
+
+> **Based on work by [Artin (@ar-gen-tin)](https://github.com/ar-gen-tin/panrise)**, licensed under MIT. Adapted for the OpenAccountants format.
+
+> **Disclaimer:** This skill provides general guidance on VAT/GST compliance for digital services. VAT rules are complex, jurisdiction-specific, and change frequently. Consult a qualified indirect tax advisor before registering, filing, or taking positions on VAT/GST obligations. Errors can result in retroactive assessments, penalties, and interest.
+
+---
+
+## Core Decision: Do You Need to Collect Tax from Customers?
+
+The answer depends on three factors:
+
+1. **WHERE** is the customer located?
+2. **WHAT** are you selling (digital product, SaaS, physical goods, consulting)?
+3. **HOW MUCH** do you sell into that jurisdiction?
+
+---
+
+## Compliance Strategy by Revenue Level
+
+| Revenue Level | Recommendation | Estimated Cost |
+|---------------|----------------|----------------|
+| <€10,000 from any single jurisdiction | Monitor only — below most thresholds | $0 |
+| €10,000–€100,000 with global customers | Use a Merchant of Record (Paddle, Lemon Squeezy) — they handle all tax | 5–10% of revenue |
+| >€100,000 with concentrated markets | Self-register in top 2–3 markets + Stripe Tax for automation | $2,000–5,000/year in accounting |
+
+### Merchant of Record (MoR) Decision Framework
+
+| Revenue | Complexity Tolerance | Recommendation |
+|---------|----------------------|----------------|
+| <$50,000 | Any | MoR (Paddle / Lemon Squeezy) |
+| $50,000–$200,000 | Low | MoR |
+| $50,000–$200,000 | High | Self-register top markets + Stripe Tax |
+| >$200,000 | Any | Self-register + accountant + Stripe Tax |
+
+**MoR services (Paddle, Lemon Squeezy, FastSpring)** act as the legal seller:
+- They collect VAT/GST from customers
+- They file and remit VAT to each country
+- You receive net payment
+- Cost: 5–10% of revenue (includes payment processing)
+
+---
+
+## EU VAT (Value Added Tax)
+
+### When It Applies
+
+- Selling digital products/services (SaaS, ebooks, courses, software) to EU consumers (B2C)
+- Applies regardless of where YOUR company is registered
+- Threshold: **€10,000/year** in total EU B2C sales → must register
+
+### EU VAT Rates (Digital Services)
+
+| Country | Standard Rate |
+|---------|---------------|
+| Germany | 19% |
+| France | 20% |
+| Netherlands | 21% |
+| Spain | 21% |
+| Italy | 22% |
+| Ireland | 23% |
+| Sweden | 25% |
+
+### VAT OSS (One-Stop Shop)
+
+- Register in ONE EU country → report all EU B2C sales through one portal
+- No need to register in each country separately
+- Available to non-EU businesses via "Non-Union OSS" scheme
+- File quarterly returns
+
+### B2B Sales to EU
+
+- If the EU customer provides a valid VAT number → **reverse charge** (0% VAT; customer self-assesses)
+- Always validate EU VAT numbers via VIES system before zero-rating
+- URL: https://ec.europa.eu/taxation_customs/vies/
+
+---
+
+## UK VAT
+
+### When It Applies
+
+- Selling digital services to UK consumers (B2C)
+- **No threshold for non-UK businesses** — must register from first sale
+- UK businesses: £90,000 threshold
+
+### UK VAT Rate
+
+- **20%** standard rate
+
+---
+
+## US Sales Tax
+
+### When It Applies
+
+- Selling to US customers (digital or physical)
+- "Nexus" required: physical presence OR **economic nexus**
+- Economic nexus: most states trigger at **$100,000 in sales OR 200 transactions/year**
+
+### Key Facts
+
+- US has NO federal sales tax — it is state-by-state (45 states + DC)
+- Digital products/SaaS taxability varies by state:
+  - **Taxable in:** TX, NY, PA, WA, and ~20 others
+  - **Not taxable in:** CA (SaaS), GA, MO, and others
+- If you have no US nexus: you may not need to collect (rules evolving)
+
+### Solutions
+
+| Tool | Cost | Detail |
+|------|------|--------|
+| Stripe Tax | $0.50/transaction | Automatic calculation and collection |
+| TaxJar / Avalara | Varies | Full compliance automation |
+| Paddle / Lemon Squeezy | 5–10% of revenue | MoR handles everything |
+
+---
+
+## Australia GST
+
+| Factor | Detail |
+|--------|--------|
+| Trigger | Selling digital services to Australian consumers (B2C) |
+| Threshold | AUD 75,000/year in Australian sales |
+| Rate | **10%** on digital supplies |
+| Filing | Quarterly BAS (Business Activity Statement) |
+| Non-resident suppliers | Must register for GST if above threshold |
+
+---
+
+## Singapore GST
+
+| Factor | Detail |
+|--------|--------|
+| Trigger | Taxable turnover >SGD 1,000,000/year (mandatory); voluntary registration available |
+| Non-resident digital services | Must register if >SGD 100,000 in SG consumer sales |
+| Rate | **9%** (increased from 8% in 2024) |
+| Filing | Quarterly |
+
+---
+
+## Japan Consumption Tax (JCT — 消費税)
+
+| Factor | Detail |
+|--------|--------|
+| Trigger | Foreign businesses selling digital services to Japanese consumers |
+| Threshold | Must register regardless of revenue threshold |
+| Rate | **10%** (8% reduced rate for some items) |
+
+---
+
+## New Zealand GST
+
+| Factor | Detail |
+|--------|--------|
+| Trigger | Non-resident suppliers of digital services to NZ consumers |
+| Threshold | NZD 60,000/year in NZ sales |
+| Rate | **15%** |
+
+---
+
+## Canada GST/HST
+
+| Factor | Detail |
+|--------|--------|
+| Trigger | Non-resident suppliers selling digital services to Canadian consumers |
+| Threshold | CAD 30,000/year in Canadian sales |
+| Rate | 5% GST (federal) + 0–10% provincial (HST combined up to 15%) |
+| Registration | Simplified registration available for non-residents |
+
+---
+
+## Filing Deadlines Summary
+
+| Jurisdiction | Filing Frequency | Typical Deadline |
+|--------------|------------------|------------------|
+| EU VAT OSS | Quarterly | End of month after quarter |
+| UK VAT | Quarterly | 1 month + 7 days after period |
+| Australia GST | Quarterly | 28 days after quarter |
+| Singapore GST | Quarterly | 1 month after quarter |
+| Japan JCT | Annually or semi-annually | 2 months after fiscal year end |
+| Canada GST/HST | Annually or quarterly | Varies by reporting period |
+| US Sales Tax | Varies by state | Monthly / quarterly / annually |
+
+---
+
+## Digital Services Tax (DST) — NOT the Same as VAT
+
+DST is a revenue-based tax on digital services. Unlike VAT (transaction-level, charged to customers) and corporate tax (profit-based), DST is calculated on gross revenue and comes out of your own revenue.
+
+### DST Rates and Thresholds
+
+| Country | DST Rate | Global Revenue Threshold | Local Revenue Threshold |
+|---------|----------|--------------------------|------------------------|
+| UK | 2% | £500M global | £25M UK |
+| France | 3% | €750M global | €25M France |
+| Italy | 3% | €750M global | €5.5M Italy |
+| Spain | 3% | €750M global | €3M Spain |
+| Turkey | 7.5% | €750M global | TRY 20M Turkey |
+| India (Equalization Levy) | 2% | **No threshold** | ₹2 crore (~$240K) |
+| Kenya | 1.5% | **No threshold** | KES 0 (all digital services) |
+
+**For most small businesses:** The high global revenue thresholds in Europe (£500M, €750M) make DST irrelevant.
+
+**Exceptions — India and Kenya have NO global revenue threshold:**
+- **India Equalization Levy:** 2% on gross consideration for non-resident e-commerce operators selling digital services to Indian customers. Must register and file quarterly.
+- **Kenya Digital Service Tax:** 1.5% on gross transaction value. No minimum threshold.
+
+| Your India/Kenya Revenue | Action |
+|--------------------------|--------|
+| <$10,000/year | Monitor; enforcement limited at this scale |
+| $10,000–$50,000/year | Consult tax advisor; weigh registration cost vs exposure |
+| >$50,000/year | Register and comply; enforcement risk is real |
+
+---
+
+## Penalties and Remediation
+
+### Late Registration Penalties
+
+Most EU countries impose penalties for selling above the €10,000 threshold without registration:
+- **Minimum penalty:** ~€500 (small/first-time violation)
+- **Maximum penalty:** ~5% of unpaid VAT (sustained non-compliance)
+- Interest accrues from the date VAT was originally due
+
+### Voluntary Disclosure Programs
+
+| Jurisdiction | Program | Penalty Reduction |
+|--------------|---------|-------------------|
+| EU (most countries) | Voluntary correction | 50–75% reduction |
+| UK | Unprompted disclosure to HMRC | Best terms (~30% of maximum) |
+| Australia | Voluntary disclosure | Significant reduction; no penalty if minor |
+| US | Voluntary Disclosure Programs (VDP) | Varies by state; generally 50%+ reduction |
+
+**"Unprompted" means you contact the authority before they contact you.** Once an audit begins, voluntary disclosure terms are lost.
+
+### Remediation Steps
+
+1. Stop selling into the affected jurisdiction until registered (or switch to MoR immediately)
+2. Calculate total VAT owed retroactively from the date the threshold was crossed
+3. File voluntary disclosure with the relevant tax authority
+4. Pay outstanding VAT + reduced penalty + accrued interest
+5. Register going forward through standard process
+
+### When to Get Professional Help
+
+If total exposure exceeds **€5,000** or involves **multiple countries**, hire a VAT specialist. Typical remediation cost: €500–2,000 per engagement — almost always cheaper than the penalties avoided.
+
+---
+
+## Physical Goods — Key Differences from Digital Services
+
+| Dimension | Digital Services | Physical Goods |
+|-----------|-----------------|----------------|
+| Delivery | Instant, borderless | Shipping, customs clearance |
+| VAT trigger | Customer location | Import entry |
+| Additional taxes | DST (rare) | Customs duty, tariffs |
+| Complexity | Medium | High |
+
+### EU Physical Goods (Post-2021)
+
+- **No de minimis exemption** — ALL imports subject to VAT (was €22 before 2021)
+- Customs duty threshold: €150 still applies
+- **IOSS (Import One-Stop Shop):** Lets non-EU sellers collect and remit VAT at point of sale for goods <€150. Without IOSS, carrier or customs collects VAT from buyer on delivery (poor customer experience).
+
+### US De Minimis (Section 321)
+
+- Shipments ≤**$800 USD** per day per importer: exempt from customs duty
+- Above $800: customs duty + potential tariffs apply
+- Threshold under legislative review — verify before building logistics around it
+
+---
+
+## Platform Income — VAT Threshold Aggregation
+
+If earning across multiple platforms (YouTube, Patreon, Substack, Gumroad), **aggregate total EU digital services revenue** for VAT threshold purposes:
+
+- EU VAT OSS threshold: **€10,000/year** across ALL EU B2C digital sales (not per platform)
+- Gumroad and Paddle handle VAT for their platform sales (they are MoR)
+- Stripe, Patreon, and AdSense do NOT handle VAT — the seller is responsible
+
+---
+
+## Official Sources & Further Reading
+
+- **EU VAT OSS:** https://vat-one-stop-shop.ec.europa.eu
+- **EU VIES VAT Number Validation:** https://ec.europa.eu/taxation_customs/vies/
+- **UK HMRC — VAT for digital services:** https://www.gov.uk/guidance/vat-on-digital-services
+- **Australia ATO — GST on digital supplies:** https://www.ato.gov.au/Business/International-tax-for-business/GST-on-imported-services-and-digital-products/
+- **Singapore IRAS — GST for digital services:** https://www.iras.gov.sg
+- **Japan NTA — JCT:** https://www.nta.go.jp
+- **Canada CRA — GST/HST for non-residents:** https://www.canada.ca/en/revenue-agency.html
+- **Stripe Tax:** https://stripe.com/tax
+- **Paddle:** https://www.paddle.com
+- **Lemon Squeezy:** https://www.lemonsqueezy.com
+
+---
+
+*Data reflects 2024–2026 rules. VAT/GST thresholds, rates, and registration requirements change frequently. Verify all figures with official sources and a qualified indirect tax advisor.*
+*Original content: [Artin (@ar-gen-tin)](https://github.com/ar-gen-tin/panrise) — MIT License.*
+*OpenAccountants — open-source tax computation skills — info@openaccountants.com*

--- a/skills/cross-border/forex-controls.md
+++ b/skills/cross-border/forex-controls.md
@@ -1,0 +1,320 @@
+---
+name: forex-controls
+description: >
+  Foreign exchange controls and cross-border money movement rules by country. Use when the
+  user asks about: forex controls, foreign exchange limits, FEMA, LRS, SAFE, 外汇管制,
+  capital controls, money transfer limits, remittance limits, CRS reporting, TCS India,
+  IOF Brazil, sending money abroad, receiving money from overseas, forex restrictions China,
+  India remittance limit, Brazil forex, Taiwan outward remittance, Korea forex reporting,
+  Japan foreign exchange, ODI filing China, cross-border transfer, 境外汇款, 购汇额度,
+  地下钱庄, forex quota, capital movement restrictions, repatriation of profits,
+  sending money home, or any question about moving money across international borders
+  as a founder or freelancer.
+version: 1.0
+jurisdiction: INTL
+tax_year: 2025-2026
+category: international
+---
+
+# Foreign Exchange Controls — Cross-Border Money Movement by Country
+
+> **Based on work by [Artin (@ar-gen-tin)](https://github.com/ar-gen-tin/panrise)**, licensed under MIT. Adapted for the OpenAccountants format.
+
+> **Disclaimer:** This skill provides general information about foreign exchange regulations. Forex rules change frequently and enforcement varies. Violating forex controls can result in severe penalties including account freezes, fines, and criminal charges. Consult a qualified advisor in the relevant jurisdiction before structuring cross-border transactions.
+
+---
+
+## Why Forex Controls Matter
+
+Forex (外汇) controls determine whether a person or business can freely move money in and out of a country. For founders earning from global customers, forex restrictions are often the single most important factor in choosing where to incorporate.
+
+**Key principle:** If your home country has strict forex controls, incorporate in a country WITHOUT controls (HK, SG, US, UAE). This enables unrestricted global payment receipt and selective remittance of only living expenses to the home country.
+
+---
+
+## Decision Matrix
+
+| Nationality | Forex Impact | Annual Limit | Recommended Structure |
+|-------------|-------------|--------------|----------------------|
+| Chinese (大陆) | **CRITICAL** | $50,000/year individual | HK Ltd → HK bank → Stripe HK |
+| Indian | **HIGH** | $250,000/year (LRS) + 20% TCS >₹10 lakh | US LLC or SG Pte. Ltd. via LRS |
+| Brazilian | **HIGH** | Complex bank requirements + IOF tax | US LLC + Mercury |
+| Taiwanese | **MODERATE** | Declaration required >TWD 5,000,000 (~$150K USD) | HK Ltd or SG Pte. Ltd. |
+| Korean | **MODERATE** | Report >$50,000 transactions | US LLC or SG Pte. Ltd. |
+| Japanese | **LOW** | Report >¥30,000,000 (~$200K USD); no hard limits | Any structure works |
+| US / EU / HK / SG / UAE | **NONE** | Free capital movement | Choose based on tax/customers |
+
+---
+
+## Country-by-Country Rules
+
+### China — STRICT (外汇管制)
+
+#### Individual Limits
+
+- **$50,000 USD/year** purchase limit (购汇额度) per person
+- Applies to converting RMB to foreign currency
+- Each transaction requires declaring purpose (travel, education, living expenses — NOT investment)
+- **Cannot legally use individual quota for business purposes**
+- Banks may reject or flag repeated near-limit transfers
+
+#### Business (Company) Forex
+
+- Legitimate trade payments: relatively smooth (with invoices + contracts)
+- Capital account (investment, loans): requires SAFE (国家外汇管理局) approval
+- Profit repatriation from overseas subsidiary: allowed with documentation
+- ODI (境外直接投资): requires NDRC + MOFCOM + SAFE approval for amounts >$5M USD (smaller amounts vary by province)
+
+#### Practical Strategies for Chinese Founders
+
+1. **Hong Kong company** — No forex controls in HK; receive USD/EUR freely
+2. **Keep money offshore** — Only remit living expenses to mainland
+3. **Personal remittance** — Within $50K/year limit via bank transfer
+4. **Salary from HK company** — Subject to HK salaries tax if work performed in HK
+5. **Service fees** — HK company pays mainland 个体户 for services (needs contract + 发票)
+
+#### CRS Impact
+
+- China participates in CRS (Common Reporting Standard)
+- Foreign bank accounts are automatically reported to Chinese tax authorities
+- Applies to: HK, Singapore, most EU countries, many offshore centers
+- **Notable exception:** US does not participate in CRS (but has FATCA)
+- 2025 marks CRS enforcement expansion to mid-tier wealth brackets (<$1M assets)
+
+#### Penalties
+
+| Violation | Consequence |
+|-----------|------------|
+| Using individual quota for business | Accounts frozen, blacklisted from forex purchase for 2 years |
+| Undeclared overseas income | Back taxes + penalties (50–500% of unpaid amount) |
+| Illegal forex channels (地下钱庄) | Criminal offense — 5–10 years imprisonment for amounts >RMB 1,000,000 |
+| Structuring transfers (蚂蚁搬家) | 30% fine on violation amount; 2-year forex purchase ban |
+
+#### Mainland Bank Inbound Wire Risk Controls
+
+Inbound wires to mainland bank accounts may trigger compliance review:
+
+| Trigger | Detail |
+|---------|--------|
+| Single transfer >$5,000 USD (frequent) | Human review likely |
+| Single transfer >$50,000 USD | Mandatory human review |
+| Multiple rapid transfers | Flagged as abnormal pattern |
+| Mismatched declaration category | Automatic flag; may result in return of funds |
+
+**Declaration categories for inbound wires:**
+
+| Payment Nature | Declaration Category | Required Documents |
+|----------------|---------------------|--------------------|
+| Salary from HK company | 职工报酬 | Employment contract + payslip |
+| Dividends from HK company | 利润汇回 | Shareholder resolution + articles |
+| Service fees (个体户) | 服务贸易收入 | Service contract + VAT invoice |
+| Personal living expenses | 经常转移 | Proof of family relationship |
+
+---
+
+### India — STRICT (FEMA / RBI)
+
+#### Individual Limits (LRS — Liberalised Remittance Scheme)
+
+- **$250,000 USD/year** per person for permissible capital and current account transactions
+- Covers: investment abroad, gifts, maintenance, travel, education
+- **Can be used to fund an overseas company** (investment under LRS)
+- Requires: PAN card, A2 form through authorized dealer bank
+
+#### Tax Collected at Source (TCS)
+
+- **20% TCS on remittances >₹10 lakh/year** (effective April 2025; was ₹7 lakh)
+- TCS is refundable against income tax liability — it is not a final tax
+- Budget 2026 reduces education/medical TCS to 2%
+
+#### Business Forex
+
+- Current account (trade payments): generally free with documentation
+- Capital account (ODI): RBI approval needed; automatic route available for most cases
+- Round-tripping prohibition: sending money abroad and bringing it back is strictly monitored
+
+#### Practical Strategies for Indian Founders
+
+1. **Wyoming LLC + Mercury** — Fund via LRS ($250K limit usually sufficient for solo operations)
+2. **Singapore Pte. Ltd.** — Popular for Asia-focused Indian founders (strong DTAA with India)
+3. **Keep offshore revenue offshore** — Repatriate only what is needed
+4. **Separate Indian entity** for domestic clients (Indian subsidiary for domestic revenue)
+
+#### Indian Tax on Foreign Income
+
+- India taxes **worldwide income** for residents
+- Must declare: salary/fees from foreign company, dividends from owned foreign company, capital gains on foreign assets
+- **DTAA relief:** India has DTAs with US, Singapore, UK, UAE — avoid double taxation
+- **Form 67:** Required to claim foreign tax credit in India
+
+---
+
+### Brazil — STRICT
+
+- Central Bank controls all forex transactions
+- Individuals: up to $10,000 USD per day without documentation
+- Companies: all transactions need exchange contract through authorized bank
+- **IOF (Imposto sobre Operações Financeiras):** 0.38–6.38% on forex transactions
+- Brazilian founders commonly use US LLC + Mercury to avoid domestic forex complexity
+
+---
+
+### Taiwan — MODERATE
+
+#### Individual Limits
+
+- **TWD 5,000,000** (~$150,000 USD)/year for individual outward remittance without declaration
+- Above TWD 5,000,000: must file declaration with Central Bank
+- This is a declaration threshold, NOT a hard cap (unlike China's strict quota)
+
+#### Business Forex
+
+- Generally free for trade transactions with documentation
+- Investment abroad: report to Investment Commission (MOEA) for amounts >TWD 5,000,000
+- **OBU (Offshore Banking Unit):** Tax-exempt interest income in OBU accounts
+
+#### Practical Strategy
+
+- **Hong Kong company** — Cultural proximity, cheaper than Singapore
+- **OBU account** — For offshore income separation
+- **Singapore** — If avoiding CFC triggers (SG 17% tax > Taiwan's 14% CFC threshold)
+
+#### CFC Rules (2023+)
+
+Holding >50% of a low-tax company (<14% effective rate) triggers deemed distribution for Taiwan tax. Exemption: real substance OR overseas income <NT$7,000,000.
+
+---
+
+### South Korea — MODERATE
+
+#### Individual Limits
+
+- **$50,000 USD** per transaction without documentation
+- Annual cumulative >$50K: must report to designated foreign exchange bank
+- Investment abroad: report to Bank of Korea for amounts >$1,000,000
+
+#### Business Forex
+
+- Trade payments: generally free with invoice/contract
+- ODI: report to designated bank; amounts >$10,000,000 need Bank of Korea notification
+
+---
+
+### Japan — LIGHT
+
+#### Individual Limits
+
+- No individual remittance limits
+- Transactions >¥30,000,000 (~$200,000 USD): must report to Ministry of Finance (after the fact)
+- Foreign Exchange and Foreign Trade Act restricts investment in sensitive sectors only
+
+#### Business Forex
+
+- Generally free; Japan has very liberal forex policies
+- Large transactions reported post-facto
+
+---
+
+### Hong Kong — NONE ✓
+
+- **Zero forex controls**
+- Free movement of capital in and out
+- No limits on foreign currency holding or conversion
+- HKD is pegged to USD (7.75–7.85)
+- Primary reason HK is the #1 choice for Chinese and Taiwanese founders
+
+---
+
+### Singapore — NONE ✓
+
+- **Zero forex controls**
+- Free capital movement
+- MAS (Monetary Authority of Singapore) does not restrict currency transactions
+- No reporting requirements for most transfers
+
+---
+
+### United States — LIGHT (Reporting Only)
+
+- **No limits on moving money in/out**
+- Reporting requirements:
+
+| Requirement | Threshold | Consequence of Non-Compliance |
+|-------------|-----------|-------------------------------|
+| FBAR (FinCEN 114) | Foreign accounts aggregate >$10,000 at any time during year | $10,000 penalty per unreported account per year |
+| FATCA (Form 8938) | Foreign financial assets >$50,000–$200,000 (varies by filing status) | $10,000 penalty + additional $10,000 per 30 days of non-compliance |
+| CTR | Banks auto-report cash transactions >$10,000 | Structuring to avoid is a federal crime |
+
+---
+
+### UAE / Dubai — NONE ✓
+
+- **Zero forex controls**
+- No limits on repatriation of capital or profits
+- Free movement of funds in any currency
+- Note: UAE introduced 5% personal income tax effective January 2026; forex controls remain zero
+
+---
+
+### EU (General) — LIGHT
+
+- Free movement of capital within EU (Treaty of Lisbon)
+- Cross-border transfers within EU: same as domestic (SEPA)
+- Transfers >€10,000 in cash: must declare at customs
+- No limits on electronic transfers
+- Individual countries may have reporting requirements (e.g., France requires reporting of foreign accounts)
+
+---
+
+## China-Specific: Mainland Income Reporting for Offshore Earners
+
+### Annual Filing Window (汇算清缴)
+
+- **Deadline:** March 1 – June 30 of following year (e.g., 2025 income reported by June 30, 2026)
+- Filing path: 个税APP → 综合所得年度汇算 → 其他收入 → 境外所得（附表三）
+
+### Foreign Tax Credit Calculation
+
+```
+Credit limit (per country) = China total tax × (income from that country / total worldwide income)
+```
+
+- If foreign tax paid ≤ credit limit → full credit; China collects the difference
+- If foreign tax paid > credit limit → excess carries forward for 5 tax years (no refund)
+
+### Penalties for Non-Reporting
+
+| Scenario | Consequence |
+|----------|------------|
+| Discovered by tax authority | Back taxes + late payment surcharge (0.05%/day) + fine (50–500% of tax owed) |
+| Voluntary self-correction | Late payment surcharge applies; fine typically reduced (<50%) |
+| Tax evasion >RMB 100,000 AND >10% of tax due | Criminal liability (Article 201, Criminal Law) |
+
+---
+
+## CRS Response Protocol
+
+When receiving a CRS inquiry letter from Chinese tax authorities:
+
+| Letter Type | Urgency | Action |
+|-------------|---------|--------|
+| Compliance reminder (合规提示函) | Low | Self-audit, voluntary supplemental filing |
+| Risk notice / interview summons (风险提示函/约谈通知) | Medium — respond within 30 days | Prepare HK company documents, bank statements, tax records |
+| Formal audit notice (税务稽查通知书) | **High — engage tax attorney immediately** | Do not destroy any documents; attorney-led response |
+
+---
+
+## Official Sources & Further Reading
+
+- **China SAFE (国家外汇管理局):** https://www.safe.gov.cn
+- **India RBI — LRS FAQ:** https://www.rbi.org.in/Scripts/FAQView.aspx?Id=115
+- **India FEMA:** https://www.rbi.org.in/scripts/Fema.aspx
+- **Taiwan Central Bank:** https://www.cbc.gov.tw
+- **US FBAR (FinCEN):** https://www.fincen.gov/report-foreign-bank-and-financial-accounts
+- **Hong Kong Monetary Authority:** https://www.hkma.gov.hk
+
+---
+
+*Data reflects 2024–2026 rules. Forex regulations are enforced with increasing rigor worldwide. Verify current limits and procedures with your bank and a qualified advisor before large cross-border transfers.*
+*Original content: [Artin (@ar-gen-tin)](https://github.com/ar-gen-tin/panrise) — MIT License.*
+*OpenAccountants — open-source tax computation skills — info@openaccountants.com*

--- a/skills/cross-border/international-incorporation.md
+++ b/skills/cross-border/international-incorporation.md
@@ -1,0 +1,306 @@
+---
+name: international-incorporation
+description: >
+  International company formation and jurisdiction selection guide for solo founders,
+  freelancers, and digital nomads. Use when the user asks about: where to register a company,
+  business jurisdiction selection, Wyoming LLC setup, Delaware LLC, Hong Kong company formation,
+  Singapore Pte Ltd, Estonia e-Residency OÜ, UK Ltd incorporation, Dubai freezone company,
+  offshore company structure, one-person company (一人公司), solo founder incorporation,
+  entity type selection, pass-through vs corporation, company formation costs, annual compliance
+  by jurisdiction, 注册公司, 海外公司, 开公司, 离岸公司, 会社設立, 法人化,
+  incorporating abroad, best country to register a business, cheapest jurisdiction,
+  Stripe Atlas, company for non-US founders, company closure, operating agreement,
+  or any question about choosing where to incorporate an international business.
+version: 1.0
+jurisdiction: INTL
+tax_year: 2025-2026
+category: international
+---
+
+# International Company Formation — Jurisdiction Selection Guide
+
+> **Based on work by [Artin (@ar-gen-tin)](https://github.com/ar-gen-tin/panrise)**, licensed under MIT. Adapted for the OpenAccountants format.
+
+> **Disclaimer:** This skill provides general guidance on international company formation. It does not constitute legal or tax advice. All structures and tax treatments must be verified with qualified local advisors (CPAs, tax attorneys, chartered accountants) in the relevant jurisdictions before implementation. Tax rules, costs, and compliance requirements change frequently.
+
+---
+
+## Workflow
+
+1. **Identify the user's profile** — nationality, business type, revenue, customer location, primary goal.
+2. **Check forex constraints** — if the user's home country has strict forex controls, this narrows jurisdiction choices (see `forex-controls.md`).
+3. **Apply the jurisdiction decision tree** — match profile to recommended structure.
+4. **Present the comparison** — costs, tax rates, compliance burden, banking options.
+5. **Flag ongoing obligations** — annual filings, penalties for non-compliance, substance requirements.
+
+---
+
+## Tier 1 Jurisdictions — Best for Most Solo Founders
+
+### United States — Wyoming LLC
+
+| Factor | Detail |
+|--------|--------|
+| Corporate tax | 0% federal (pass-through for non-US owners) |
+| Personal tax | 0% for non-US owners; US citizens pay federal income + SE tax (~15.3%) |
+| Setup cost | $100–500 USD |
+| Setup timeline | 1–3 days |
+| Annual cost | $60–600 USD (annual report + registered agent) |
+| Banking | Mercury (remote opening), Wise Business |
+| Substance required | None for non-US LLC owners |
+
+**Best for:** Global SaaS, digital services, any solo founder wanting US credibility without US tax liability.
+
+**Key advantage:** A US LLC owned by a non-US person is a "disregarded entity" for US tax purposes — 0% US federal income tax. Only taxed where the owner is personally tax-resident.
+
+**Watch out:** US citizens face self-employment tax (~15.3%). EIN required for banking. Form 5472 filing mandatory for non-US owners ($25,000 penalty per form per year if missed).
+
+### United States — Delaware LLC / C-Corp
+
+| Factor | Detail |
+|--------|--------|
+| Corporate tax | 0% federal (LLC pass-through); 21% federal (C-Corp) |
+| Setup cost | $90 filing + $300/year franchise tax (LLC); $500 via Stripe Atlas (C-Corp) |
+| Setup timeline | 1–2 days |
+| Annual cost | $300+ franchise tax |
+| Banking | Mercury, Stripe Atlas pipeline |
+
+**Best for:** Founders planning to raise US VC funding. Delaware is the gold standard for SAFE notes and convertible instruments.
+
+**Stripe Atlas pipeline:** Pay $500 → Delaware C-Corp incorporated → EIN procured → Mercury bank account → Stripe payments activated. Total time: ~1–2 weeks.
+
+### Singapore — Pte. Ltd.
+
+| Factor | Detail |
+|--------|--------|
+| Corporate tax | 17% headline (effective ~8.5% on first SGD 200,000 with startup exemption) |
+| Capital gains | 0% |
+| Dividend WHT | 0% |
+| Setup cost | SGD 300–800 |
+| Setup timeline | 1–2 days |
+| Annual cost | SGD 3,000–5,000 (nominee director + secretary + filing) |
+| Banking | DBS, OCBC (may require in-person visit) |
+
+**Best for:** Asia-Pacific-focused businesses with revenue >$50,000 USD/year.
+
+**Requirements:** At least 1 Singapore-resident director (nominee ~SGD 2,000/year), mandatory company secretary, registered office in Singapore.
+
+### Estonia — e-Residency OÜ
+
+| Factor | Detail |
+|--------|--------|
+| Corporate tax | 0% on retained profits; 20% on distributions |
+| Setup cost | ~€385 (e-Residency card + registration) |
+| Setup timeline | 2–4 weeks |
+| Annual cost | €500–1,500 |
+| Banking | Wise Business (primary), LHV |
+
+**Best for:** Non-EU founders needing EU market access who reinvest most profits. Fully remote administration.
+
+**Critical:** e-Residency does NOT confer Estonian tax residency. Personal tax is owed where the owner actually resides.
+
+### Dubai — Freezone
+
+| Factor | Detail |
+|--------|--------|
+| Corporate tax | 9% on income >AED 375,000; 0% below |
+| Personal income tax | 5% (effective January 2026; was 0% until December 2025) |
+| Setup cost | AED 5,000–15,000 |
+| Setup timeline | 3–10 days |
+| Annual cost | AED 10,000–20,000 (license + visa + office + insurance) |
+| Banking | Emirates NBD, Mashreq, Wise |
+
+**Best for:** Founders willing to relocate to UAE for low combined personal + corporate tax.
+
+**Requirements:** Must actually live in UAE to establish tax residency. Popular freezones: DMCC, IFZA, Meydan.
+
+---
+
+## Tier 2 Jurisdictions — Good for Specific Situations
+
+### United Kingdom — Ltd
+
+| Factor | Detail |
+|--------|--------|
+| Corporate tax | 19% (first £50,000); 25% (above £250,000) |
+| Setup cost | £12 |
+| Setup timeline | Same day |
+| Annual cost | £200–500 |
+| Banking | Wise Business, Revolut Business |
+
+**Best for:** UK/EU clients, B2B consulting. Cheapest and fastest incorporation globally.
+
+### Hong Kong — Limited Company (有限公司)
+
+| Factor | Detail |
+|--------|--------|
+| Corporate tax | 8.25% (first HKD 2,000,000); 16.5% above |
+| Offshore income | 0% (if properly structured — see substance requirements) |
+| Dividend WHT | 0% |
+| Setup cost | HKD 3,000–5,000 (~$400–650 USD) |
+| Setup timeline | 1–2 weeks |
+| Annual cost | HKD 5,000–10,000 |
+| Banking | HSBC, ZA Bank, Airwallex HK |
+
+**Best for:** Chinese mainland founders (大陆创始人) — no forex controls in HK, Stripe HK available, offshore income exemption.
+
+**Offshore profits claim (离岸免税):** If business is conducted outside HK (no HK office, no HK employees, contracts signed outside HK), offshore income can be 0% taxed. FSIE rules (2023+) tightened substance requirements for passive income.
+
+---
+
+## Jurisdiction Decision Tree
+
+```
+What is the founder's nationality?
+├── Chinese Mainland (中国大陆)
+│   └── Global revenue? → YES → Hong Kong Ltd (escape forex controls, Stripe HK)
+│                        → NO  → 个体户 or 小规模纳税人
+├── Taiwanese (台灣)
+│   └── Significant international revenue? → YES → HK Ltd or SG Pte. Ltd.
+│                                          → NO  → Taiwan domestic company
+├── Indian
+│   └── US LLC (fund via LRS $250K) or SG Pte. Ltd. (strong DTAA)
+├── US Citizen
+│   └── Wyoming LLC (avoid CFC traps of foreign corporations)
+└── Other nationality → Where are customers?
+    ├── US/Global, no VC  → Wyoming LLC
+    ├── US/Global, want VC → Delaware C-Corp (Stripe Atlas)
+    ├── EU, reinvest profits → Estonia OÜ (0% retained)
+    ├── EU, distribute profits → UK Ltd (cheapest)
+    ├── Asia, revenue >$50K → Singapore Pte. Ltd. or HK Ltd
+    ├── Asia, revenue <$50K → Wyoming LLC + Wise
+    └── Want low personal tax + will relocate → Dubai Freezone
+```
+
+### Revenue Thresholds
+
+| Revenue | Guidance |
+|---------|----------|
+| <$5,000/year | Do not incorporate. Invoice personally or use sole proprietorship. |
+| $5,000–$25,000 | Simple single entity (Wyoming LLC or UK Ltd). Monthly overhead: ~$50–100. |
+| $25,000–$100,000 | Same structure + proper accounting software. Monthly overhead: ~$100–250. |
+| $100,000–$500,000 | Consider Singapore or Estonia for tax optimization. Monthly overhead: ~$300–700. |
+| >$500,000 | Multi-jurisdiction structure + accountant + legal counsel. Monthly overhead: $1,000+. |
+
+---
+
+## Pass-Through vs Corporation
+
+| Entity Type | Tax Treatment | Best For |
+|-------------|---------------|----------|
+| US LLC (single-member) | Profits pass to owner's personal return | Non-US founders (0% US tax); US founders (flexible) |
+| C-Corp (Delaware) | Corporate tax (21%) + dividend tax | Founders seeking US VC |
+| Estonia OÜ | 0% retained; 20% on distributions | EU-serving founders who reinvest |
+| Singapore Pte. Ltd. | 17% corporate (effective ~8.5% for small companies) | Asia-Pacific focused |
+| UK Ltd | 19–25% corporate | UK/EU clients, low setup cost |
+| HK Ltd | 8.25–16.5%; offshore 0% | China/Asia trade, offshore structures |
+
+---
+
+## Annual Cost Comparison
+
+| Structure | Setup | Annual Maintenance | Accounting | Total Year 1 |
+|-----------|-------|--------------------|------------|---------------|
+| Wyoming LLC | $160 | $60 | $500–1,500 | **$720–1,720** |
+| Delaware LLC | $390 | $300 | $500–1,500 | **$1,190–2,190** |
+| Stripe Atlas (DE C-Corp) | $500 | $300 | $1,000–3,000 | **$1,800–3,800** |
+| Hong Kong Ltd | $500 | $800–1,500 | $800–1,500 | **$2,100–3,500** |
+| Estonia OÜ | $600 | $300–500 | $600–1,200 | **$1,500–2,300** |
+| UK Ltd | $60 | $200 | $500–1,500 | **$760–1,760** |
+| Singapore Pte. Ltd. | $800 | $3,000–5,000 | $1,000–2,000 | **$4,800–7,800** |
+| Dubai Freezone | $3,000 | $3,000–5,000 | $1,000–2,000 | **$7,000–10,000** |
+
+---
+
+## Key Compliance Requirements by Jurisdiction
+
+| Jurisdiction | Filing | Deadline | Penalty for Late |
+|--------------|--------|----------|------------------|
+| Wyoming LLC | Annual Report | 1st day of anniversary month | $50 late fee + $2/month |
+| Delaware LLC | Franchise Tax | June 1 | $200 + 1.5%/month interest |
+| US LLC (non-US owner) | Form 5472 + pro-forma 1120 | April 15 (extension available) | **$25,000 per form per year** |
+| Singapore | Annual Return (ACRA) | Within 30 days of AGM | SGD 300 late fee |
+| Singapore | Corporate Tax (Form C-S) | November 30 | Penalties + estimated assessment |
+| Estonia OÜ | Annual Report | Within 6 months of FY end | €100–3,200 fine |
+| UK Ltd | Confirmation Statement | Anniversary of incorporation | £250, then striking off |
+| UK Ltd | Accounts filing | 9 months after FY end | £150–1,500 |
+| Hong Kong | Annual Return (NAR1) | Within 42 days of anniversary | HKD 870–3,480 |
+| Hong Kong | Profits Tax Return | Within 1 month of issuance | Penalty + estimated assessment |
+| Dubai Freezone | License renewal | Annual | License cancellation |
+
+---
+
+## Entity Structures for Chinese Founders (大陆创始人)
+
+### Recommended: HK Ltd + 个体户 Combination
+
+```
+Chinese Founder (个人)
+├── Hong Kong Limited Company (有限公司)
+│   ├── Receives global payments via Stripe HK / PayPal / Airwallex
+│   ├── Offshore profits taxed at 0% (if business conducted outside HK)
+│   └── Pays service fees to mainland 个体户 via contract
+└── 个体户 (mainland)
+    ├── Issues invoice (增值税普票) to HK company
+    └── Pays 0.5–2% effective tax (核定征收 rate)
+```
+
+**Service fee requirements:** Real service agreement with market-rate pricing, valid 增值税普票 issued, documented deliverables. Service fee should not exceed 50% of HK company revenue (transfer pricing scrutiny threshold).
+
+### Getting Money Back to Mainland
+
+| Method | Tax Treatment |
+|--------|---------------|
+| Salary from HK company | Subject to HK salaries tax if work performed in HK |
+| Dividends | No HK WHT; China 20% individual income tax on foreign dividends |
+| Service fees to 个体户 | Needs valid contract + 发票; 核定征收 rate (0.5–2%) |
+| Personal remittance | Within annual $50,000 USD forex limit |
+
+---
+
+## Company Closure / Winding Down
+
+| Jurisdiction | Process | Cost | Timeline |
+|--------------|---------|------|----------|
+| Wyoming LLC | Articles of Dissolution + settle debts + final tax return | $0 state fee | 1–3 months |
+| Delaware LLC | Certificate of Cancellation + final franchise tax | $200+ | 1–3 months |
+| Singapore Pte. Ltd. | ACRA striking off or voluntary winding up | SGD 30–3,000+ | 3–6 months |
+| Estonia OÜ | Liquidation via e-Business Register | €200–500 | 3–12 months |
+| UK Ltd | Striking off (DS01 form) or voluntary liquidation | £10 | 3–6 months |
+| Hong Kong Ltd | Companies Registry deregistration or voluntary winding up | HKD 690 | 5–7 months |
+| Dubai Freezone | Cancel license + deregister + cancel visa | AED 2,000–5,000 | 2–4 months |
+
+**Never abandon a company without formal dissolution.** Penalties, late fees, and government liens continue to accrue on dormant entities.
+
+---
+
+## Operating Agreement (US LLC)
+
+Every LLC — even single-member — needs an operating agreement covering:
+
+1. **Membership interest** — who owns what percentage
+2. **Management structure** — member-managed vs manager-managed
+3. **Distribution policy** — when and how profits are distributed
+4. **Succession / death provisions** — who takes over if the sole member dies or becomes incapacitated
+5. **Buy-sell mechanism** — dissolution or transfer procedures
+
+**US estate tax risk for non-US owners:** Non-US persons owning US-sited assets >$60,000 face federal estate tax up to 40% at death. Holding a US LLC through a foreign holding company (e.g., HK Ltd) removes this exposure.
+
+---
+
+## Official Sources & Further Reading
+
+- **IRS** — EIN application, Form 5472 instructions: https://www.irs.gov
+- **Wyoming Secretary of State** — LLC filing: https://sos.wyo.gov
+- **Delaware Division of Corporations**: https://corp.delaware.gov
+- **ACRA Singapore**: https://www.acra.gov.sg
+- **Estonia e-Residency**: https://e-resident.gov.ee
+- **UK Companies House**: https://www.gov.uk/government/organisations/companies-house
+- **HK Companies Registry**: https://www.cr.gov.hk
+- **Stripe Atlas**: https://stripe.com/atlas
+
+---
+
+*Data reflects 2024–2026 rules. For amounts >$100,000 USD or life-changing decisions, verify current rules with a qualified advisor in each relevant jurisdiction.*
+*Original content: [Artin (@ar-gen-tin)](https://github.com/ar-gen-tin/panrise) — MIT License.*
+*OpenAccountants — open-source tax computation skills — info@openaccountants.com*

--- a/skills/cross-border/tax-residency-planning.md
+++ b/skills/cross-border/tax-residency-planning.md
@@ -1,0 +1,290 @@
+---
+name: tax-residency-planning
+description: >
+  Personal tax residency rules, the 183-day rule, digital nomad visas, exit taxes, and
+  tax residency planning for international founders and freelancers. Use when the user asks
+  about: tax residency, 183-day rule, where am I taxed, digital nomad visa, tax residency
+  change, exit tax, departure tax, territorial tax countries, zero tax countries, tax nowhere,
+  permanent establishment risk, center of vital interests, tax treaty tie-breaker, DTA tie-breaker,
+  OECD Article 4, split tax year, mid-year relocation, FEIE, Foreign Earned Income Exclusion,
+  bona fide residence test, tax residency certificate, 税务居民, 居住者, 非居住者,
+  residencia fiscal, digital nomad tax, Beckham Law Spain, NHR Portugal, Thailand LTR visa,
+  Panama territorial tax, Georgia micro business, Dubai 0% tax, flag theory, or any question
+  about personal tax residency and where to pay personal income tax as an international founder.
+version: 1.0
+jurisdiction: INTL
+tax_year: 2025-2026
+category: international
+---
+
+# Tax Residency Planning — Personal Tax Rules for International Founders
+
+> **Based on work by [Artin (@ar-gen-tin)](https://github.com/ar-gen-tin/panrise)**, licensed under MIT. Adapted for the OpenAccountants format.
+
+> **Disclaimer:** This skill provides general guidance on personal tax residency. It does not constitute tax or legal advice. Tax residency determinations are fact-specific and can have severe financial consequences if handled incorrectly. Consult a qualified cross-border tax advisor before changing your tax residency or structuring around residency rules.
+
+---
+
+## Core Concepts
+
+Three separate concepts determine how an international founder is taxed:
+
+| Concept | Definition | Can You Change It? |
+|---------|------------|--------------------|
+| Company incorporation | Where the business is registered | Yes — choose jurisdiction |
+| Company tax residency | Where the business pays corporate tax (usually where it's managed) | Partially — depends on substance |
+| Personal tax residency | Where YOU pay personal income tax | Yes — but requires genuine relocation |
+
+For solo founders using pass-through entities (e.g., US LLC), personal tax residency is the primary tax determinant.
+
+---
+
+## The 183-Day Rule
+
+Most countries use 183 days of physical presence as a threshold for tax residency. However, the rule is more complex than it appears.
+
+### Variations by Country
+
+| Variation | Countries | Detail |
+|-----------|-----------|--------|
+| Any partial day = 1 day | Most countries | Arriving at 11pm counts as a full day |
+| Calendar year basis | US (substantial presence), most EU | January 1 – December 31 |
+| Fiscal year basis | UK (April 6), Australia (July 1) | Offset calendar |
+| Additional tests beyond days | Germany, Netherlands, Japan | Family, property, "center of vital interests" |
+| Permanent home test | Most OECD countries | Having a home available can trigger residency even with <183 days |
+| Citizenship-based | United States | US citizens are ALWAYS US tax residents regardless of location |
+
+### What 183 Days Does NOT Capture
+
+- A country may claim residency with <183 days if you maintain a "permanent home" there
+- Some countries use a lookback period (US substantial presence test: weighted 3-year count)
+- "Center of vital interests" (family, property, social ties) can override day counts
+- Leaving a country does not automatically end tax residency — formal deregistration is often required
+
+---
+
+## Country-by-Country Tax Residency Rules
+
+### Zero / Very Low Personal Income Tax Countries
+
+| Country | Tax on Foreign Income | Residency Visa | Annual Cost | Notes |
+|---------|----------------------|----------------|-------------|-------|
+| UAE/Dubai | 5% (effective January 2026; was 0% until December 2025) | Via freezone visa | $3,000–10,000 | Must establish genuine residency |
+| Cayman Islands | 0% | Investment-based | $18,000–24,000 | Expensive but total tax freedom |
+| Bahamas | 0% | Permanent Residency available | ~$1,000 | Caribbean lifestyle |
+| Monaco | 0% | Deposit required | €500,000+ deposit | Ultra-high-net-worth only |
+
+### Territorial Tax Countries (0% on Foreign Income)
+
+| Country | Local Tax Rate | Foreign Income Tax | Digital Nomad Visa | Notes |
+|---------|---------------|--------------------|--------------------|-------|
+| Panama | 15–25% | 0% (territorial) | Friendly Nations Visa | Easy residency |
+| Costa Rica | 10–25% | 0% (territorial) | Rentista visa | Growing tech scene |
+| Georgia | 1% (micro business) | 0% (territorial) | Easy residency | Ultra-low tax for <GEL 500,000 revenue |
+| Paraguay | 10% | 0% (territorial) | Easy residency | Cheapest South American option |
+| Malaysia | 0–30% | 0% (pre-2024, changing) | MM2H visa | Rules tightening — verify current status |
+| Thailand | 0–35% | Changing (2024+ remittance rule) | LTR visa | LTR visa holders: flat 17% |
+
+### Popular Digital Nomad Visas
+
+| Country | Visa Name | Duration | Minimum Income | Tax Implication |
+|---------|-----------|----------|----------------|-----------------|
+| Portugal | D8 (Digital Nomad) | 1 year + renew | €3,500/month | NHR abolished 2024; now taxed at standard rates |
+| Spain | Digital Nomad Visa | 1 year + renew | €2,520/month | Beckham Law: 24% flat rate (limited applicability) |
+| Croatia | Digital Nomad | 1 year | €2,540/month | 0% local tax in first year |
+| Estonia | Digital Nomad | 1 year | €4,500/month | Not tax resident if <183 days |
+| Greece | Digital Nomad | 2 years | €3,500/month | 50% income tax reduction for 7 years |
+| Dubai | Virtual Working Program | 1 year | $5,000/month | 5% PIT (effective January 2026) |
+| Thailand | LTR Visa | 5–10 years | Varies | Flat 17% (vs normal up to 35%) |
+
+---
+
+## Effective Tax Rate Comparison by Residency
+
+On $100,000 and $200,000 annual profit from a pass-through entity:
+
+| Residency | On $100K Profit | On $200K Profit | Effort to Establish |
+|-----------|-----------------|-----------------|---------------------|
+| UAE/Dubai | ~$5,000 (5% PIT) | ~$10,000 | High (must live there) |
+| Panama | $0 (foreign income) | $0 | Medium |
+| Georgia | ~$1,000 (1% micro) | ~$2,000 | Low |
+| Paraguay | $0 (foreign income) | $0 | Low |
+| Germany | ~$35,000 | ~$80,000 | Already there |
+| US citizen (abroad) | ~$0–15,000 (after FEIE) | ~$20,000–35,000 | Complex |
+
+---
+
+## Tax Traps for International Founders
+
+### Trap 1: US Citizens Cannot Escape US Tax
+
+- US taxes worldwide income regardless of where the citizen lives
+- Must file US return even if living abroad permanently
+- **FEIE (Foreign Earned Income Exclusion):** Excludes up to ~$130,000 (2025) / $132,900 (2026) of earned income if bona fide foreign residence established
+- **FTC (Foreign Tax Credit):** Credits foreign taxes paid against US liability
+- **CFC rules:** Owning >50% of a foreign corporation triggers Subpart F / GILTI — Form 5471 mandatory ($10,000+ penalty per year if missed)
+- **Solution for US citizens:** US LLC (pass-through) avoids CFC complexity
+
+### Trap 2: Permanent Establishment (PE) Risk
+
+- Working from a co-working space in Country X for >90–183 days may create a PE for your company there
+- PE = your company owes corporate tax in that country on attributable profits
+- "Service PE" triggered by extended project work in a country
+- **Mitigation:** Track days carefully, don't sign contracts locally, hold board meetings in the incorporation country
+
+### Trap 3: Company Tax Residency ≠ Incorporation
+
+- A company incorporated in Singapore but managed from a laptop in Portugal may be tax resident in Portugal
+- Tax authorities examine where "central management and control" happens
+- **Mitigation:** Hold board meetings (even virtual) in the incorporation country, keep documented minutes
+
+### Trap 4: "Nowhere" Tax Residency Does Not Work
+
+- Traveling constantly and claiming no tax residency invites problems
+- Tax authorities examine: passport, bank accounts, property, family, center of vital interests
+- **Mitigation:** Deliberately establish tax residency in ONE favorable country
+
+### Trap 5: Social Security Double Contribution
+
+- Many countries require social security contributions from residents
+- Without totalization agreements, the founder may pay into two systems
+- EU countries have coordination rules; US has agreements with ~30 countries
+
+---
+
+## Exit Tax (Departure Tax)
+
+When leaving a high-tax country, departure can trigger a large one-time tax bill. This is often the single largest tax event in a founder's life.
+
+| Country | Rule | Trigger | Deferral? |
+|---------|------|---------|-----------|
+| Germany | § 6 AStG | Deemed disposal of shares in foreign companies on departure (>1% shareholding held 5+ years) | 5-year deferral within EU/EEA; installments for non-EU moves |
+| United States | HEART Act (2008) | Mark-to-market on all worldwide assets for covered expatriates renouncing citizenship | No deferral; net worth >$2M OR avg annual net income tax >$190K (2024, indexed) |
+| Australia | CGT Event I1 | Deemed disposal of all taxable Australian property on becoming non-resident | Main residence exemption may apply |
+| Canada | Departure Tax | Deemed disposition of all property at FMV on ceasing to be resident | Deferral available if security posted with CRA |
+| France | Exit Tax (Art. 167 bis CGI) | Shareholdings worth >€800K or >50% of company profits | 5-year deferral (EU/EEA); 2-year deferral (other) |
+| Netherlands | Conservatory Assessment | 10-year lookback on substantial interest holdings (>5% shareholding) | Tax assessed at departure; collected on actual disposal within 10 years |
+
+**Planning guidance:**
+- Plan departure 12–24 months in advance — most mitigation strategies require lead time
+- Get a written tax opinion BEFORE moving, not after
+- Germany § 6 deferral only works for EU/EEA moves; moving to Dubai triggers installment payments
+- US covered expatriates: $800K per-person lifetime exclusion on mark-to-market gain
+
+---
+
+## Split Tax Year (Mid-Year Relocation)
+
+### Countries WITH Formal Split-Year Treatment
+
+| Country | Rule | Detail |
+|---------|------|--------|
+| UK | Statutory Residence Test (SRT) | 8 defined "cases" for split-year treatment; each half taxed separately |
+| Germany | Prorated income | Unlimited liability ends on Abmeldung date; limited liability continues for German-source income |
+| Australia | Partial-year resident | ATO determines residency date based on facts; foreign income not taxed in non-resident portion |
+
+### Countries WITHOUT Split-Year Treatment
+
+- **USA:** No split year for citizens (always filing). Dual-status return applies for green card holders.
+- **Singapore:** No formal split; authorities consider tax residency for the full year.
+- **UAE:** No income tax, so split year is irrelevant.
+- **Panama / Georgia / Paraguay:** Territorial systems; foreign income not taxed regardless.
+
+### Practical Steps for Transition Year
+
+1. **Formal deregistration** — Get paper proof (Abmeldung in Germany, P85 form in UK, departure notification in Australia)
+2. **Establish new residency immediately** — Signed lease, local bank account, utility bill, all dated early
+3. **Get a Tax Residency Certificate (TRC)** from the new country as soon as you qualify
+4. **File returns in BOTH countries** for the transition year — even if nothing is owed in one
+5. **Claim DTA tie-breaker** if both countries assert full-year residency
+
+---
+
+## Tax Treaty Tie-Breaker Rules (OECD Article 4)
+
+When two countries both claim a person as their tax resident, the DTA tie-breaker is applied sequentially:
+
+| Step | Test | Key Details |
+|------|------|-------------|
+| 1 | Permanent home availability | Where do you have a home available for continuous use? Rented accommodation counts. A home rented OUT to tenants is NOT available. |
+| 2 | Center of vital interests | Where are your closest personal and economic ties? Family, employment, bank accounts, property. Holistic assessment. |
+| 3 | Habitual abode | Where do you spend time habitually? Assessed over an extended period, not just the current year. |
+| 4 | Nationality | Citizenship as final tie-breaker. Dual nationals may fall through to mutual agreement (MAP, 24–36 months). |
+
+### Documentation Required for Tie-Breaker Claims
+
+| Document | Purpose |
+|----------|---------|
+| Lease agreements / property ownership | Proves permanent home availability |
+| Utility bills in your name | Evidence of actual use of accommodation |
+| Passport stamps / border crossing records | Day-count evidence for habitual abode |
+| Bank statements | Shows where economic life is centered |
+| Business records (contracts, invoices) | Shows where economic activity is located |
+| School enrollment records (children) | Strong personal ties evidence |
+| Tax Residency Certificate (TRC) | Primary official evidence — single most important document |
+
+---
+
+## Recommended Strategies by Profile
+
+### Profile A: US Citizen, Digital Nomad
+
+- **Structure:** Wyoming/Delaware LLC (pass-through)
+- **Tax strategy:** FEIE (~$130K exclusion) + FTC for amounts above
+- **Residency:** Establish bona fide residence in a foreign country (need 330+ days abroad)
+- **Banking:** Mercury + Wise
+- **Avoid:** Foreign corporations (triggers CFC/GILTI complexity)
+
+### Profile B: Non-US, Digital Nomad, Revenue <$100K
+
+- **Structure:** Wyoming LLC (0% US tax for non-residents)
+- **Tax residency:** Establish in territorial tax country (Panama, Georgia, Paraguay)
+- **Banking:** Mercury + Wise
+- **Total tax:** Near 0% legally
+- **Annual cost:** ~$1,500 all-in
+
+### Profile C: Non-US, Living in One Country, Revenue >$100K
+
+- **Structure:** Depends on customer location (US customers → Wyoming LLC; EU → Estonia OÜ; Asia → Singapore)
+- **Tax residency:** Country of residence (file there)
+- **Optimization:** Use DTA between personal country and company country
+
+### Profile D: Founder Seeking Lowest Legal Tax
+
+- **Structure:** Dubai Freezone (or Wyoming LLC)
+- **Tax residency:** UAE (5% PIT effective January 2026)
+- **Requirement:** Actually live in UAE (get Emirates ID, establish life there)
+- **Total tax:** 9% corporate on >AED 375K + 5% personal = effective ~12–15%
+- **NOT for US citizens** (still owe US tax)
+
+---
+
+## Flag Theory for Solo Founders
+
+Five "flags" that do NOT need to be in the same country:
+
+| Flag | What It Is | Can You Change It? |
+|------|------------|--------------------|
+| Passport | Citizenship | Difficult |
+| Tax residency | Where you pay personal tax | Yes — requires genuine relocation |
+| Company | Where your business is registered | Yes — choose based on customers/tax |
+| Banking | Where your money is held | Yes — choose based on features/access |
+| Living | Where you actually spend time | Yes — but must align with tax residency claim |
+
+**Example (legal):** Chinese citizen → Dubai tax residency (5% PIT) → Wyoming LLC (0% US tax) → Mercury (US) + Wise (multi-currency) → Living in Dubai + travel.
+
+---
+
+## Official Sources & Further Reading
+
+- **OECD Model Tax Convention** — Article 4 (Residence): https://www.oecd.org/tax/treaties/
+- **IRS — FEIE**: https://www.irs.gov/individuals/international-taxpayers/foreign-earned-income-exclusion
+- **IRS — FBAR**: https://www.fincen.gov/report-foreign-bank-and-financial-accounts
+- **UK Statutory Residence Test**: https://www.gov.uk/government/publications/rdr3-statutory-residence-test-srt
+- **Dubai Virtual Working Program**: https://www.visitdubai.com/en/sc7/one-year-virtual-working-programme
+
+---
+
+*Data reflects 2024–2026 rules. Tax residency changes are high-stakes decisions — verify all rules with a qualified cross-border tax advisor before acting.*
+*Original content: [Artin (@ar-gen-tin)](https://github.com/ar-gen-tin/panrise) — MIT License.*
+*OpenAccountants — open-source tax computation skills — info@openaccountants.com*

--- a/skills/international/france/fr-business-accounting.md
+++ b/skills/international/france/fr-business-accounting.md
@@ -1,0 +1,283 @@
+---
+name: fr-business-accounting
+description: >
+  French business accounting, VAT declarations, invoicing, and e-invoicing 2026 reform.
+  Trigger on phrases like "comptabilité française", "expert-comptable",
+  "TVA France", "déclaration CA3", "déclaration CA12", "TVA intracommunautaire",
+  "facturation France", "facture électronique", "e-invoicing France",
+  "Factur-X", "UBL", "CII", "plateforme agréée", "PDP", "PPF",
+  "réforme facturation 2026", "e-reporting", "PEPPOL France",
+  "mentions obligatoires facture", "avoir facture", "numérotation factures",
+  "franchise en base TVA", "autoliquidation TVA", "régime réel simplifié TVA",
+  "régime réel normal TVA", "FEC", "fichier des écritures comptables",
+  "Plan Comptable Général", "PCG", "liasse fiscale", "bilan France",
+  "compte de résultat", "clôture annuelle", "amortissements comptables",
+  "IS France", "impôt sur les sociétés", "taux réduit PME 15%".
+  Covers TVA regimes and rates, e-invoicing/e-reporting reform timeline,
+  mandatory invoice mentions, IS computation, annual closing, and FEC generation.
+version: 1.0
+jurisdiction: FR
+tax_year: 2025
+category: international
+---
+
+# France — Business Accounting, VAT & E-Invoicing v1.0
+
+> **Based on work by [Romain Simon (@romainsimon)](https://github.com/romainsimon/paperasse)**, licensed under MIT. Adapted for the OpenAccountants format.
+
+> **Disclaimer:** This skill is for informational purposes only and does not constitute tax advice. All positions must be reviewed and signed off by a qualified expert-comptable before filing. Get this reviewed at **openaccountants.com**.
+
+---
+
+## Section 1 — Quick Reference
+
+| Field | Value |
+|---|---|
+| Country | France |
+| Scope | Business accounting (IS/IR entities), TVA, invoicing |
+| Currency | EUR only |
+| Accounting framework | Plan Comptable Général (PCG) |
+| Tax authority | DGFiP |
+| Key legislation | CGI (art. 38-39, 219, 293 B, 242 nonies A), Code de Commerce |
+
+---
+
+## Section 2 — VAT (TVA) Regimes and Rates
+
+### Standard rates (2025)
+
+| Rate | Application |
+|---|---|
+| 20% (taux normal) | Most goods and services |
+| 10% (taux intermédiaire) | Restaurants, certain renovation works, public transport |
+| 5.5% (taux réduit) | Food staples, books, energy, accessibility works |
+| 2.1% (taux super-réduit) | Press, certain medicines, live performances |
+
+### TVA regimes
+
+| Regime | Condition | Declaration |
+|---|---|---|
+| Franchise en base (art. 293 B CGI) | Services CA ≤ EUR 36,800 (tolerance EUR 39,100); Sales CA ≤ EUR 91,900 (tolerance EUR 101,000) | No TVA collected or deducted. Mandatory mention: "TVA non applicable, art. 293 B du CGI" |
+| Régime réel simplifié | CA < EUR 840,000 (goods) or EUR 254,000 (services) | CA12 annual + quarterly advances |
+| Régime réel normal | Above simplified thresholds | CA3 monthly (or quarterly if TVA < EUR 4,000/year) |
+
+### Intra-EU / international services
+
+| Scenario | Treatment |
+|---|---|
+| Service purchased from EU provider | **Autoliquidation** (art. 283-2 CGI) — buyer self-assesses TVA |
+| Service sold to EU business (B2B) | Reverse charge — invoice without TVA, mention "Autoliquidation" |
+| Service sold to EU consumer (B2C) | French TVA unless OSS threshold exceeded |
+| Import of goods from outside EU | TVA at customs or autoliquidation (since 2022) |
+
+---
+
+## Section 3 — E-Invoicing Reform (Réforme Facturation Électronique 2026)
+
+### Timeline
+
+| Date | Obligation | Scope |
+|---|---|---|
+| **1 September 2026** | **Reception** of e-invoices | All TVA-liable entities (including franchise en base) |
+| **1 September 2026** | **Emission** of e-invoices | Grandes Entreprises (GE) and ETI |
+| **1 September 2027** | **Emission** of e-invoices | PME and micro-entreprises |
+
+### Key concepts
+
+| Concept | Description |
+|---|---|
+| PA (Plateforme Agréée) | Certified platform for transmitting/receiving e-invoices. Mandatory for all. |
+| PPF (Portail Public de Facturation) | Since Oct 2024, **no longer handles emission/reception**. Only serves as central directory + e-reporting concentrator. |
+| e-Reporting | Transmission of B2C, international, and payment data. Does **NOT** cover domestic B2B between TVA-liable entities (already transmitted via e-invoicing). |
+| Formats | Factur-X (CII), UBL, CII — structured XML embedded in or alongside PDF |
+| PEPPOL | European e-invoicing network — accepted delivery channel |
+
+### New mandatory mentions (from 1 September 2026, B2B domestic invoices)
+
+| Mention | Notes |
+|---|---|
+| Client SIREN | Required on all domestic B2B invoices |
+| Transaction category | "Biens" / "Services" / "Mixte" — separate from line descriptions |
+
+### E-reporting scope
+
+| Transaction type | E-reporting required? |
+|---|---|
+| B2B domestic (both TVA-liable) | No — covered by e-invoicing |
+| B2C | Yes |
+| International (export, intra-EU) | Yes |
+| Payment data | Yes (for TVA-on-payments regime) |
+
+---
+
+## Section 4 — Invoice Requirements (Mentions Obligatoires)
+
+### Mandatory mentions on every invoice
+
+| Mention | Legal basis |
+|---|---|
+| Invoice date | Art. 242 nonies A CGI |
+| Sequential invoice number (no gaps) | Art. 242 nonies A CGI |
+| Seller: name, address, SIREN/SIRET | Art. 242 nonies A CGI |
+| Buyer: name, address | Art. 242 nonies A CGI |
+| Buyer SIREN (B2B domestic, from Sept 2026) | Réforme 2026 |
+| VAT identification numbers (seller + buyer for intra-EU) | Art. 242 nonies A CGI |
+| Description of goods/services | Art. 242 nonies A CGI |
+| Quantity | Art. 242 nonies A CGI |
+| Unit price (HT) | Art. 242 nonies A CGI |
+| TVA rate(s) applied | Art. 242 nonies A CGI |
+| Total HT, TVA amount, Total TTC | Art. 242 nonies A CGI |
+| Payment terms (due date) | Art. L441-9 Code de Commerce |
+| Late payment penalties rate | Art. L441-10 Code de Commerce |
+| Fixed recovery fee (EUR 40) | Art. D441-5 Code de Commerce |
+| Early payment discount or "Escompte: néant" | Art. 242 nonies A CGI |
+
+**If franchise en base:** "TVA non applicable, art. 293 B du CGI" instead of TVA amounts.
+
+### Credit notes (avoirs)
+
+Must reference the original invoice number and clearly state the reason for the credit.
+
+### Numbering
+
+Sequential, chronological, no gaps. Common format: annual reset (e.g., F-2025-001, F-2025-002… F-2026-001).
+
+### Retention
+
+Invoices must be retained for **10 years** (art. L123-22 Code de Commerce). Digital archival with integrity guarantees.
+
+---
+
+## Section 5 — Corporate Tax (Impôt sur les Sociétés — IS)
+
+### Rates (2025)
+
+| Bracket | Rate | Condition |
+|---|---|---|
+| First EUR 42,500 of profit | **15%** (taux réduit PME) | CA < EUR 10M, capital fully paid up, ≥75% held by individuals |
+| Above EUR 42,500 | **25%** (taux normal) | |
+
+**Short financial year:** the EUR 42,500 threshold is prorated: EUR 42,500 × (days / 365).
+
+### IS is not deductible
+
+IS itself (account 695) is **not deductible** from taxable profit (art. 39-1-4° CGI). It must be added back in the fiscal result.
+
+### Non-deductible charges (common traps)
+
+| Charge | Rule |
+|---|---|
+| Fines and penalties | Not deductible |
+| Luxury expenses (chasse, yacht) | Not deductible |
+| Personal expenses of shareholder | Not deductible — risk of "acte anormal de gestion" |
+| IS itself | Not deductible |
+| Excessive management fees | Excess not deductible |
+
+### Deductibility conditions (art. 39-1 CGI)
+
+All charges must satisfy four conditions:
+1. Incurred in the interest of the business
+2. Reflect normal management
+3. Supported by documentation (invoices)
+4. Result in a decrease of net assets
+
+---
+
+## Section 6 — Annual Closing (Clôture Annuelle) — Summary
+
+### 12-step workflow
+
+1. Collect all transactions for the financial year
+2. Categorise expenses (vendor → PCG account)
+3. Bank reconciliation
+4. Inventory entries (amortisation, PCA/CCA, provisions)
+5. IS calculation
+6. Generate journal entries (`data/journal-entries.json`)
+7. Generate financial statements (bilan, compte de résultat, balance)
+8. Generate the FEC (Fichier des Écritures Comptables)
+9. Prepare liasse fiscale (2033 for simplified, 2050 for normal)
+10. Prepare 2065-SD (IS declaration)
+11. Prepare PV d'approbation / déclaration de confidentialité
+12. Generate PDFs
+
+### FEC (Fichier des Écritures Comptables)
+
+Mandatory file with **18 columns**, pipe-separated (`|`). Must include all journal entries for the financial year.
+
+**Conformity checks:**
+- Total debits = total credits (global balance)
+- Each entry (EcritureNum) is balanced
+- Sequential numbering (no gaps)
+- Dates within the financial year
+- No negative amounts
+- PieceRef populated for every entry
+- CompteNum consistent with PCG roots
+
+**Non-compliant FEC → comptabilité non probante** (art. L. 192 LPF) → burden of proof shifts to the taxpayer.
+
+---
+
+## Section 7 — Shareholder Current Account (Compte Courant d'Associé — 455)
+
+**High fiscal risk zone**, especially for SASU/EURL.
+
+| Check | Rule |
+|---|---|
+| Pre-incorporation expenses | Must be assumed within 6 months of registration; annexed to statuts or PV |
+| Home office (bureau à domicile) | Pro-rata of surface area; plan required; non-deductible: mortgage principal, personal utilities |
+| Interest on current account | Deductible only up to TMPV BCE rate; capital must be fully paid up (art. 212 CGI) |
+| Mixed-use expenses | Only professional portion deductible |
+| Currency conversion | BCE rate per transaction or monthly average accepted |
+
+---
+
+## Section 8 — Fiscal Calendar (Key Deadlines)
+
+| Deadline | Obligation |
+|---|---|
+| Monthly 19th–24th | CA3 (TVA mensuelle) |
+| Quarterly | CA3 (TVA trimestrielle if < EUR 4,000/year) |
+| May (2nd business day after 1 May) | CA12 annual TVA return |
+| 15 March, 15 June, 15 September, 15 December | IS quarterly advances |
+| Within 3 months of year-end + 1 month extension | Liasse fiscale + 2065-SD |
+| Within 6 months of year-end | AGO (approbation des comptes) |
+| 1 month after AGO | Dépôt au greffe |
+
+Check the official calendar: `https://www.impots.gouv.fr/professionnel/calendrier-fiscal`
+
+---
+
+## Section 9 — Conservative Defaults
+
+| Ambiguity | Default |
+|---|---|
+| TVA regime unknown | Franchise en base (if CA permits) |
+| Charge deductibility doubtful | Non-deductible (conservative) |
+| Mixed-use proportion unclear | 0% professional (flag for reviewer) |
+| IS rate applicable unclear | 25% (no PME reduced rate) |
+| Immobilisation vs charge threshold | EUR 500 HT (capitalise above) |
+
+---
+
+## Section 10 — Key Legal References
+
+| Rule | Article |
+|---|---|
+| Taxable profit | art. 38-1 CGI |
+| Net asset variation | art. 38-2 CGI |
+| Deductible charges | art. 39-1 CGI |
+| IS rates | art. 219-I CGI |
+| PME reduced rate | art. 219-I-b CGI |
+| IS non-deductible | art. 39-1-4° CGI |
+| Franchise en base TVA | art. 293 B CGI |
+| Autoliquidation | art. 283-2 CGI |
+| CCA interest cap | art. 39-1-3° and 212 CGI |
+| Invoice mentions | art. 242 nonies A CGI |
+| FEC obligation | art. L. 47 A-I LPF |
+| Document retention | art. L123-22 Code de Commerce |
+
+---
+
+*OpenAccountants — open-source tax computation skills*
+*This output must be reviewed by a qualified professional before filing or acting upon.*
+*Latest verified skills: **openaccountants.com** | Report errors: **github.com/openaccountants/openaccountants***

--- a/skills/international/france/fr-capital-gains.md
+++ b/skills/international/france/fr-capital-gains.md
@@ -1,0 +1,348 @@
+---
+name: fr-capital-gains
+description: >
+  French capital gains, investment income, and equity compensation tax rules.
+  Trigger on phrases like "plus-values mobilières", "PFU", "flat tax", "prélèvement forfaitaire unique",
+  "dividendes France", "intérêts", "revenus de capitaux mobiliers", "RCM",
+  "PEA", "plan d'épargne en actions", "assurance-vie", "rachat assurance-vie",
+  "abattement 40% dividendes", "option barème", "prélèvements sociaux",
+  "RSU France", "actions gratuites", "AGA", "BSPCE", "stock-options",
+  "PEE", "PERCO", "épargne salariale", "abondement employeur",
+  "gain d'acquisition", "equity salarial", "PER sortie capital",
+  "PV mobilières", "cession de titres", "compte-titres ordinaire", "CTO".
+  Covers PFU vs barème arbitrage, dividends, interest, capital gains on securities,
+  PEA, assurance-vie rachats, RSU/BSPCE/stock-options, PEE/PERCO, and the
+  differentiated PS rates under LFSS 2026. For crypto see fr-crypto-tax.
+version: 1.0
+jurisdiction: FR
+tax_year: 2025
+category: international
+---
+
+# France — Capital Gains, Investment Income & Equity Compensation v1.0
+
+> **Based on work by [Romain Simon (@romainsimon)](https://github.com/romainsimon/paperasse)**, licensed under MIT. Adapted for the OpenAccountants format.
+
+> **Disclaimer:** This skill is for informational purposes only and does not constitute tax advice. All positions must be reviewed and signed off by a qualified expert-comptable or avocat fiscaliste before filing. Get this reviewed at **openaccountants.com**.
+
+---
+
+## Section 1 — Quick Reference
+
+| Field | Value |
+|---|---|
+| Country | France |
+| Taxes covered | PFU (flat tax), prélèvements sociaux (PS), barème option on capital income |
+| Currency | EUR only |
+| Tax year | Calendar year |
+| Key forms | 2042, 2042-C, 2074, 2042-IFI |
+| Primary legislation | art. 200 A CGI (PFU), art. 158-3° CGI (40% abattement), art. 150-0 A CGI (PV mobilières) |
+
+---
+
+## Section 2 — PFU vs Barème: The Fundamental Arbitrage
+
+### Default: PFU (Prélèvement Forfaitaire Unique / Flat Tax)
+
+| Income type | IR component | PS component (revenus 2025) | Total PFU |
+|---|---|---|---|
+| Dividends | 12.8% | 17.2% | **30.0%** |
+| Interest (RCM) | 12.8% | 17.2% | **30.0%** |
+| Capital gains on securities (PV mobilières) | 12.8% | 18.6% | **31.4%** |
+| PEA gains (exit after 5 yr) | 0% (exempt) | 17.2% → 18.6% from 01/01/2026 | 17.2% or 18.6% |
+
+### Differentiated PS rates (LFSS 2026)
+
+LFSS 2026 (loi n° 2025-1403, art. 12) raised CSG from 9.2% to 10.6% (PS total: 17.2% → 18.6%), with **two different effective dates:**
+
+| Category | Legal basis | PS on 2025 income | PS on 2026+ income | Effective PFU 2025 |
+|---|---|---|---|---|
+| **Revenus du patrimoine** (capital gains, crypto, LMNP) | L. 136-6 CSS | **18.6%** | 18.6% | **31.4%** |
+| **Produits de placement** (dividends, interest, PEA exit, PER capital) | L. 136-7 CSS | 17.2% | **18.6% from 01/01/2026** | 30.0% |
+| **Unchanged** (AV, bare rental, SCPI, old PEL/CEL) | — | 17.2% | 17.2% | — |
+
+### Option barème (progressive rates)
+
+On election (global and irrevocable for the year), all capital income is taxed at the progressive IR schedule instead of 12.8%.
+
+**Benefits of barème:**
+- 40% abattement on dividends (art. 158-3° CGI)
+- CSG déductible 6.8% in N+1 (economy = 6.8% × base × TMI in N+1)
+
+**Quick guidance:**
+
+| TMI | Recommendation | Reason |
+|---|---|---|
+| 0% or 11% | Barème | Low bracket + 40% dividend abattement + deductible CSG |
+| 30% | Compute both | Depends on composition (dividends vs interest vs gains) |
+| 41% or 45% | PFU | Flat 12.8% < 41%/45% bracket |
+
+**Critical rule:** the barème option is **global** (all capital income for the year) and **irrevocable**. Never recommend without checking the full composition.
+
+### Worked comparison — Single, TMI 30%, EUR 10,000 dividends (2025)
+
+**Under PFU (dividends = produits de placement, PS 17.2%):**
+
+| Component | Amount |
+|---|---|
+| IR: 10,000 × 12.8% | 1,280 |
+| PS: 10,000 × 17.2% | 1,720 |
+| **Total** | **3,000** |
+
+**Under barème:**
+
+| Component | Amount |
+|---|---|
+| Taxable base: 10,000 × (1 − 40%) | 6,000 |
+| IR: 6,000 × 30% | 1,800 |
+| PS: 10,000 × 17.2% | 1,720 |
+| CSG déductible N+1: 10,000 × 6.8% × 30% | −204 |
+| **Net total** | **3,316** |
+
+→ PFU more favourable (EUR 3,000 < EUR 3,316) despite the 40% abattement.
+
+---
+
+## Section 3 — Types of Capital Income
+
+### Dividends (case 2DC)
+
+- Default PFU 30% (2025); rising to 31.4% from dividends received in 2026
+- Option barème: 40% abattement + progressive IR + PS
+- Foreign dividends: may carry withholding tax from source country — credit under tax treaty
+
+### Interest / RCM (case 2TR)
+
+- Bonds, crowdfunding interest, taxable savings accounts, term deposits
+- PFU or barème on option. **No abattement** (unlike dividends)
+- Crowdfunding immobilier: taxed as RCM, not rental income
+- Livrets réglementés (Livret A, LDDS, LEP): **fully exempt** from IR and PS
+
+### Capital gains on securities (case 3VG)
+
+- Net gain on sale of shares, partnership interests, UCITS
+- PFU or barème on option
+- Holding period abattements: **only for shares acquired before 2018 AND barème option**
+- Director retirement abattement: EUR 500,000 lump sum under strict conditions
+
+---
+
+## Section 4 — PEA (Plan d'Épargne en Actions)
+
+### Contribution ceilings
+
+| Plan | Ceiling |
+|---|---|
+| PEA classique | EUR 150,000 |
+| PEA-PME | Combined PEA + PEA-PME ≤ EUR 225,000 |
+| PEA jeune (adult child attached to household) | EUR 20,000 |
+
+Ceilings apply to **contributions**, not plan value. A plan can exceed EUR 150,000 through gains.
+
+### Tax treatment by plan age
+
+| Plan age | Withdrawal effect | IR | PS |
+|---|---|---|---|
+| < 5 years | **Closure** of plan | PFU 12.8% (or barème) | 17.2% |
+| ≥ 5 years | Free withdrawals, no closure | **Exempt** | 17.2% (→ 18.6% from 01/01/2026) |
+
+After 5 years: **total IR exemption on gains**. Only PS are due at each withdrawal.
+
+PS from 01/01/2026: **18.6%** on total gain at withdrawal (including gain accrued before 2026). PEA gains are "produits de placement" (L. 136-7 CSS).
+
+**Eligible assets:** European equities (EU + EEA), UCITS with ≥75% European equities, eligible European ETFs. Non-eligible: US/Asian stocks, bonds, gold, crypto.
+
+---
+
+## Section 5 — Assurance-Vie (Life Insurance) — Taxation of Withdrawals (Rachats)
+
+### Proportionality principle
+
+A partial withdrawal does **not** extract only non-taxable capital. It extracts a **proportional** fraction of gains and capital.
+
+```
+taxable_gain_portion = (total_gains / total_contract_value) × withdrawal_amount
+```
+
+### Annual abattement after 8 years
+
+| Situation | Annual abattement |
+|---|---|
+| Single, widowed, divorced | EUR 4,600 |
+| Couple (joint filing) | EUR 9,200 |
+
+Condition: 8 years of **contract** age (not contribution age). Renewable each calendar year.
+
+### Tax rates by contribution date
+
+**Contributions after 27 September 2017:**
+
+| Situation | Rate |
+|---|---|
+| Contract < 8 years | PFU 30% (12.8% IR + 17.2% PS) |
+| Contract ≥ 8 years, total contributions < EUR 150,000 | 24.7% (7.5% IR + 17.2% PS) after abattement |
+| Contract ≥ 8 years, total contributions ≥ EUR 150,000 | 30% on fraction above EUR 150,000 of **net contributions** |
+
+The EUR 150,000 threshold is assessed across **all AV contracts** of the household.
+
+**Contributions before 27 September 2017:** Degressive PFL rates (35% / 15% / 7.5%) by contract age.
+
+**PS rate on AV: 17.2% unchanged** (excluded from LFSS 2026 increase).
+
+### Strategy: optimised withdrawals after 8 years
+
+Spread withdrawals to stay within the annual abattement (EUR 9,200 couple). Example: need EUR 50,000 over 5 years → EUR 10,000/year optimises the abattement if gain portion ≤ abattement per withdrawal.
+
+---
+
+## Section 6 — RSU / AGA (Restricted Stock Units / Actions Gratuites)
+
+### Two distinct taxable events
+
+**1. Gain d'acquisition (at vesting)**
+
+| Attribute | Detail |
+|---|---|
+| Nature | **Salary income** (traitements et salaires) |
+| 2042 box | 1TT / 1UT |
+| Tax | Progressive IR schedule (after 10% salary abattement on total salaries) |
+| Social contributions | CSG/CRDS 9.7% + salarial contribution 10% (qualifying plans, within caps) |
+
+**2. Plus-value de cession (at sale)**
+
+| Attribute | Detail |
+|---|---|
+| Nature | PV mobilière |
+| Tax | PFU **31.4%** for disposals from 2025 (12.8% IR + 18.6% PS) or barème on option |
+| Qualification | "Revenus du patrimoine" (L. 136-6 CSS) → PS 18.6% from 2025 |
+
+**Classic trap:** treating the acquisition gain as a standard capital gain. It is first and foremost **salary** (barème), subject to CSG 9.7% and salarial contribution 10%. Only the subsequent appreciation (vesting value → sale price) is a capital gain.
+
+**Strategy:** for massive vesting (> 1.5× annual salary), consider the **quotient pour revenus exceptionnels** (coefficient 4) to smooth across brackets. Useless if already at TMI 45%.
+
+---
+
+## Section 7 — BSPCE (Bons de Souscription de Parts de Créateur d'Entreprise)
+
+**Key difference vs RSU:** no acquisition gain taxed as salary. The gain is only realised and taxed **at sale** of the underlying shares.
+
+### Tax rate on disposal gain
+
+| Tenure in the company at sale date | Total rate (2025 disposals) |
+|---|---|
+| **≥ 3 years** | **31.4%** (12.8% IR + 18.6% PS — PV mobilière) |
+| **< 3 years** | **50%** (30% IR + 20% PS — specific salarial contribution) |
+
+**Early departure penalty** (< 3 years) is severe. Factor into departure decisions.
+
+### Issuing company eligibility
+
+- SA or SAS incorporated in France
+- Registered < 15 years
+- Unlisted or listed on SME compartment
+- Subject to IS
+- Capital ≥ 25% held by natural persons
+- No restructuring history (merger, demerger, takeover)
+
+If conditions not met: requalification as salary → progressive IR + full social contributions.
+
+---
+
+## Section 8 — Stock-Options
+
+| Plan period | Regime |
+|---|---|
+| Before 2012 | Favourable specific schedule (by holding period) |
+| 2012–2016 | Salary (IR barème + specific social contributions) |
+| After 2017 | Salary (barème) + salarial contribution 10% on qualifying plans |
+
+**Excess discount** (rabais excédentaire): difference between market price at grant and exercise price, above 5% → taxed as salary at exercise.
+
+Always consult the plan to determine the applicable regime.
+
+---
+
+## Section 9 — PEE / PERCO / Employee Savings
+
+### PEE (Plan d'Épargne Entreprise)
+
+| Feature | Detail |
+|---|---|
+| Employer match (abondement) | IR-exempt + PS-exempt within caps |
+| Match cap | ~EUR 3,709 per beneficiary (8% PASS — verify annually) |
+| Lock-up | 5 years (early exit for marriage, 3rd child birth, home purchase, job loss, etc.) |
+| Exit after 5 years | **IR-exempt**, only PS 17.2% on gains |
+
+### PERCO / PERO (Company PER)
+
+| Feature | Detail |
+|---|---|
+| Exit | At retirement — annuity or lump sum |
+| Tax at exit | Same as individual PER (contributions at barème, gains at PFU) |
+| Match cap | ~EUR 7,418 (distinct from PEE cap) |
+
+### Priority rule
+
+| Priority | Envelope | Why |
+|---|---|---|
+| 1st | PEE + employer match | Match = 50–300% instant return — unbeatable |
+| 2nd | PERCO/PERO + employer match | Same logic, retirement lock |
+| 3rd | Individual PER | Only TMI deduction, no match |
+
+**Golden rule:** never contribute to an individual PER before saturating the employer match on PEE + PERCO. The match is free money.
+
+---
+
+## Section 10 — PER Sortie en Capital (Exit Taxation)
+
+When exiting an individual PER as a lump sum:
+
+| Component | Tax treatment |
+|---|---|
+| **Contributions (previously deducted)** | Progressive IR schedule (barème) — treated as income |
+| **Investment gains** | PFU: 12.8% IR + PS (17.2% before 01/01/2026; 18.6% from 01/01/2026) |
+
+PER gains are "produits de placement" (L. 136-7 CSS).
+
+**Trap:** a lump-sum exit on contributions at TMI 45% is nearly neutral — same tax as a normal income year. Fractionate the exit over multiple years if possible.
+
+---
+
+## Section 11 — Conservative Defaults
+
+| Ambiguity | Default |
+|---|---|
+| PFU vs barème unclear | Apply PFU (simpler, no global commitment) |
+| RSU gain classification unclear | Treat as salary (acquisition gain) |
+| BSPCE tenure unclear | Assume < 3 years (50% rate — conservative) |
+| PEA age unclear | Assume < 5 years (taxable) |
+| AV abattement eligibility unclear | No abattement applied |
+| PS rate unclear for 2025 income | Apply 18.6% for PV mobilières, 17.2% for dividends/interest |
+
+---
+
+## Section 12 — Key Legal References
+
+| Rule | Article |
+|---|---|
+| PFU | art. 200 A CGI |
+| Option barème | art. 200 A-2 CGI |
+| Dividend 40% abattement | art. 158-3° CGI |
+| Capital gains on securities | art. 150-0 A to 150-0 D CGI |
+| Prélèvements sociaux | art. L. 136-1 et seq. CSS |
+| PS differentiation (patrimoine vs placement) | art. L. 136-6 and L. 136-7 CSS |
+| LFSS 2026 CSG increase | loi n° 2025-1403, art. 12 |
+| RSU / AGA | art. 80 quaterdecies CGI |
+| BSPCE | art. 163 bis G CGI |
+| Stock-options | art. 80 bis CGI |
+| PEA | art. 163 quinquies D CGI, art. L. 221-30 CMF |
+| Assurance-vie rachats | art. 125-0 A CGI |
+| AV abattement | art. 125-0 A-I-2° CGI |
+| AV 150k threshold | art. 125-0 A-I-2° bis CGI |
+| PEE | art. L. 3332-1 et seq. Code du travail |
+
+---
+
+*OpenAccountants — open-source tax computation skills*
+*This output must be reviewed by a qualified professional before filing or acting upon.*
+*Latest verified skills: **openaccountants.com** | Report errors: **github.com/openaccountants/openaccountants***

--- a/skills/international/france/fr-crypto-tax.md
+++ b/skills/international/france/fr-crypto-tax.md
@@ -1,0 +1,205 @@
+---
+name: fr-crypto-tax
+description: >
+  French cryptocurrency and digital asset taxation for individuals.
+  Trigger on phrases like "crypto France impôt", "fiscalité crypto", "bitcoin impôt France",
+  "ethereum déclaration France", "plus-value crypto", "PAMC crypto",
+  "prix d'acquisition moyen pondéré", "formulaire 2086", "déclaration 2086",
+  "cession crypto-actifs", "staking impôt France", "mining fiscalité",
+  "airdrop fiscalité", "exonération 305 euros", "crypto flat tax France",
+  "échange crypto-to-crypto", "stablecoin fiscalité", "Koinly France",
+  "Waltio", "déclaration crypto France", "BNC staking".
+  Covers the PAMC method, the EUR 305 exemption threshold, PFU 31.4%,
+  barème option, form 2086, staking/mining/airdrops, and documentation obligations.
+version: 1.0
+jurisdiction: FR
+tax_year: 2025
+category: international
+---
+
+# France — Crypto-Asset Taxation (Particuliers) v1.0
+
+> **Based on work by [Romain Simon (@romainsimon)](https://github.com/romainsimon/paperasse)**, licensed under MIT. Adapted for the OpenAccountants format.
+
+> **Disclaimer:** This skill is for informational purposes only and does not constitute tax advice. All positions must be reviewed and signed off by a qualified expert-comptable or avocat fiscaliste before filing. Get this reviewed at **openaccountants.com**.
+
+---
+
+## Section 1 — Quick Reference
+
+| Field | Value |
+|---|---|
+| Country | France |
+| Tax | IR + prélèvements sociaux on crypto capital gains |
+| Currency | EUR only |
+| Tax year | Calendar year |
+| Primary legislation | art. 150 VH bis CGI |
+| Key forms | 2086 (per-disposal detail), 2042-C (cases 3AN/3BN) |
+| Exemption threshold | EUR 305 annual gross disposals |
+| Default rate | PFU **31.4%** (12.8% IR + 18.6% PS) for 2025 income |
+
+---
+
+## Section 2 — Scope: Occasional vs Professional
+
+This skill covers the **occasional** regime for individuals. If the activity is habitual/professional, it is reclassified as **BIC** with TNS social contributions.
+
+**Indicators of professional activity:**
+- High transaction volume
+- Near-daily frequency
+- Use of professional tools (bots, API, automated arbitrage)
+- Crypto income constitutes primary household revenue
+
+---
+
+## Section 3 — Taxable Events (Fait Générateur)
+
+| Operation | Taxable? | Notes |
+|---|---|---|
+| Buy crypto with EUR/USD | No | Acquisition only |
+| **Sell crypto for EUR/USD** | **Yes** | Disposal to fiat |
+| **Pay with crypto (goods/services)** | **Yes** | Disguised disposal |
+| Crypto-to-crypto exchange (BTC → ETH) | **No** | Deferral (sursis, art. 150 VH bis-I-2) |
+| Crypto → stablecoin (USDC, USDT) | **No** | Stablecoins treated as crypto-assets |
+| **Stablecoin → EUR/USD** | **Yes** | Disposal to fiat |
+| Staking / mining / airdrop | See Section 8 | Different regime (BNC or BIC) |
+
+**Crypto-to-crypto deferral rule:** exchanges between crypto-assets do not trigger taxation. Only conversion to fiat currency (or use as payment) is a taxable event.
+
+---
+
+## Section 4 — PAMC Method (Prix d'Acquisition Moyen Pondéré en Continu)
+
+### Official formula
+
+```
+capital_gain = disposal_price − (total_portfolio_acquisition_cost × disposal_price / portfolio_value_before_disposal)
+```
+
+### Practical consequences
+
+- Each disposal draws from the **global** portfolio (not FIFO, not LIFO)
+- Requires tracing the **complete history** from the first purchase
+- If acquisition prices are undocumented → risk of reclassification as disposal at price 0 (maximum gain)
+
+### Recommended tools
+
+Koinly, CoinTracking, Waltio, Cryptio. Verify that the tool correctly applies the French PAMC method.
+
+---
+
+## Section 5 — Tax Rates
+
+### Default: PFU 31.4%
+
+| Component | Rate |
+|---|---|
+| IR | 12.8% |
+| PS (revenus du patrimoine, L. 136-6 CSS) | **18.6%** (LFSS 2026, applicable to 2025 disposals) |
+| **Total PFU** | **31.4%** |
+
+Applied on the **net annual gain** (after offsetting current-year losses).
+
+### Option barème (since revenus 2023)
+
+Available since LFI 2022. **Advantageous only if TMI ≤ 11%.**
+
+The barème option is **global** — applies to all capital income for the year (dividends, interest, capital gains). Arbitrage must be performed at the global level.
+
+---
+
+## Section 6 — EUR 305 Exemption Threshold
+
+| Annual gross disposals | Treatment |
+|---|---|
+| ≤ EUR 305 | **Total exemption** — no tax, no filing of 2086 |
+| > EUR 305 | **Full taxation** on the gain (not just the excess) |
+
+**Trap:** the threshold applies to the **gross disposal amount**, not the gain. Selling EUR 500 of crypto with only EUR 10 gain still triggers taxation on the EUR 10 gain.
+
+---
+
+## Section 7 — Loss Offsetting
+
+- Current-year crypto losses **can offset** current-year crypto gains
+- Crypto losses **cannot offset** standard securities capital gains (separate bucket)
+- **No carryforward** of crypto losses to future years (specific rule)
+
+---
+
+## Section 8 — Staking, Mining, Airdrops
+
+**Separate regime from capital gains** — taxed according to the nature of the activity:
+
+| Activity | Probable regime | Notes |
+|---|---|---|
+| Occasional staking | BNC non-professionnel | Valued in EUR at each reception date |
+| Mining | BIC | |
+| Professional staking/lending | BIC | |
+| Passive airdrop (no task) | Not taxable at reception | Capital gain computed at disposal |
+| Active rewards (tasks required) | BNC or salary | |
+
+**Occasional staking — BNC declaration at reception:** value in EUR at each date of receipt. Declare on 2042-C-PRO case 5HQ (micro-BNC, 34% abattement) or 5HG (réel). Micro-BNC exemption if receipts ≤ EUR 305.
+
+**Grey zone:** DGFiP doctrine is evolving. Check latest BOFiP positions.
+
+---
+
+## Section 9 — Form 2086 (Mandatory Disclosure)
+
+Mandatory for **every disposal** once annual gross disposals exceed EUR 305.
+
+**Per-disposal details required:**
+- Date of disposal
+- Portfolio value before disposal
+- Total portfolio acquisition cost
+- Disposal price
+- Computed gain or loss
+
+**Reporting on 2042-C:**
+- Case **3AN**: net annual gain (profit)
+- Case **3BN**: net annual loss
+
+---
+
+## Section 10 — Documentation Requirements
+
+Retain for **minimum 6 years** (statute of limitations):
+- Complete transaction history (exchange exports)
+- Proof of acquisition dates and prices
+- Crypto-to-crypto exchange details (even though non-taxable — prove portfolio continuity)
+- Wallet-to-wallet transfers (prove portfolio continuity)
+- Staking reward exports with fiat valuation at each reception date
+
+---
+
+## Section 11 — Conservative Defaults
+
+| Ambiguity | Default |
+|---|---|
+| Activity classification unclear | Occasional (particulier regime) |
+| Acquisition cost undocumented | EUR 0 (maximum gain — conservative from tax authority perspective) |
+| Staking income classification unclear | BNC non-professionnel |
+| PFU vs barème unclear | PFU (no global commitment) |
+| Stablecoin → stablecoin | Non-taxable (crypto-to-crypto) |
+
+---
+
+## Section 12 — Key Legal References
+
+| Rule | Article |
+|---|---|
+| Crypto capital gains regime | art. 150 VH bis CGI |
+| PAMC method | art. 150 VH bis-II CGI |
+| Crypto-to-crypto deferral | art. 150 VH bis-I-2 CGI |
+| Professional/habitual activity (BIC) | art. 34 CGI |
+| PS (revenus du patrimoine) | art. L. 136-6 CSS |
+| LFSS 2026 CSG increase | loi n° 2025-1403, art. 12 |
+| BOFiP PV crypto | BOI-RPPM-PVBMC-30 |
+| BOFiP BNC staking/mining | BOI-BNC-CHAMP-10-10-20-40 |
+
+---
+
+*OpenAccountants — open-source tax computation skills*
+*This output must be reviewed by a qualified professional before filing or acting upon.*
+*Latest verified skills: **openaccountants.com** | Report errors: **github.com/openaccountants/openaccountants***

--- a/skills/international/france/fr-personal-income-tax.md
+++ b/skills/international/france/fr-personal-income-tax.md
@@ -1,0 +1,438 @@
+---
+name: fr-personal-income-tax
+description: >
+  Comprehensive French personal income tax (impôt sur le revenu / IR) guide for all individuals.
+  Trigger on phrases like "impôt sur le revenu", "IR France", "barème progressif",
+  "quotient familial", "décote", "prélèvement à la source", "PAS", "CEHR",
+  "contribution exceptionnelle hauts revenus", "CDHR", "déclaration 2042",
+  "revenus exceptionnels", "quotient pour revenus exceptionnels", "TMI",
+  "taux marginal d'imposition", "tranches d'imposition France", "parts fiscales",
+  "parent isolé case T", "pension alimentaire déduction", "réductions d'impôt",
+  "crédits d'impôt", "emploi à domicile", "dons associations", "plafonnement niches fiscales",
+  "non-résident fiscal France", "exit tax", "impatriation", "PUMA cotisation subsidiaire",
+  "calcul IR France", "simulation impôt sur le revenu", "avis d'imposition".
+  Covers the full IR computation sequence: progressive brackets, quotient familial with
+  plafonnement, décote, CEHR, CDHR, prélèvement à la source, deductions/reductions/credits,
+  non-residents, and special cases. For capital gains see fr-capital-gains, for rental
+  income see fr-rental-income, for crypto see fr-crypto-tax.
+version: 1.0
+jurisdiction: FR
+tax_year: 2025
+category: international
+---
+
+# France — Personal Income Tax (Impôt sur le Revenu) — Comprehensive Guide v1.0
+
+> **Based on work by [Romain Simon (@romainsimon)](https://github.com/romainsimon/paperasse)**, licensed under MIT. Adapted for the OpenAccountants format.
+
+> **Disclaimer:** This skill is for informational purposes only and does not constitute tax advice. All positions must be reviewed and signed off by a qualified expert-comptable or avocat fiscaliste before filing. Get this reviewed at **openaccountants.com**.
+
+---
+
+## Section 1 — Quick Reference
+
+| Field | Value |
+|---|---|
+| Country | France (République française) |
+| Tax | Impôt sur le Revenu (IR) + Prélèvements sociaux + CEHR + CDHR |
+| Currency | EUR only |
+| Tax year | Calendar year (1 January – 31 December) |
+| Primary legislation | Code Général des Impôts (CGI), art. 197 |
+| Tax authority | Direction Générale des Finances Publiques (DGFiP) |
+| Filing portal | impots.gouv.fr (espace particulier) |
+| Filing deadline | Late May / early June (varies by département, online) |
+| Key forms | 2042, 2042-C, 2042-C-PRO, 2042-IFI, 2047, 2074, 2086 |
+
+---
+
+## Section 2 — Full IR Computation Sequence
+
+**Never skip a step. Each intermediate must be computed.**
+
+```
+1. Revenus bruts par catégorie
+   ↓ abattements spécifiques (10% salaires, 10% pensions, 40% dividendes if barème…)
+2. Revenus nets catégoriels
+   ↓ somme
+3. Revenu brut global (RBG)
+   ↓ déductions (PER, pension alimentaire, CSG déductible N-1)
+4. Revenu Net Imposable (RNI)
+   ↓ ÷ nombre de parts
+5. Quotient
+   ↓ application du barème progressif
+6. Impôt par part
+   ↓ × nombre de parts
+7. Impôt brut
+   ↓ plafonnement du gain QF
+8. Impôt après QF
+   ↓ décote (if impôt < threshold)
+9. Impôt après décote
+   ↓ − réductions d'impôt (floor at 0)
+10. Impôt après réductions
+    ↓ − crédits d'impôt (refundable — can be negative)
+11. Impôt net
+    + Prélèvements sociaux (separate, on capital income)
+    + CEHR (if RFR > thresholds)
+    + CDHR (if effective rate < 20% floor)
+    = Total tax liability
+```
+
+---
+
+## Section 3 — Progressive Rate Table (Barème IR)
+
+### 2025 Brackets (revenus 2025, déclaration 2026) — per part
+
+| Revenu net imposable (EUR/part) | Rate | Cumulative tax at top of bracket |
+|---|---|---|
+| 0 – 11,600 | 0% | 0 |
+| 11,601 – 29,579 | 11% | 1,977.69 |
+| 29,580 – 84,577 | 30% | 18,477.09 |
+| 84,578 – 181,917 | 41% | 58,386.49 |
+| Above 181,917 | 45% | — |
+
+*Tranches LFI 2026 (revenus 2025, indexation +0.9%). Source: art. 197 CGI.*
+
+### Worked Example — Single, RNI = EUR 40,000, 1 part
+
+| Bracket | Calculation | Tax |
+|---|---|---|
+| 0 – 11,600 | 11,600 × 0% | 0 |
+| 11,601 – 29,579 | 17,979 × 11% | 1,977.69 |
+| 29,580 – 40,000 | 10,421 × 30% | 3,126.30 |
+| **Total** | | **5,103.99** |
+
+---
+
+## Section 4 — Abattements (Standard Deductions) by Income Category
+
+| Income type | 2042 box | Abattement | Min / Max | Notes |
+|---|---|---|---|---|
+| Salaries (salaires) | 1AJ/1BJ | 10% | min EUR 509, max EUR 14,555 | Or opt for frais réels |
+| Pensions / retirement | 1AS/1BS | 10% | min EUR 450, max EUR 4,446 per household | |
+| **Unemployment (ARE)** | **1AP/1BP** | **None** | — | Common trap: never put in 1AJ |
+| Dividends (option barème) | 2DC | 40% | — | Only under barème option |
+| Dividends (PFU) | 2DC | None | — | |
+| Micro-BNC | 5TE | 34% | min EUR 305, ceiling EUR 77,700 | |
+| Micro-foncier (bare rental) | 4BE | 30% | ceiling EUR 15,000 | |
+| Micro-BIC LMNP long-term | 5ND | 50% | ceiling EUR 77,700 | |
+| Micro-BIC furnished tourism unclassified | 5ND | 30% | ceiling EUR 15,000 | Loi Le Meur |
+| Micro-BIC furnished tourism classified | 5NG | 50% | ceiling EUR 77,700 | |
+
+**Salary terminology trap:**
+
+| Term | Where found | Value |
+|---|---|---|
+| Salaire brut | Pay slip — top | Before contributions |
+| Salaire net | Pay slip — deposited amount | After contributions, before non-deductible CSG |
+| **Salaire net imposable (1AJ)** | **Pay slip — dedicated line** | **Amount declared in box 1AJ** |
+| RNI (after abattement) | Avis d'imposition | 1AJ × 0.9 (standard range) |
+
+---
+
+## Section 5 — Quotient Familial (Family Quotient)
+
+### Parts de base (base shares)
+
+| Situation | Base parts |
+|---|---|
+| Single, divorced, separated | 1 |
+| Married / PACSed (joint filing) | 2 |
+| Widowed without children | 1 |
+| Widowed with child(ren) | 2 (+ child parts) |
+
+### Majoration for children
+
+| Child rank | Additional parts |
+|---|---|
+| 1st child | +0.5 |
+| 2nd child | +0.5 |
+| 3rd child and each subsequent | +1.0 each |
+
+**Special cases:**
+- Shared custody (résidence alternée): half the above values (0.25 / 0.25 / 0.5)
+- Disabled child (carte CMI-invalidité): +0.5 additional part
+- Single parent (parent isolé, case T): +0.5 on first child
+
+### Examples
+
+| Household | Total parts |
+|---|---|
+| Single, no children | 1 |
+| Single, 1 child | 1.5 (or 2 if parent isolé) |
+| Married, 0 children | 2 |
+| Married, 2 children | 3 |
+| Married, 3 children | 4 |
+
+### Plafonnement du gain QF (QF capping)
+
+**Critical mechanism often forgotten.** The tax benefit from supplementary half-parts (children) is capped.
+
+**Algorithm:**
+
+```
+tax_with_all_parts     = normal calculation with all parts
+tax_without_children   = calculation with base parts only (1 or 2)
+actual_gain            = tax_without_children − tax_with_all_parts
+
+cap_per_half_part      = EUR 1,807 (revenus 2025)
+nb_supplementary_halves = (total_parts − base_parts) × 2
+max_gain               = cap_per_half_part × nb_supplementary_halves
+
+final_tax = tax_without_children − min(actual_gain, max_gain)
+```
+
+**Practical consequence:** above approximately EUR 90,000–100,000 RNI for a couple with 2 children, the QF benefit plateaus at EUR 3,614 (2 × EUR 1,807).
+
+**Parent isolé (case T):** the half-part for single parents has its own higher cap (EUR 4,273 for the first child-related part). Widowed with children: cap EUR 4,273.
+
+---
+
+## Section 6 — Décote (Low-Income Smoothing)
+
+Applied **after** QF plafonnement, **before** reductions/credits.
+
+### Formulas (revenus 2025)
+
+| Situation | Condition | Décote formula |
+|---|---|---|
+| Single | Impôt brut < EUR 1,982 | 897 − 0.4525 × impôt brut |
+| Couple | Impôt brut < EUR 3,277 | 1,483 − 0.4525 × impôt brut |
+
+**The décote cannot make the tax negative (floor at 0).**
+
+### Effective marginal rate in the décote zone
+
+In the décote zone, each additional euro of income:
+- Increases tax at the bracket rate
+- Reduces the décote by 0.4525 × that amount
+
+Effective marginal rate ≈ bracket_rate × 1.4525. A household in the 11% bracket can face ~16% effective marginal rate in the décote zone.
+
+---
+
+## Section 7 — CEHR (Contribution Exceptionnelle sur les Hauts Revenus)
+
+Base: **RFR** (revenu fiscal de référence), not RNI. Added on top of IR net. Art. 223 sexies CGI.
+
+| Situation | 3% bracket | 4% bracket |
+|---|---|---|
+| Single | EUR 250,001 – 500,000 | > EUR 500,000 |
+| Couple | EUR 500,001 – 1,000,000 | > EUR 1,000,000 |
+
+Smoothing possible over the average of the 2 preceding years.
+
+---
+
+## Section 8 — CDHR (Contribution Différentielle sur les Hauts Revenus)
+
+**Distinct from CEHR.** Imposes a **20% floor** on effective tax rate for high-RFR households. Art. 224 CGI, created by LFI 2025 (loi n° 2025-127), extended by LFI 2026 until deficit < 3% GDP.
+
+| Situation | RFR threshold |
+|---|---|
+| Single, widowed, separated, divorced | > EUR 250,000 |
+| Couple (married or PACSed, joint filing) | > EUR 500,000 |
+
+**Mechanism:** if (IR + CEHR) / adjusted RFR < 20%, the CDHR tops up the difference.
+
+**Automatic calculation** by the administration after filing. Advance of 95% due between 1–15 December via impots.gouv.fr PAS service.
+
+**Typical profiles affected:** executives with large PFU dividends (effective IR ~12.8% while RFR > 250k), business angels with large capital gains, RSU/BSPCE vesting years.
+
+---
+
+## Section 9 — Prélèvement à la Source (PAS — Withholding at Source)
+
+### Two mechanisms
+
+| Mechanism | Income types | Collector |
+|---|---|---|
+| Retenue à la source (withholding) | Salaries, pensions, unemployment | Employer / pension fund / Pôle Emploi |
+| Acompte contemporain (advance payment) | BIC, BNC, BA, rental income, received alimony | DGFiP via bank debit (monthly or quarterly) |
+
+### Rate types
+
+| Rate type | Description |
+|---|---|
+| Personalised (default) | Calculated by DGFiP from last filing |
+| Individualised (couples) | Separate rates per spouse — same total, different split |
+| Neutral (non-personalised) | Grid for single with no children — confidentiality option |
+
+### Modulation
+
+- **Downward:** allowed if estimated gap > 5%. Penalty 10% if gap > 10% and unjustified (art. 1729 G CGI).
+- **Upward:** allowed without minimum threshold.
+- **Life change:** marriage, PACS, birth, divorce, death — signal within **60 days** (art. 204 I CGI).
+
+### Annual settlement
+
+PAS is an **advance**, not final. Declaration in Apr-Jun N+1 leads to:
+1. Definitive IR calculated on year N income
+2. Compared with total withheld in N
+3. **Balance due** (September N+1, spread if > EUR 300) or **refund** (July-August N+1)
+
+### January advance for tax credits
+
+DGFiP pays a **60% advance** mid-January based on N-2 expenses (emploi à domicile, garde d'enfant, dons, Pinel). Adjusted in summer N+1. Option to renounce in December if expense won't recur.
+
+---
+
+## Section 10 — Deductions, Reductions, and Credits
+
+### Fundamental distinction
+
+| Mechanism | Acts on | Refundable if excess? | Calculation step |
+|---|---|---|---|
+| **Déduction** | Taxable income (RNI) | N/A | Step 3 |
+| **Réduction** | Tax due | No — floor at 0 | Step 9 |
+| **Crédit** | Tax due | Yes — refunded | Step 10 |
+
+A EUR 1,000 deduction at TMI 30% saves EUR 300. A EUR 1,000 credit saves EUR 1,000.
+
+### Key deductions (act on RNI)
+
+| Deduction | Limit | Notes |
+|---|---|---|
+| PER (épargne retraite) | 10% of professional income, min EUR 4,710, max EUR 37,680 | Report unused caps 3 years; couple mutualisation |
+| Pension alimentaire (child support) | Capped annually | Proof of need and actual payment required |
+| CSG déductible | 6.8% of capital income CSG | Only if barème option on capital in N-1; zero under PFU |
+| Frais réels (actual expenses) | Replaces 10% salary abattement | Must document every expense |
+
+### Key reductions (floor at 0)
+
+**Subject to the EUR 10,000 global cap (plafonnement des niches fiscales):**
+
+| Device | Rate | Notes |
+|---|---|---|
+| Pinel | Spread over 6/9/12 years | Last vintage 2024 — in extinction |
+| FCPI / FIP | 18% – 25% of investment | Separate investment ceiling |
+| Denormandie | Similar to Pinel, older housing | Targeted to degraded town centres |
+
+**Outside the EUR 10,000 cap:**
+
+| Device | Rate | Notes |
+|---|---|---|
+| Dons associations (charitable gifts) | 66% standard; 75% for poverty relief (up to EUR 1,000/year) | Excess above 20% of taxable income reportable 5 years |
+| Cotisations syndicales (union dues) | 66% | Cap: 1% of gross salary |
+| Girardin industriel (overseas) | Variable | Specific conditions |
+
+### Key credits (refundable)
+
+| Credit | Rate | Ceiling | Notes |
+|---|---|---|---|
+| Emploi à domicile (home help) | 50% | EUR 12,000/year (max credit EUR 6,000); +EUR 1,500 per child or person 65+ (max EUR 15,000) | CESU+ instant advance available since 2022 |
+| Garde d'enfant hors domicile (childcare) | 50% | EUR 3,500/child (max credit EUR 1,750/child) | Child under 6 at 1 January |
+
+### Global cap on tax incentives (plafonnement des niches fiscales)
+
+**EUR 10,000 per year** (EUR 18,000 for specific overseas investments).
+
+Devices "inside the cap" (Pinel, FCPI, etc.) are summed. If total exceeds EUR 10,000, the excess is **lost** (not reportable).
+
+Devices "outside the cap" (charitable gifts, home help credit) are unlimited by this mechanism.
+
+---
+
+## Section 11 — Special Cases
+
+### Revenus exceptionnels — Quotient mechanism
+
+Smoothing for one-off income (RSU vesting, departure indemnity, exceptional bonus) that would artificially push through multiple brackets.
+
+**Formula (coefficient = 4):**
+
+```
+supplementary_tax = [IR(ordinary_income + exceptional/4) − IR(ordinary_income)] × 4
+```
+
+**Conditions:**
+- Income exceeds the average of taxable income over the 3 preceding years
+- Exceptional, non-recurring character
+- Explicit request on the declaration
+
+**Useless if** the household is already at TMI 45% — the marginal rate doesn't change with division.
+
+### Non-residents
+
+- Taxed only on **French-source income** (art. 164 A CGI)
+- Minimum rate: 20% on fraction ≤ EUR 27,519 and 30% above (revenus 2025)
+- No quotient familial beyond 2 parts; no décote
+- Tax treaty analysis required — out of scope for complex cases
+
+### PUMA — Cotisation subsidiaire maladie
+
+Affects individuals with low professional income but significant capital income.
+
+| Condition | Threshold (2025) |
+|---|---|
+| Professional income below | ~20% PASS ≈ EUR 9,420 |
+| Capital income above | ~50% PASS ≈ EUR 23,550 |
+
+Rate: **6.5%** on (capital income − 50% PASS). Collected by URSSAF, not DGFiP. Non-deductible from IR.
+
+**Trap:** commonly forgotten in FIRE / early-retirement simulations — adds ~6.5% on top of PS.
+
+### Year of marriage / PACS
+
+Joint filing for the entire year (since 2011), or separate filing on option. Compute both to find more favourable.
+
+### Year of divorce / separation
+
+Separate filing for the full year. Case T (parent isolé) available for the parent with sole custody.
+
+### Year of spouse's death
+
+Joint filing from 1 January to date of death. Separate filing for the surviving spouse for the remainder.
+
+### Statute of limitations (droit de reprise)
+
+| Tax | Standard period |
+|---|---|
+| IR | 3 years |
+| IFI | 6 years |
+| All taxes (undisclosed activity / fraud) | 10 years |
+
+**Document retention:** minimum 6 years (recommended: 10 years).
+
+---
+
+## Section 12 — Conservative Defaults
+
+| Ambiguity | Default |
+|---|---|
+| Filing status unknown | Single, 1 part |
+| Number of children unknown | 0 |
+| Regime unknown | Barème progressif (no PFU option) |
+| Credit eligibility unclear | No credit applied |
+| PAS rate unknown | Standard personalised rate |
+| ARE vs salary unclear | Classify as ARE (no 10% abattement — conservative) |
+
+---
+
+## Section 13 — Key Legal References
+
+| Rule | Article |
+|---|---|
+| Progressive brackets | art. 197 CGI |
+| Quotient familial | art. 194–195 CGI |
+| QF capping | art. 197-2 CGI |
+| Décote | art. 197-4° CGI |
+| 10% salary abattement | art. 83-3° CGI |
+| CEHR | art. 223 sexies CGI |
+| CDHR | art. 224 CGI |
+| PAS | art. 204 A to 204 N CGI |
+| Exceptional income quotient | art. 163-0 A CGI |
+| PER deduction | art. 163 quatervicies CGI |
+| Non-residents | art. 164 A to 165 CGI |
+| Tax residence definition | art. 4 B CGI |
+| Charitable gifts | art. 200 CGI |
+| Home help credit | art. 199 sexdecies CGI |
+| Childcare credit | art. 200 quater B CGI |
+| Global cap (niches) | art. 200-0 A CGI |
+| PUMA | art. L. 380-2 CSS |
+
+---
+
+*OpenAccountants — open-source tax computation skills*
+*This output must be reviewed by a qualified professional before filing or acting upon.*
+*Latest verified skills: **openaccountants.com** | Report errors: **github.com/openaccountants/openaccountants***

--- a/skills/international/france/fr-rental-income.md
+++ b/skills/international/france/fr-rental-income.md
@@ -1,0 +1,222 @@
+---
+name: fr-rental-income
+description: >
+  French rental income taxation: revenus fonciers, LMNP, LMP, and SCI à l'IR.
+  Trigger on phrases like "revenus fonciers", "location nue", "location meublée",
+  "LMNP", "LMP", "meublé de tourisme", "micro-foncier", "régime réel foncier",
+  "déficit foncier", "micro-BIC location", "amortissement LMNP",
+  "SCI à l'IR", "SCI transparence fiscale", "Airbnb France impôts",
+  "déclaration 2044", "déclaration 2031", "liasse BIC meublé",
+  "charges déductibles location", "travaux déductibles foncier",
+  "bascule LMP LMNP", "loi Le Meur meublé tourisme",
+  "location saisonnière fiscalité", "déficit imputable revenu global".
+  Covers bare rental (micro-foncier and réel), furnished rental (LMNP micro-BIC
+  and réel with amortisation), LMP status, SCI à l'IR, and déficit foncier rules.
+version: 1.0
+jurisdiction: FR
+tax_year: 2025
+category: international
+---
+
+# France — Rental Income (Revenus Fonciers, LMNP, SCI) v1.0
+
+> **Based on work by [Romain Simon (@romainsimon)](https://github.com/romainsimon/paperasse)**, licensed under MIT. Adapted for the OpenAccountants format.
+
+> **Disclaimer:** This skill is for informational purposes only and does not constitute tax advice. All positions must be reviewed and signed off by a qualified expert-comptable or avocat fiscaliste before filing. Get this reviewed at **openaccountants.com**.
+
+---
+
+## Section 1 — Quick Reference
+
+| Field | Value |
+|---|---|
+| Country | France |
+| Taxes covered | IR on rental income, prélèvements sociaux |
+| Currency | EUR only |
+| Tax year | Calendar year |
+| Key forms | 2042 (case 4BE), 2044, 2044-SPE, 2042-C-PRO, 2031, 2033, 2072 |
+| Primary legislation | art. 14–33 quater CGI (fonciers), art. 35-I-5° bis CGI (LMNP), art. 155-IV CGI (LMP), art. 8 CGI (SCI) |
+
+---
+
+## Section 2 — Fundamental Distinction
+
+| Type of rental | Tax regime | Income category |
+|---|---|---|
+| Bare / unfurnished (location nue) | Revenus fonciers | Revenus fonciers (micro or réel) |
+| Furnished non-professional (LMNP) | **BIC** | LMNP (micro-BIC or réel) |
+| Furnished professional (LMP) | **BIC** | LMP (réel obligatory) |
+| SCI at IR | Revenus fonciers | Fiscal transparency |
+| SCI at IS | IS | **Out of scope** — see business accounting skill |
+
+**Classic error:** declaring furnished rental as revenus fonciers. Furnished = BIC. The tax consequences are very different (amortisation possible under réel).
+
+---
+
+## Section 3 — Bare Rental (Location Nue) — Revenus Fonciers
+
+### 3.1 Micro-foncier (simplified regime)
+
+| Parameter | Value |
+|---|---|
+| Condition | Gross rental income ≤ EUR 15,000 |
+| Abattement | 30% automatic |
+| 2042 box | 4BE |
+| Exclusions | SCI, monuments historiques, Pinel, Borloo, Malraux |
+
+**Advantage:** simplicity, no bookkeeping required.
+**Disadvantage:** no déficit possible. If actual charges > 30%, you overpay.
+
+### 3.2 Régime réel
+
+Obligatory above EUR 15,000 gross, or on irrevocable 3-year option.
+
+**Deductible charges:**
+
+| Charge | Deductible? | Notes |
+|---|---|---|
+| Mortgage interest (intérêts d'emprunt) | Yes — foncier income only | Never against global income |
+| Maintenance / repair works (travaux d'entretien) | Yes | Not construction, not extension |
+| Improvement works (travaux d'amélioration) | Yes | |
+| Taxe foncière | Yes | Exclude TEOM (recoverable from tenant) |
+| Insurance premiums (PNO, GLI) | Yes | |
+| Management fees (agency, syndic non-recoverable) | Yes | |
+| Provisions for co-ownership charges | Yes | |
+
+**Construction / extension / reconstruction works are NOT deductible** — they only increase the acquisition cost for future capital gains computation.
+
+### 3.3 Déficit foncier (rental loss)
+
+When charges exceed receipts:
+
+| Rule | Value |
+|---|---|
+| Imputable on global income | Up to **EUR 10,700**/year |
+| Energy renovation exception | Up to EUR 21,400 (temporary device) |
+| Excess beyond cap | Reportable on rental income for **10 years** |
+| Mortgage interest | **NEVER** imputable on global income — only on rental income |
+
+**Optimisation strategy:** concentrate major works in one year to maximise the global income deduction.
+
+**Critical constraint:** do not sell the property within **3 years** after imputing a déficit on global income — otherwise the déficit is clawed back.
+
+---
+
+## Section 4 — Furnished Rental: LMNP (Location Meublée Non Professionnelle)
+
+### 4.1 Micro-BIC regime
+
+**Post loi Le Meur reform (Nov 2024), applicable revenus 2025** — the key distinction is now **classified vs unclassified tourism**.
+
+| Type of furnished rental | Revenue ceiling | Abattement |
+|---|---|---|
+| Long-term furnished (LMNP longue durée) | EUR 77,700 | 50% |
+| Classified furnished tourism (meublé de tourisme classé) | EUR 77,700 | 50% |
+| **Unclassified furnished tourism** | **EUR 15,000** | **30%** |
+
+Above the ceilings: régime réel is obligatory.
+
+**2042-C-PRO boxes:** 5ND (long-term / unclassified), 5NG (classified tourism).
+
+### 4.2 Régime réel LMNP
+
+**Principle:** BIC result = receipts − charges − **amortisation**.
+
+**Amortisation schedules:**
+
+| Asset | Rate | Duration |
+|---|---|---|
+| Building (excluding land) | 2–3%/year | 25–40 years |
+| Land | Non-amortisable | — |
+| Furniture / equipment | 10–20%/year | 5–10 years |
+| Major works | Per useful life | Variable |
+
+**Fiscal result** is often nil or negative thanks to amortisation → no IR on rents for years.
+
+**LMNP deficit:** NOT imputable on global income (unlike LMP). Reportable on furnished BIC income for **10 years**.
+
+### 4.3 Prélèvements sociaux on LMNP
+
+LMNP is classified as "revenus du patrimoine" (L. 136-6 CSS) → PS rate **18.6% from 2025 income** (LFSS 2026).
+
+---
+
+## Section 5 — LMP (Location Meublée Professionnelle)
+
+### Conditions (cumulative)
+
+1. Furnished rental receipts > **EUR 23,000** per year
+2. **AND** furnished rental receipts > 50% of total professional income of the household (salaries + BNC + BIC + director compensation)
+
+### Consequences of LMP status
+
+| Feature | LMP | LMNP |
+|---|---|---|
+| Deficit imputation | On global income | Only on furnished BIC (10-year report) |
+| Capital gains | Professional regime (exemption possible after 5 yrs under revenue conditions) | Private capital gains regime |
+| Social contributions | TNS contributions on profit (SSI) — significant | PS only |
+| IFI | Potentially exempt as professional asset | Taxable |
+
+**Involuntary reclassification trap:** a drop in professional income (unemployment, retirement) can trigger LMP status despite unchanged rents. Monitor annually.
+
+---
+
+## Section 6 — SCI à l'IR (Real Estate Company at Income Tax)
+
+**Default regime:** fiscal transparency. Income and charges flow directly to each partner's personal tax return pro rata to their shares.
+
+| Feature | SCI at IR |
+|---|---|
+| Income category | Revenus fonciers (micro or réel, depending on total rental income of household) |
+| Amortisation | **Not available** (unlike SCI at IS) |
+| Capital gains on sale | Private real estate capital gains regime (exemption: 22 years IR / 30 years PS) |
+| Typical use | Heritage transmission (démembrement, donation of shares), long-term bare rental |
+
+**Meublé in SCI = risk of IS reclassification.** Furnished rental in an SCI exposes it to IS regime reclassification.
+
+### SCI at IS (out of scope)
+
+Allows amortisation but capital gains at sale are computed on net book value (after amortisation) → much heavier taxation. See business accounting skill.
+
+---
+
+## Section 7 — Forms Summary
+
+| Regime | Form |
+|---|---|
+| Micro-foncier | 2042 case 4BE |
+| Régime réel foncier | 2044 (or 2044 spéciale) |
+| Micro-BIC LMNP | 2042-C-PRO (cases 5ND, 5NG, etc.) |
+| Réel LMNP / LMP | 2031 + 2033 (liasse BIC) + 2042-C-PRO |
+| SCI at IR | 2072 (SCI declaration) + report on 2044 (partners) |
+
+---
+
+## Section 8 — Conservative Defaults
+
+| Ambiguity | Default |
+|---|---|
+| Furnished vs bare unclear | Classify as bare rental (revenus fonciers — no amortisation; conservative) |
+| Regime unknown | Micro (simplest; check ceiling) |
+| LMP vs LMNP unclear | LMNP (no TNS contributions) |
+| Déficit foncier eligibility unclear | Do not impute on global income |
+| Tourism classification unclear | Unclassified (30% abattement — most conservative) |
+
+---
+
+## Section 9 — Key Legal References
+
+| Rule | Article |
+|---|---|
+| Revenus fonciers | art. 14 to 33 quater CGI |
+| Déficit foncier | art. 156-I-3° CGI |
+| LMNP | art. 35-I-5° bis CGI |
+| LMP | art. 155-IV CGI |
+| SCI transparency | art. 8 CGI |
+| PS on LMNP (revenus du patrimoine) | art. L. 136-6 CSS |
+
+---
+
+*OpenAccountants — open-source tax computation skills*
+*This output must be reviewed by a qualified professional before filing or acting upon.*
+*Latest verified skills: **openaccountants.com** | Report errors: **github.com/openaccountants/openaccountants***

--- a/skills/international/france/fr-tax-audit.md
+++ b/skills/international/france/fr-tax-audit.md
@@ -1,0 +1,337 @@
+---
+name: fr-tax-audit
+description: >
+  French tax audit procedures, penalties, and taxpayer rights (contrôle fiscal).
+  Trigger on phrases like "contrôle fiscal", "vérification de comptabilité",
+  "redressement fiscal", "DGFIP contrôle", "proposition de rectification",
+  "pénalités fiscales", "majoration 40%", "manquement délibéré",
+  "intérêts de retard", "abus de droit", "commission départementale",
+  "recours hiérarchique", "charte du contribuable vérifié",
+  "FEC contrôle", "rejet de comptabilité", "acte anormal de gestion",
+  "tax audit France", "tax penalties France", "objection tax France",
+  "délai de reprise", "prescription fiscale", "régularisation spontanée".
+  Covers the 8 verification axes (FEC, IS, charge deductibility, CCA 455,
+  revenue, TVA, fixed assets, international), penalty schedules, audit
+  procedures, and taxpayer rights.
+version: 1.0
+jurisdiction: FR
+tax_year: 2025
+category: international
+---
+
+# France — Tax Audit Procedures & Penalties (Contrôle Fiscal) v1.0
+
+> **Based on work by [Romain Simon (@romainsimon)](https://github.com/romainsimon/paperasse)**, licensed under MIT. Adapted for the OpenAccountants format.
+
+> **Disclaimer:** This skill is for informational purposes only and does not constitute tax advice. All positions must be reviewed and signed off by a qualified expert-comptable or avocat fiscaliste before filing. Get this reviewed at **openaccountants.com**.
+
+---
+
+## Section 1 — Quick Reference
+
+| Field | Value |
+|---|---|
+| Country | France |
+| Authority | Direction Générale des Finances Publiques (DGFiP) |
+| Scope | Vérification de comptabilité of IS/IR entities |
+| Key legislation | Livre des Procédures Fiscales (LPF), CGI |
+| FEC obligation | art. L. 47 A-I LPF |
+
+---
+
+## Section 2 — Audit Procedure (Phases)
+
+| Phase | Legal basis | Description |
+|---|---|---|
+| 1. Avis de vérification | art. L. 47 LPF | Minimum 2 business days advance notice |
+| 2. FEC examination | art. L. 47 A-I LPF | Mandatory delivery within 15 days |
+| 3. On-site verification | art. L. 13 LPF | At registered office |
+| 4. Proposition de rectification | art. L. 57 LPF | Formal notification of adjustments |
+| 5. Taxpayer response | — | 30 days (extendable by 30 days) |
+| 6. Inspector's response | — | Confirmation or abandonment of each item |
+| 7. Commission départementale | — | In case of persistent disagreement |
+| 8. Mise en recouvrement | — | Issuance of amended tax notice |
+
+### Taxpayer guarantees
+
+| Right | Source |
+|---|---|
+| Oral and adversarial debate | art. L. 47 LPF |
+| Charte du contribuable vérifié | LPF |
+| Hierarchical appeal (interlocuteur départemental) | LPF |
+| Departmental tax commission | LPF |
+| Maximum audit duration: 3 months for SMEs | art. L. 52 LPF |
+
+---
+
+## Section 3 — The 8 Verification Axes
+
+### Axis 1: FEC Examination (art. L. 47 A-I LPF)
+
+**Mandatory checks on the FEC file:**
+
+| Check | Consequence of failure |
+|---|---|
+| Format conformity (18 columns, pipe `\|` separator) | Comptabilité non probante |
+| Global balance: total debits = total credits | Comptabilité non probante |
+| Per-entry balance: each EcritureNum is balanced | Presumption of concealment |
+| Sequential numbering (no gaps) | Presumption of concealment |
+| Dates within the financial year | Fictitious entries |
+| No negative amounts | Format violation |
+| PieceRef populated for every entry | Missing supporting documents |
+| CompteNum consistent with PCG roots | Irregular accounts |
+
+**Non-compliant FEC → comptabilité non probante (art. L. 192 LPF):** burden of proof shifts to the taxpayer.
+
+### Axis 2: Corporate Tax (IS) Control (art. 38–39 CGI)
+
+| Checkpoint | Legal basis | Detail |
+|---|---|---|
+| IS add-back (account 695) | art. 39-1-4° CGI | IS is not deductible — verify it is added back |
+| PME reduced rate eligibility | art. 219-I-b CGI | CA < EUR 10M, capital paid up, ≥75% held by individuals |
+| Short year proration | art. 219-I-b CGI | EUR 42,500 × (days / 365) |
+| Non-deductible charges | art. 39 CGI | Fines, luxury expenses, personal expenses |
+| Acte anormal de gestion | Case law (CE) | Charges unrelated to business interest |
+
+### Axis 3: Charge Deductibility (art. 39-1 CGI)
+
+**Four cumulative conditions:**
+1. Incurred in the interest of the business
+2. Reflects normal management
+3. Supported by invoices/documentation
+4. Results in a decrease of net assets
+
+**Systematic examination grid:**
+
+| Account | Typical audit question |
+|---|---|
+| 604 (Subcontracting, APIs) | Exclusively professional use? Invoices in company name? |
+| 6132 (Home office) | Justified proportion? Conforming to BOFiP? Convention exists? |
+| 6135 (SaaS / hosting) | 100% professional? No personal consumption? |
+| 6181 (Documentation) | Link with business activity? |
+| 622 (Intermediaries) | Nature and supporting documents? |
+| 6231 (Advertising) | Gifts = gratuities? Directories = advertising? |
+| 627/6278 (Banking) | Consistent with bank statements? |
+| 651 (Domain names) | All related to business activity? |
+| 654 (Chargebacks) | Documented irrecoverability? |
+
+### Axis 4: Shareholder Current Account 455 (art. 39-1-3° and 212 CGI)
+
+**High fiscal risk**, especially SASU/EURL.
+
+| Check | Detail |
+|---|---|
+| Pre-incorporation expenses | Assumed within 6 months? Annexed to statuts/PV? Professional character? |
+| Home office | Justified surface proportion? Plan available? Non-deductible: mortgage principal |
+| Interest on current account | No interest = OK. If interest paid: capped at TMPV BCE rate |
+| Currency conversion | BCE rate acceptable; inspector may demand per-transaction rate |
+
+### Axis 5: Revenue (art. 38-2 CGI)
+
+| Check | Detail |
+|---|---|
+| Revenue completeness | Cross-check payment platforms (Stripe, PayPal) vs. accounting |
+| Period cut-off | Revenue booked only for the financial year |
+| Credit balance on 411 (Clients) | Abnormal — advance? Omitted revenue? |
+| Asset disposals | Proper classification (account 775)? |
+| Commissions / ancillary revenue | Nature? Foreign withholding tax? |
+
+### Axis 6: TVA
+
+**If franchise en base (art. 293 B CGI):**
+
+| Check | Detail |
+|---|---|
+| Threshold monitoring | Services: EUR 36,800 (tolerance EUR 39,100). Annualise if short year |
+| Invoice mention | "TVA non applicable, art. 293 B du CGI" |
+| Asset disposals | Subject to TVA or exempt? |
+| Intra-EU / extra-EU services | Autoliquidation (art. 283-2 CGI)? |
+
+**If TVA collected:**
+
+| Check | Detail |
+|---|---|
+| CA3/CA12 vs accounting concordance | |
+| Deductible TVA documentation | |
+| Pro-rata deduction if mixed activity | |
+
+### Axis 7: Fixed Assets and Depreciation (art. 39-1-2° CGI)
+
+| Check | Detail |
+|---|---|
+| Capitalisation threshold | EUR 500 HT (SME tolerance). If franchise TVA: TTC amounts |
+| Depreciation method | Linear 3 years for IT equipment (standard). Pro-rata temporis from date of commissioning |
+| Mixed use | Phone and computer: 100% professional justified? If mixed: only professional portion deductible |
+
+### Axis 8: International Operations
+
+| Check | Detail |
+|---|---|
+| Transfer pricing | Applicable if foreign subsidiary or intra-group transactions |
+| Withholding tax (art. 182 B CGI) | Payments to foreign providers: 25% withholding? Check applicable tax treaty |
+| DES (Déclaration Européenne de Services) | Required for intra-EU service purchases |
+
+---
+
+## Section 4 — Penalty Schedule
+
+### Interest on late payment (intérêts de retard — art. 1727 CGI)
+
+| Parameter | Value |
+|---|---|
+| Monthly rate | 0.20% |
+| Annual rate | 2.40% |
+| Start date | 1st day of month following due date |
+| End date | Last day of month of payment |
+
+### Surcharges (majorations — art. 1729 CGI)
+
+| Situation | Rate | Condition |
+|---|---|---|
+| Good faith | 0% | Material error, first offence |
+| Insufficient declaration (bonne foi) | 10% | art. 1758 A CGI |
+| Deliberate omission (manquement délibéré) | **40%** | Proven intent to evade |
+| Fraudulent schemes (manoeuvres frauduleuses) | **80%** | Artifice, false documents |
+| Abuse of law (abus de droit) | **80%** | Artificial arrangements |
+
+### Computation example — deliberate omission
+
+```
+Disallowed charges:                      EUR 10,000
+Additional IS (at 25%):                  EUR  2,500
+Late interest (12 months × 0.20%):       EUR     60
+Surcharge (40%):                         EUR  1,000
+────────────────────────────────────────────────────
+Total assessment:                        EUR  3,560
+```
+
+---
+
+## Section 5 — Risk Assessment Grid
+
+### Aggravating factors
+
+| Factor | Impact |
+|---|---|
+| SASU/EURL without auditor | Heightened scrutiny on personal charges |
+| First financial year | Limited history, frequent errors |
+| Revenue in foreign currency | Conversion rate risk |
+| High 455 current account balance | Suspicion of patrimony confusion |
+| Internet/SaaS activity | Territorial allocation difficulties |
+
+### Mitigating factors
+
+| Factor | Impact |
+|---|---|
+| Small size (CA < EUR 50k) | Lighter verification |
+| Regular bookkeeping | Compliant FEC, balanced entries |
+| First year in good faith | Tolerance for formal errors |
+| No employees | No social risk |
+| Franchise en base TVA | No collected-TVA risk |
+
+---
+
+## Section 6 — Common Adjustment Scenarios
+
+### Scenario 1: Personal expenses in account 455
+
+**Assessment:** Reintegration of personal portion. Possible requalification as "disguised remuneration" → social contributions. If significant amounts: acte anormal de gestion.
+
+### Scenario 2: Overstated home office
+
+**Assessment:** Reintegration of excess (declared % − actual %) × charges. Surcharge 10% (good faith) or 40% (if recurring).
+
+### Scenario 3: Pre-incorporation expenses without état des actes
+
+**Assessment:** Full reintegration of pre-incorporation charges. Additional IS on the amount.
+
+### Scenario 4: Omitted revenue (credit balance on 411)
+
+**Assessment:** If inspector considers it undeclared revenue → added to fiscal result + IS + 40% surcharge if intentional.
+
+### Scenario 5: Incorrect currency conversion
+
+**Assessment:** Recalculation of all foreign-currency charges at correct BCE rate. IS on the difference.
+
+---
+
+## Section 7 — Statute of Limitations (Droit de Reprise)
+
+| Tax | Standard period |
+|---|---|
+| IS / IR | 3 years (until 31 Dec of the 3rd year following the tax year) |
+| TVA | 3 years |
+| IFI | 6 years |
+| All taxes (undisclosed activity / fraud) | **10 years** |
+
+**Document retention recommendation:** minimum 6 years (recommended: 10 years to cover all scenarios).
+
+---
+
+## Section 8 — Voluntary Regularisation
+
+If the taxpayer corrects before an audit:
+- Late interest: 0.20%/month (still applies)
+- **No surcharge** if regularisation is spontaneous and in good faith
+- For significant cases (crypto, foreign income, unreported gains): consult an avocat fiscaliste for structured regularisation
+
+---
+
+## Section 9 — Audit Report Format
+
+For each anomaly, the adjustment is formalised as a **chef de redressement** containing:
+
+1. **Tax concerned** (IS / TVA / Other)
+2. **Financial year**
+3. **Legal basis** (CGI article / BOFiP reference)
+4. **Nature** of the adjustment
+5. **Factual finding**
+6. **Legal foundation and case law**
+7. **Amount** (base, additional tax, interest, surcharge, total)
+8. **Risk level** (high / medium / low)
+9. **Corrective recommendation**
+
+---
+
+## Section 10 — Conservative Defaults
+
+| Ambiguity | Default |
+|---|---|
+| Charge deductibility doubtful | Flag as potentially non-deductible |
+| Surcharge rate unclear | Assume 10% (good faith) |
+| FEC gap found | Flag as potential concealment |
+| Revenue source unclear | Include in taxable revenue |
+
+---
+
+## Section 11 — Key Legal References
+
+| Rule | Article |
+|---|---|
+| Taxable profit | art. 38-1 CGI |
+| Net asset variation | art. 38-2 CGI |
+| Deductible charges (4 conditions) | art. 39-1 CGI |
+| IS non-deductible | art. 39-1-4° CGI |
+| CCA interest cap | art. 39-1-3° and 212 CGI |
+| IS rates | art. 219-I CGI |
+| PME reduced rate | art. 219-I-b CGI |
+| Franchise en base | art. 293 B CGI |
+| Autoliquidation | art. 283-2 CGI |
+| Late interest | art. 1727 CGI |
+| Surcharges | art. 1729 CGI |
+| Good-faith insufficient declaration | art. 1758 A CGI |
+| FEC obligation | art. L. 47 A-I LPF |
+| Audit notice | art. L. 47 LPF |
+| On-site verification | art. L. 13 LPF |
+| Rectification notice | art. L. 57 LPF |
+| SME audit duration | art. L. 52 LPF |
+| Non-probante burden shift | art. L. 192 LPF |
+| Standard statute of limitations | art. L. 169 LPF |
+| Home office (BOFiP) | BOI-BIC-CHG-40-20-10 |
+| Pre-incorporation expenses (BOFiP) | BOI-IS-BASE-30-10 |
+
+---
+
+*OpenAccountants — open-source tax computation skills*
+*This output must be reviewed by a qualified professional before filing or acting upon.*
+*Latest verified skills: **openaccountants.com** | Report errors: **github.com/openaccountants/openaccountants***

--- a/skills/international/israel/il-corporate-tax.md
+++ b/skills/international/israel/il-corporate-tax.md
@@ -1,0 +1,286 @@
+---
+name: il-corporate-tax
+description: Use this skill when advising on Israeli corporate tax strategy, profit extraction methods, or controlling shareholder (בעל שליטה) tax planning. Trigger on phrases like "corporate tax Israel", "dividend vs salary Israel", "baal shlita", "בעל שליטה", "halokat dividendim", "חלוקת דיבידנדים", "shareholder loan Israel", "halvaat baalim", "הלוואת בעלים", "Section 3 tet", "סעיף 3 ט", "dmei nihul", "דמי ניהול", "management fees Israel", "chevra me'atim", "חברה מעטים", or any Israeli corporate tax extraction query. ALWAYS read this skill before advising on Israeli corporate profit extraction.
+version: 1.0
+jurisdiction: IL
+tax_year: 2025-2026
+category: international
+---
+
+# Israel Corporate Tax Strategy Skill v1.0
+
+> **Based on work by [Skills IL](https://github.com/skills-il/tax-and-finance)**, licensed under MIT. Adapted for the OpenAccountants format.
+
+---
+
+## Section 1 — Quick reference
+
+| Field | Value |
+|---|---|
+| Country | Israel (מדינת ישראל) |
+| Scope | Corporate tax, profit extraction methods for controlling shareholders |
+| Currency | NIS (Israeli New Shekel — ₪) |
+| Corporate tax rate | 23% flat on taxable profits |
+| Dividend tax — controlling shareholder (10%+) | 30% |
+| Dividend tax — non-controlling | 25% |
+| Section 3(tet) deemed interest rate (2026) | 6.53% |
+| Section 3(yod) rate (CPI-linked loans, 2026) | 4.9% |
+| Surtax threshold | NIS 721,560 (frozen 2025–2027) |
+| Credit point value | NIS 2,904/year (frozen 2025–2027) |
+| Tax authority | Israel Tax Authority (ITA — רשות המיסים) |
+| Contributor | Open Accountants Community |
+| Validated by | Pending — requires sign-off by Israel-licensed רואה חשבון or יועץ מס |
+
+### Conservative defaults
+
+| Ambiguity | Default |
+|---|---|
+| Unknown shareholder percentage | Treat as controlling shareholder (30% dividend tax) |
+| Unknown Section 3(tet) rate | Use current year published rate |
+| Unknown whether salary is below minimum | Flag minimum salary requirement for controlling shareholders |
+| Unknown company type | Treat as closely held (Chevra Me'atim) |
+
+---
+
+## Section 2 — Extraction methods overview
+
+Israeli company owners (Baalei Shlita — בעלי שליטה) have four main methods to extract value:
+
+| Method | Corporate tax | Personal tax | Bituach Leumi | Key advantage |
+|---|---|---|---|---|
+| **Salary (Maskoret — משכורת)** | 0% (deductible expense) | Progressive rates (10%–50%) | Employee + Employer NI | Tax credit points, pension deductions, NI ceiling |
+| **Dividend (Dividend — דיבידנד)** | 23% (on profit first) | 30% (controlling shareholder) | None | No NI, simple, no employer cost beyond profit |
+| **Shareholder loan (Halvaat Baalim — הלוואת בעלים)** | 0% (no immediate tax) | Section 3(tet) deemed interest | None | Defers real tax, keeps cash flexible |
+| **Management fees (Dmei Nihul — דמי ניהול)** | 0% (deductible) | Income tax as business income + VAT 18% | Self-employed NI rates | Can deduct business expenses against fees |
+
+### Combined effective tax rates (2026, controlling shareholder above surtax threshold)
+
+| Method | Effective rate (approximate) |
+|---|---|
+| Salary (top bracket) | ~55–60% (50% income tax + employer NI) |
+| Dividend | 46.1% (up to ~52% with surtax) |
+| Shareholder loan | 6.53% annual deemed interest (not a real extraction) |
+| Management fees | ~50–55% + 18% VAT on gross |
+
+---
+
+## Section 3 — Dividend distribution (Halokat Dividendim — חלוקת דיבידנדים)
+
+### 3.1 Tax calculation for controlling shareholder (10%+ holding)
+
+```
+Company pre-tax profit:             P
+Corporate tax (23%):                P × 0.23
+Distributable profit:               P × 0.77
+Dividend withholding tax (30%):     P × 0.77 × 0.30 = P × 0.231
+Net to shareholder:                 P × 0.77 × 0.70 = P × 0.539
+Effective total tax rate:           46.1%
+```
+
+### 3.2 Surtax impact (Mas Yesafim — מס יסף)
+
+If total annual income (including dividend) exceeds NIS 721,560:
+- 3% surtax on excess (Section 121B)
+- Additional 2% on non-labor income above threshold (effective 2025+)
+- Total additional: 5% on dividend portion above threshold
+- Effective rate climbs to ~49.95% on portion above threshold
+
+### 3.3 When dividend is optimal
+
+- Shareholder's salary already maximizes lower tax brackets
+- Amount is large enough that salary would push into 47%+ bracket
+- Company has sufficient retained earnings (Arvei Rvaachim — ערכי רווחים)
+- No Bituach Leumi advantage left (salary already above NI ceiling)
+
+### 3.4 When dividend is suboptimal
+
+- Shareholder draws no or low salary (wasting lower brackets and credit points)
+- Amount is moderate (under ~NIS 200,000) and salary brackets not fully utilized
+- Company needs the cash for operations (dividend is irreversible)
+
+---
+
+## Section 4 — Salary extraction (Maskoret — משכורת)
+
+### 4.1 Income tax brackets (2026)
+
+| Annual income (NIS) | Rate |
+|---|---|
+| Up to 84,120 | 10% |
+| 84,121 – 120,720 | 14% |
+| 120,721 – 228,000 | 20% |
+| 228,001 – 301,200 | 31% |
+| 301,201 – 560,280 | 35% |
+| 560,281 – 721,560 | 47% |
+| Above 721,560 | 50% (47% + 3% surtax) |
+
+### 4.2 Bituach Leumi for controlling shareholder employees (2026)
+
+| Income range | Employee NI | Employee health | Employer NI |
+|---|---|---|---|
+| Up to NIS 7,703/month | 0.4% | 3.1% | 4.46% |
+| NIS 7,703 – NIS 51,910/month | 7.0% | 5.0% | 7.38% |
+| Above NIS 51,910/month | 0% (ceiling) | 0% (ceiling) | 0% (ceiling) |
+
+Controlling shareholder NI rates (4.46%/7.38% employer) differ slightly from regular employees (4.51%/7.60%).
+
+### 4.3 Salary advantages
+
+- Pension contributions (Hafrashat Pensia — הפרשת פנסיה) are tax-deductible up to ceiling
+- Keren Hishtalmut contributions (up to ceiling) are employer-deductible, tax-free to employee
+- Tax credit points reduce effective rate on first brackets
+- NI contributions build social security entitlements
+
+### 4.4 Optimal salary level
+
+The sweet spot is often drawing enough salary to utilize the lower tax brackets (up to ~NIS 228,000/year at 20% marginal rate) and maximize pension/Keren Hishtalmut deductions, then extracting additional amounts as dividends.
+
+### 4.5 Minimum salary requirement
+
+The Tax Authority expects controlling shareholders to draw a reasonable salary (~NIS 6,500+/month) before distributing dividends.
+
+---
+
+## Section 5 — Shareholder loan (Halvaat Baalim — הלוואת בעלים)
+
+### 5.1 Section 3(tet) rules (2026)
+
+When a company lends money to a shareholder at below-market interest:
+
+| Rule | Detail |
+|---|---|
+| Deemed interest rate (2026) | 6.53% per year |
+| Treatment for controlling shareholders | Deemed interest classified as salary income, taxed at marginal rates |
+| Reporting obligation | Company must report deemed interest on Form 126 |
+| Section 3(yod) rate | 4.9% (for CPI-linked loans between related parties) |
+
+### 5.2 Reclassification risks
+
+| Risk factor | Detail |
+|---|---|
+| Loan not repaid within reasonable time | ITA may reclassify as dividend (30% tax + penalties) |
+| Loan used for personal expenses | Strengthens reclassification risk |
+| No repayment schedule | Red flag for ITA |
+| Company has retained earnings | Increases risk of deemed-dividend reclassification |
+
+### 5.3 Worked example
+
+```
+Loan amount:                NIS 500,000
+Annual deemed interest:     NIS 500,000 × 6.53% = NIS 32,650
+Tax on deemed interest:     NIS 32,650 × 47% (marginal rate) = NIS 15,346
+Net annual cost:            NIS 15,346 (3.07% of loan)
+```
+
+Compare with dividend on the same NIS 500,000: tax of ~NIS 230,500 (46.1%). The loan defers this but accumulates cost annually.
+
+### 5.4 When shareholder loan makes sense
+
+- Short-term cash need (under 12 months) with clear repayment plan
+- Bridge financing until dividend declaration is approved
+- Company has a formal loan agreement with interest and repayment terms
+
+### 5.5 When to avoid shareholder loans
+
+- Long-term extraction need (accumulates deemed interest annually)
+- Company has distributable retained earnings
+- No documented loan agreement or repayment schedule
+
+---
+
+## Section 6 — Management fees (Dmei Nihul — דמי ניהול)
+
+### 6.1 How it works
+
+1. Shareholder (or their management company) invoices the company for management services
+2. Company deducts the fee as a business expense (no corporate tax)
+3. Fee is subject to income tax as business income + VAT (18%)
+4. If through a personal Osek Murshe: subject to self-employed NI rates
+
+### 6.2 Self-employed NI rates (2026)
+
+| Income range | NI rate | Health rate | Total |
+|---|---|---|---|
+| Up to NIS 7,703/month | 2.87% | 3.1% | 5.97% |
+| NIS 7,703 – NIS 51,910/month | 12.83% | 5.0% | 17.83% |
+
+52% of the NI amount is tax-deductible.
+
+### 6.3 Requirements and risks
+
+- Transfer pricing rules apply (Section 85A) — fees must reflect arm's length market rates
+- ITA may challenge "excessive" management fees as disguised dividends
+- Must issue Heshbonit Mas (tax invoice)
+- Requires maintaining a separate business entity with bookkeeping
+- Properly documented service agreements required
+
+---
+
+## Section 7 — Strategy comparison
+
+### 7.1 Decision matrix
+
+| Factor | Salary | Dividend | Loan | Management fees |
+|---|---|---|---|---|
+| Total effective tax rate | 10%–60% | 46.1%–52% | 6.53% deemed/year | Variable + 18% VAT |
+| Bituach Leumi | Yes (capped) | No | No | Yes (higher rates) |
+| Corporate tax deductible | Yes | No | N/A | Yes |
+| Pension benefits | Yes | No | No | Self-funded |
+| Reversible | No | No | Yes (repay loan) | No |
+| ITA scrutiny | Low | Low | High | Medium |
+| Timing flexibility | Monthly | Board resolution | Immediate | Per invoice |
+
+### 7.2 Common optimal combinations
+
+| Scenario | Recommended approach |
+|---|---|
+| Small extraction (under NIS 200,000) | Salary up to the 20% bracket to maximize credit points and pension |
+| Medium extraction (NIS 200,000 – 500,000) | Salary to optimize brackets + dividend for the remainder |
+| Large extraction (NIS 500,000+) | Salary at optimal level + dividend; potentially short-term loan bridge |
+| One-time tax assessment | Short-term shareholder loan with 12-month repayment, funded by planned dividend |
+
+---
+
+## Section 8 — Closely held companies (Chevra Me'atim — חברה מעטים)
+
+A closely held company is subject to a 2% annual tax on accumulated undistributed profits unless at least 6% of accumulated profits are distributed as dividends.
+
+This rule creates pressure to distribute regularly rather than accumulating profits indefinitely within the company.
+
+---
+
+## Section 9 — Compliance checklist
+
+| Requirement | Check |
+|---|---|
+| Company has a CPA (Roe Cheshbon — רואה חשבון) | All strategies require professional filing |
+| Board resolution for dividends | Required before distribution, must be documented |
+| Loan agreement for shareholder loans | Written agreement with interest rate, repayment schedule, and signatures |
+| Minimum salary for controlling shareholder | ITA expects ~NIS 6,500+/month before dividends |
+| Withholding tax on dividends | Company must withhold 30% and deposit with ITA by the 15th of the following month |
+| Form 856 reporting | Payments to shareholders must be reported |
+| Section 3(tet) reporting | Deemed interest must be reported on Form 126 |
+| Transfer pricing for management fees | Fees must reflect market rates |
+| VAT invoice for management fees | Must issue Heshbonit Mas |
+| Surtax reporting | Include all income sources when calculating surtax threshold |
+
+---
+
+## Section 10 — Reference material
+
+| Resource | Reference |
+|---|---|
+| Israeli Tax Authority | https://www.gov.il/he/departments/israel_tax_authority |
+| Income Tax Ordinance | https://www.nevo.co.il/law/70264 |
+| Bituach Leumi — contribution rates | https://www.btl.gov.il/Insurance/National%20Insurance/Pages/default.aspx |
+| Kol Zchut — income tax brackets | https://www.kolzchut.org.il/he/מדרגות_מס_הכנסה |
+
+---
+
+## Disclaimer
+
+> **חשוב:** כל המידע בקובץ זה מיועד למטרות מידע וחישוב בלבד. יש לבדוק כל עמדה מול רואה חשבון (Ro'eh Cheshbon) או יועץ מס (Yo'etz Mas) מוסמך לפני הגשה או פעולה.
+
+This skill and its outputs are provided for informational and computational purposes only and do not constitute tax, legal, or financial advice. Open Accountants and its contributors accept no liability for any errors, omissions, or outcomes arising from the use of this skill. All outputs must be reviewed and signed off by a qualified professional — such as a רואה חשבון (Ro'eh Cheshbon — CPA) or יועץ מס (Yo'etz Mas — tax advisor) licensed in Israel — before filing or acting upon.
+
+The most up-to-date, verified version of this skill is maintained at [openaccountants.com](https://openaccountants.com). Log in to access the latest version, request a professional review from a licensed accountant, and track updates as tax law changes.

--- a/skills/international/israel/il-crypto-tax.md
+++ b/skills/international/israel/il-crypto-tax.md
@@ -1,0 +1,283 @@
+---
+name: il-crypto-tax
+description: Use this skill when advising on Israeli cryptocurrency tax reporting and capital gains calculations. Trigger on phrases like "crypto tax Israel", "bitcoin tax Israel", "מס קריפטו", "FIFO Israel", "Form 1325 crypto", "Form 1322", "capital gains crypto Israel", "staking tax Israel", "airdrop tax Israel", "DeFi tax Israel", "voluntary disclosure crypto Israel", "gilui mirtzon", "גילוי מרצון", or any Israeli cryptocurrency tax query. ALWAYS read this skill before advising on Israeli crypto taxation.
+version: 1.0
+jurisdiction: IL
+tax_year: 2025-2026
+category: international
+---
+
+# Israel Cryptocurrency Tax Reporting Skill v1.0
+
+> **Based on work by [Skills IL](https://github.com/skills-il/tax-and-finance)**, licensed under MIT. Adapted for the OpenAccountants format.
+
+---
+
+## Section 1 — Quick reference
+
+| Field | Value |
+|---|---|
+| Country | Israel (מדינת ישראל) |
+| Scope | Cryptocurrency capital gains tax, DeFi income classification, reporting |
+| Currency | NIS (Israeli New Shekel — ₪) |
+| Classification | Cryptocurrency = Asset (Neches — נכס) under Section 88 ITO |
+| Primary guidance | ITA Circular 2018/05 (חוזר 05/2018) |
+| Cost basis method | FIFO (First In, First Out) — mandatory default |
+| Tax rate — individuals | 25% capital gains (Revach Hon — רווח הון) |
+| Tax rate — significant shareholder (10%+) | 30% |
+| Tax rate — business/traders | Marginal rates (up to 50%) if activity constitutes a business |
+| Corporate rate | 23% |
+| Surtax on capital income above NIS 721,560 | 5% (3% base + 2% additional on capital income) |
+| Advance payment form | Form 1399י (transaction codes 77 and 71) |
+| Advance payment deadline | Within 30 days of disposal |
+| Reporting forms | Forms 1322 / 1325 (attached to annual Form 1301) |
+| Contributor | Open Accountants Community |
+| Validated by | Pending — requires sign-off by Israel-licensed רואה חשבון or יועץ מס |
+
+### Conservative defaults
+
+| Ambiguity | Default |
+|---|---|
+| Unknown whether activity is business or investment | Treat as investment (25% capital gains) — flag for professional review if high frequency |
+| Staking reward classification unclear | Treat as income at receipt (most conservative) |
+| Unknown NIS exchange rate for transaction date | Use most recent Bank of Israel business day rate |
+| Crypto received as gift | Use donor's carryover basis (Section 97(a)(5)) |
+| Stablecoins (USDT, USDC) | Still an "asset" — every conversion is a taxable disposal |
+
+---
+
+## Section 2 — Legal framework
+
+### 2.1 Core principles
+
+- Cryptocurrency is classified as an **asset** (Neches) under Section 88 of the Income Tax Ordinance (Pekudat Mas Hachnasa — פקודת מס הכנסה), NOT as currency
+- Gains are taxed as **capital gains** (Revach Hon) under Chapter E of the Ordinance
+- ITA Circular 2018/05 provides primary guidance on crypto taxation
+- Every disposal (sale, trade, conversion) is a taxable event valued in NIS
+- **Crypto-to-crypto swaps are taxable events** — unlike some jurisdictions, Israel has always treated these as disposals
+
+### 2.2 Business vs investment classification
+
+If crypto activity constitutes a business (Esek — עסק), gains are taxed as ordinary income at marginal rates (up to 50%). Classification depends on:
+- Frequency and volume of trading
+- Whether taxpayer holds crypto as inventory vs investment
+- Time and effort devoted to crypto activity
+- Whether the taxpayer has another profession
+
+When in doubt, treat as investment (25%) but flag for professional review.
+
+---
+
+## Section 3 — FIFO cost basis method
+
+Israel mandates FIFO (First In, First Out) for calculating cost basis unless the taxpayer can demonstrate a different method was consistently applied.
+
+### 3.1 FIFO rules
+
+1. Queue all purchases by date (oldest first)
+2. For each sale, match against the oldest available purchase lots
+3. Calculate gain/loss for each matched lot: (sale price − purchase price − fees) per unit
+4. If a lot is partially consumed, the remainder stays in the queue
+5. Sum all gains and losses for the tax year
+
+### 3.2 Currency conversion
+
+- All transactions must be converted to NIS at the Bank of Israel exchange rate (Sha'ar Yatzig — שער יציג) on the transaction date
+- For crypto-to-crypto trades, the NIS value of BOTH sides must be determined at the time of trade
+- For weekends/holidays when BOI doesn't publish rates, use the most recent business day rate
+
+---
+
+## Section 4 — DeFi and special income classification
+
+| Activity | Classification | Tax rate | Reporting form |
+|---|---|---|---|
+| Buy and hold, then sell | Capital gain | 25% | Form 1325 |
+| Crypto-to-crypto swap | Capital gain (disposal + acquisition) | 25% | Form 1325 |
+| Staking rewards | Income at receipt (conservative); debated | 25–50% | Form 1301 or 1325 |
+| Liquidity mining / yield farming | Ordinary income | Marginal rates | Form 1301 |
+| Airdrops (free tokens) | Income at receipt, capital gain on subsequent sale | Marginal + 25% | Form 1301 + 1325 |
+| Mining | Business income or capital gain (depends on scale) | Variable | Form 1301 or 1325 |
+| NFT sales (creator) | Business income | Marginal rates | Form 1301 |
+| NFT sales (collector) | Capital gain | 25% | Form 1325 |
+| Hard fork tokens | Zero cost basis, capital gain on sale | 25% | Form 1325 |
+| Lending interest (CeFi/DeFi) | Interest income | 25% (passive) | Form 1301 |
+
+### Classification notes
+
+- **Staking:** ITA has not issued definitive guidance. Conservative approach treats rewards as income at receipt (market value), then capital gain/loss on subsequent sale
+- **Airdrops:** Received tokens are income at market value on receipt date. Cost basis for future sale = market value at receipt
+- **Hard forks:** New tokens have zero cost basis; entire sale proceeds are capital gain
+- **Stablecoins:** USDT, USDC, DAI are still "asset" under Section 88. Every USDT-to-USDC swap, every conversion leg of a DeFi trade, every off-ramp to fiat is a taxable disposal
+
+---
+
+## Section 5 — Loss offsetting rules
+
+- Capital losses from crypto can offset capital gains from crypto in the same tax year
+- Capital losses can offset gains from other assets (stocks, real estate) in the same year
+- Capital losses carry forward to offset future capital gains under Section 92 (but cannot offset ordinary income)
+- Losses from one spouse can offset gains of the other spouse if filing jointly
+- **Israel has no wash-sale rule** — a taxpayer can sell in December at a loss and re-buy in January with the loss fully recognized
+
+---
+
+## Section 6 — Reporting requirements
+
+### 6.1 Annual reporting (Forms 1322 / 1325)
+
+- **Form 1322** (Nispach Gimel — נספח ג) — primary capital gains schedule attached to annual return
+- **Form 1325** (Nispach Gimel(1) — נספח ג(1)) — auxiliary detail form for securities/crypto where tax was not withheld at source
+
+For each disposal, report:
+1. Asset description (e.g., "Bitcoin (BTC)")
+2. Date of acquisition (FIFO-determined)
+3. Date of disposal
+4. Acquisition cost (NIS)
+5. Disposal proceeds (NIS)
+6. Capital gain or loss (NIS)
+7. Holding period
+
+### 6.2 Advance payment (Form 1399י)
+
+- File within **30 days** of the capital gain event
+- Transaction codes: **77** (sale) and **71** (virtual currency)
+- Payment: 25% of gain for individuals (30% for significant shareholders)
+- Advance payments are credited against annual tax liability
+- Penalties for non-payment: interest (Ribit — ריבית) and CPI linkage (Hafreshei Hatzmada — הפרשי הצמדה)
+
+### 6.3 Annual return obligation
+
+Salaried individuals with crypto disposals must file Form 1301 even if they would otherwise be exempt. Any disposal generally triggers a filing obligation.
+
+**Filing deadlines (tax year 2025, filed in 2026):**
+- Online: June 30, 2026
+- Paper: May 31, 2026
+- CPA-represented: extensions available
+
+---
+
+## Section 7 — Surtax on crypto gains (Mas Yesafim — מס יסף)
+
+From 2026, capital income (including crypto gains) above NIS 721,560 is subject to:
+- 3% base surtax on all income above the threshold
+- Additional 2% on capital-source income above the same threshold
+- **Effective 5% surtax on crypto gains above NIS 721,560**
+- Threshold frozen through 2027
+
+---
+
+## Section 8 — Voluntary disclosure (Nohal Gilui Mirtzon — נוהל גילוי מרצון)
+
+The 2025–2026 Voluntary Disclosure Procedure expressly covers digital assets and grants criminal immunity.
+
+| Track | Eligibility | Deadline |
+|---|---|---|
+| Green Track | Annual income up to NIS 500,000 and cumulative crypto assets up to NIS 1.5M (as of 31.12.2024) | 31 August 2026 |
+| Regular Track | Larger cases | 31 August 2026 |
+
+Anonymity is no longer available — all applications filed with identifying details.
+
+---
+
+## Section 9 — Special rules
+
+### 9.1 Gifts and inheritance
+
+Under Section 97(a)(5), gifts and inheritance use **carryover basis** — the recipient inherits the donor's original cost basis and acquisition date. Treating inherited crypto as zero-basis or fair-market-value at inheritance is incorrect.
+
+### 9.2 Lost crypto
+
+Crypto lost to exchange insolvency (FTX, Celsius pattern), theft, or lost private keys is recognized as a capital loss ONLY when the loss is final and documented (e.g., bankruptcy court order, police report). Do not write off frozen-but-not-bankrupt balances.
+
+### 9.3 Inflation indexation
+
+Section 91(b)(3) splits capital gain into a "real gain" (taxed at 25%) and an "inflation-component gain" (taxed at 0% for individuals on assets acquired after 1.1.1994). For long-held lots, a CPA should perform the manual indexation pass, which reduces effective tax.
+
+---
+
+## Section 10 — Worked examples
+
+### Example 1 — Simple buy and sell
+
+**Scenario:** Bought 0.5 BTC in January 2025 for NIS 80,000, sold in August 2025 for NIS 120,000.
+
+**Working:**
+- Capital gain: NIS 120,000 − NIS 80,000 = NIS 40,000
+- Tax: NIS 40,000 × 25% = NIS 10,000
+- Surtax: total income below NIS 721,560 → no surtax
+- Advance payment: Form 1399י within 30 days of August sale → NIS 10,000
+- Annual reporting: Forms 1325/1322 with 2025 Form 1301
+
+### Example 2 — Crypto-to-crypto with FIFO
+
+**Scenario:** Bought 2 ETH at NIS 5,000 each (March 2024), 3 ETH at NIS 7,000 each (June 2024). In October, traded 3 ETH for 0.5 BTC when ETH = NIS 9,000.
+
+**Working:**
+- FIFO: consume Lot 1 (2 ETH @ NIS 5,000) then 1 ETH from Lot 2 (@ NIS 7,000)
+- Lot 1 gain: 2 × (NIS 9,000 − NIS 5,000) = NIS 8,000
+- Lot 2 partial gain: 1 × (NIS 9,000 − NIS 7,000) = NIS 2,000
+- Total gain: NIS 10,000 → Tax: NIS 2,500
+- New BTC cost basis: NIS 27,000 (3 × NIS 9,000)
+- Remaining: 2 ETH at NIS 7,000 each
+
+### Example 3 — DeFi staking rewards
+
+**Scenario:** Staked 10 ETH, earned 0.5 ETH in rewards (ETH = NIS 8,000 at receipt). Not sold.
+
+**Working:**
+- Conservative: NIS 4,000 taxable income at receipt (0.5 × NIS 8,000)
+- Rate: 25% if passive income → NIS 1,000 tax; or marginal rates if ordinary income
+- Cost basis for 0.5 reward ETH established at NIS 8,000/ETH
+- The 10 staked ETH have not been disposed — no capital gain event on those
+- Recommend professional consultation on staking classification
+
+---
+
+## Section 11 — Common errors
+
+| Error | Consequence |
+|---|---|
+| Using US capital gains rates (15%/20%) | Israeli rate is 25% for individuals |
+| Treating crypto-to-crypto as non-taxable | Always taxable in Israel |
+| Using average cost or LIFO | Israel mandates FIFO |
+| Ignoring stablecoin conversions | USDT/USDC are assets — every swap is a disposal |
+| Treating inherited crypto as zero basis | Carryover basis applies (Section 97(a)(5)) |
+| Applying US wash-sale rule | Israel has no wash-sale rule — loss harvesting is valid |
+| Missing 30-day advance payment deadline | Interest and linkage penalties accrue |
+| Ignoring surtax on crypto gains | 5% additional on capital gains above NIS 721,560 |
+
+---
+
+## Section 12 — Reference material
+
+| Resource | Reference |
+|---|---|
+| ITA Circular 05/2018 (crypto classification) | https://www.gov.il/he/Departments/legalInfo/04-2018 |
+| Tax Authority — annual return service | https://www.gov.il/he/service/reporting-and-payment-2025-annual-tax-report-for-individuals |
+| Bank of Israel — exchange rates | https://www.boi.org.il/roles/markets/exchangerates/ |
+| Voluntary Disclosure Procedure 2025–2026 | https://www.gov.il/he/Departments/policies/voluntary-disclosure-2025 |
+| Bituach Leumi — self-employed rates | https://www.btl.gov.il/Insurance/National%20Insurance/type_list/Self_Employed/Pages/rates.aspx |
+| OECD CARF (Israel collection from 1 Jan 2026) | https://www.oecd.org/tax/exchange-of-tax-information/crypto-asset-reporting-framework.htm |
+
+---
+
+## Section 13 — When to escalate to a professional
+
+- Transaction volume exceeds 100 trades per year
+- DeFi activities involve complex protocols (multi-chain, bridging, wrapping)
+- Uncertainty whether activity constitutes business vs investment
+- Total gains exceed NIS 500,000
+- Tokens received from ICO, IEO, or similar offering
+- Cross-border transactions with foreign tax obligations
+- Voluntary disclosure consideration
+
+---
+
+## Disclaimer
+
+> **חשוב:** כל המידע בקובץ זה מיועד למטרות מידע וחישוב בלבד. יש לבדוק כל עמדה מול רואה חשבון (Ro'eh Cheshbon) או יועץ מס (Yo'etz Mas) מוסמך לפני הגשה או פעולה.
+
+This skill and its outputs are provided for informational and computational purposes only and do not constitute tax, legal, or financial advice. Open Accountants and its contributors accept no liability for any errors, omissions, or outcomes arising from the use of this skill. All outputs must be reviewed and signed off by a qualified professional — such as a רואה חשבון (Ro'eh Cheshbon — CPA) or יועץ מס (Yo'etz Mas — tax advisor) licensed in Israel — before filing or acting upon.
+
+The most up-to-date, verified version of this skill is maintained at [openaccountants.com](https://openaccountants.com). Log in to access the latest version, request a professional review from a licensed accountant, and track updates as tax law changes.

--- a/skills/international/israel/il-customs-duty.md
+++ b/skills/international/israel/il-customs-duty.md
@@ -1,0 +1,229 @@
+---
+name: il-customs-duty
+description: Use this skill when calculating Israeli customs duty, VAT, and purchase tax on imports, or advising on free trade agreement preferences. Trigger on phrases like "import tax Israel", "customs duty Israel", "מכס", "mas kniya", "מס קנייה", "personal import Israel", "Amazon import Israel", "AliExpress import Israel", "Shaar Olami", "שער עולמי", "HS code Israel", "EUR.1 Israel", "FTA Israel", "landed cost Israel", or any Israeli customs and import duty query. ALWAYS read this skill before advising on Israeli import duties.
+version: 1.0
+jurisdiction: IL
+tax_year: 2025-2026
+category: international
+---
+
+# Israel Customs and Import Duty Skill v1.0
+
+> **Based on work by [Skills IL](https://github.com/skills-il/tax-and-finance)**, licensed under MIT. Adapted for the OpenAccountants format.
+
+---
+
+## Section 1 — Quick reference
+
+| Field | Value |
+|---|---|
+| Country | Israel (מדינת ישראל) |
+| Scope | Customs duty, VAT, and purchase tax on imports |
+| Currency | NIS (Israeli New Shekel — ₪) |
+| VAT rate | 18% (effective January 2025) |
+| Personal import threshold | USD 75 (as of May 2026 — verify before use) |
+| Tariff lookup | Shaar Olami — https://shaarolami-query.customs.mof.gov.il/CustomspilotWeb/en/CustomsBook/Import/Doubt |
+| Official calculator | https://www.gov.il/en/service/customs-tax-calculation-import-by-israelis |
+| Exchange rates | Bank of Israel — https://www.boi.org.il/en/economic-roles/financial-markets/exchange-rates/ |
+| Tax authority | Israel Tax Authority (ITA — רשות המיסים) |
+| Contributor | Open Accountants Community |
+| Validated by | Pending — requires sign-off by Israel-licensed רואה חשבון or יועץ מס |
+
+### Conservative defaults
+
+| Ambiguity | Default |
+|---|---|
+| Unknown personal import threshold | Use USD 75 — verify via official calculator |
+| Unknown HS code (last 2 digits) | Do not guess — request pre-ruling from Israel Customs |
+| Unknown origin of goods | Apply MFN duty rate (no FTA preference) |
+| Unknown whether EUR.1 is valid | Treat as invalid — apply full duty |
+| Unknown purchase tax rate | Check Shaar Olami for the specific 8-digit code |
+
+---
+
+## Section 2 — Import types
+
+| Type | Typical importer | Tax treatment |
+|---|---|---|
+| Personal import, small parcel | Consumer ordering online | Exemption threshold applies |
+| Personal import, high-value | Consumer buying jewelry, electronics | Full duty + VAT + purchase tax |
+| Commercial import (B2B) | Osek Murshe importing stock | Full duty + VAT (VAT is recoverable); no threshold exemption |
+| Gift | Individual sending to an Israeli | Treated as personal import, no special exemption |
+| Oleh Hadash belongings | New immigrant | Separate Oleh exemption — consult the Aliyah unit |
+
+### Courier vs postal clearance
+
+Courier shipments (DHL, FedEx, UPS) are self-cleared by the courier, which bills the importer duty, VAT, and a handling fee. Israel Post parcels go through postal clearance: low-value items clear automatically, items above the threshold get a payment demand before delivery. The tax math is the same; fees and timelines differ.
+
+---
+
+## Section 3 — Personal import threshold
+
+As of May 2026, the personal import VAT exemption is **USD 75** (cost of goods, excluding shipping and insurance).
+
+**Recent history:** The threshold was raised to USD 150 via a Smotrich decree in November 2025, then revoked by the Knesset on 24 February 2026, returning to USD 75. **Always verify the current threshold via the official calculator before quoting a number.**
+
+| Value range | Tax treatment |
+|---|---|
+| Below USD 75 | No customs, no VAT, no purchase tax |
+| USD 75 – USD 500 (approx) | VAT + purchase tax typically apply; customs duty often waived for personal imports |
+| Above USD 500 | Full duty + VAT + purchase tax; commercial clearance rules apply |
+
+**Shipping and insurance** are excluded from the personal import threshold test but are included in CIF for commercial imports. Do not mix the two rules.
+
+---
+
+## Section 4 — HS code classification
+
+Israel uses the international Harmonized System at the 6-digit level plus 2 Israel-specific digits (positions 7 and 8):
+
+1. Describe the product: material, function, packaging form, use, brand, model
+2. Start from the 2- or 4-digit HS chapter (e.g., chapter 85 for electronics, chapter 61 for apparel)
+3. Look up the full 8-digit code in Shaar Olami: https://shaarolami-query.customs.mof.gov.il/CustomspilotWeb/en/CustomsBook/Import/Doubt
+4. **Do not guess the last 2 digits** — a US HTS code or EU CN code does NOT translate directly to the Israeli code
+
+For certainty, request a free binding pre-ruling from Israeli Customs with a product description and catalog.
+
+---
+
+## Section 5 — Duty, VAT, and purchase tax rates
+
+From the Shaar Olami entry for the HS code, read:
+
+| Tax | Typical range | Notes |
+|---|---|---|
+| Customs duty | 0–12% (many goods duty-free under MFN bindings) | Varies by HS code |
+| VAT | 18% standard | Applied on CIF + duty + purchase tax |
+| Purchase tax (Mas Kniya — מס קנייה) | Only on specific items | Alcohol, tobacco, perfumes, some electronics, passenger cars — rates can be very high |
+
+**Purchase tax is NOT a small rounding item.** Alcohol and tobacco can carry rates in the hundreds of percent.
+
+---
+
+## Section 6 — Landed cost calculation
+
+The three taxes are calculated on a cascading base:
+
+### 6.1 CIF value
+
+Israel Customs values goods at CIF: cost + insurance + freight.
+
+```
+CIF (NIS) = (product price + shipping + insurance) × USD-to-NIS rate
+```
+
+Use the Bank of Israel daily rate for the clearance date.
+
+### 6.2 Cascading tax formula
+
+```
+Duty            = CIF × duty rate
+Base after duty = CIF + duty
+Purchase tax    = base after duty × purchase tax rate
+Base for VAT    = base after duty + purchase tax
+VAT             = base for VAT × 0.18
+Landed cost     = CIF + duty + purchase tax + VAT + broker fees + handling
+```
+
+### 6.3 Worked example — personal import above threshold
+
+**Scenario:** Camera from Amazon US, USD 200 + USD 20 shipping.
+
+| Line | Amount |
+|---|---|
+| Product price | USD 200 |
+| Shipping | USD 20 |
+| CIF (assuming USD/NIS 3.65) | NIS 803 |
+| Customs duty (0% for digital cameras under MFN) | NIS 0 |
+| Purchase tax (check HS code — typically 0% for cameras) | NIS 0 |
+| VAT (18% on NIS 803) | NIS 145 |
+| Broker/handling fee (typical parcel) | NIS 100–400 |
+| **Estimated total landed cost** | **~NIS 1,048–1,348** |
+
+---
+
+## Section 7 — Free trade agreement (FTA) preferences
+
+A valid origin proof can eliminate the customs duty (but NOT VAT or purchase tax):
+
+| Origin | Agreement | Origin proof required |
+|---|---|---|
+| United States | US-Israel FTA (1985) | US Origin Invoice Declaration on the commercial invoice |
+| European Union | EU-Israel Association Agreement | EUR.1 movement certificate, or invoice declaration under €6,000 |
+| United Kingdom | UK-Israel Trade and Partnership Agreement (2019) | EUR.1 movement certificate, or invoice declaration under €6,000 |
+| Canada | Modernized CIFTA (September 2019) | Form B239 certificate of origin |
+| EFTA (CH, NO, IS, LI) | EFTA-Israel Free Trade Agreement | EUR.1 movement certificate |
+| Mercosur (BR, AR, UY, PY) | Mercosur-Israel FTA (in force June 2010) | Mercosur-Israel certificate of origin |
+
+### EUR.1 requirements
+
+- Must carry a **wet-ink (original) signature** — Israel does NOT accept electronically signed EUR.1 certificates
+- For shipments above €6,000, an EUR.1 stamped by the origin country's customs is required
+- For below €6,000, an invoice declaration by a non-approved exporter is sufficient
+- For repeat shipments, the exporter should apply for approved-exporter status so invoice declarations cover any value
+- Plan courier time for the original document to arrive
+
+### Worked example — EU commercial import with EUR.1
+
+**Scenario:** 50 Italian leather bags, CIF €12,000, HS 4202.21.xx.
+
+| Line | Without EUR.1 | With valid EUR.1 |
+|---|---|---|
+| CIF | €12,000 | €12,000 |
+| Duty (6–12% typical for leather bags) | €720–1,440 | €0 (waived) |
+| Purchase tax | Typically 0% | 0% |
+| VAT (18% on CIF + duty) | €2,290–2,419 | €2,160 |
+| **Savings from EUR.1** | — | **€720–1,440 duty saved** |
+
+Since CIF > €6,000, an EUR.1 movement certificate stamped by Italian customs is required (invoice declaration alone insufficient unless exporter holds approved-exporter status).
+
+---
+
+## Section 8 — Common errors
+
+| Error | Consequence |
+|---|---|
+| Using US or EU HS code directly | Last 2 digits are Israel-specific — wrong code = wrong duty rate |
+| Applying old personal import threshold (USD 150) | Reverted to USD 75 in February 2026 |
+| Including shipping in personal threshold test | Shipping is excluded from the USD 75 test |
+| Forgetting cascading tax calculation | VAT is on CIF + duty + purchase tax, not on product price alone |
+| Accepting electronic EUR.1 | Israel requires wet-ink original |
+| Assuming FTA removes all taxes | FTA removes duty only; VAT and purchase tax still apply |
+| Underestimating purchase tax | Alcohol, tobacco, cars can have very high purchase tax rates |
+
+---
+
+## Section 9 — Tier 2 items (require professional input)
+
+| Item | Why it needs a professional |
+|---|---|
+| Binding HS classification pre-ruling | Complex product classification |
+| Temporary import (ATA Carnet) | Different rules for goods temporarily entering Israel |
+| Eilat free zone imports | Special zero-VAT zone rules |
+| Oleh Hadash belongings exemption | Separate exemption schedule and eligibility rules |
+| Anti-dumping duties | Certain goods from specific countries carry additional duties |
+| Agricultural imports | Seasonal quotas and variable levies may apply |
+
+---
+
+## Section 10 — Reference material
+
+| Resource | Reference |
+|---|---|
+| Israel Tax Authority | https://www.gov.il/en/departments/israel_tax_authority |
+| Personal import calculator | https://www.gov.il/en/service/customs-tax-calculation-import-by-israelis |
+| Shaar Olami tariff lookup | https://shaarolami-query.customs.mof.gov.il/CustomspilotWeb/en/CustomsBook/Import/Doubt |
+| EU-Israel trade relationship | https://policy.trade.ec.europa.eu/eu-trade-relationships-country-and-region/countries-and-regions/israel_en |
+| US-Israel FTA | https://www.trade.gov/us-israel-free-trade-agreement |
+| Bank of Israel exchange rates | https://www.boi.org.il/en/economic-roles/financial-markets/exchange-rates/ |
+| CIFTA rules of origin | https://www.cbsa-asfc.gc.ca/publications/dm-md/d11/d11-5-6-eng.html |
+
+---
+
+## Disclaimer
+
+> **חשוב:** כל המידע בקובץ זה מיועד למטרות מידע וחישוב בלבד. יש לבדוק כל עמדה מול רואה חשבון (Ro'eh Cheshbon) או יועץ מס (Yo'etz Mas) מוסמך לפני הגשה או פעולה.
+
+This skill and its outputs are provided for informational and computational purposes only and do not constitute tax, legal, or financial advice. Open Accountants and its contributors accept no liability for any errors, omissions, or outcomes arising from the use of this skill. All outputs must be reviewed and signed off by a qualified professional — such as a רואה חשבון (Ro'eh Cheshbon — CPA) or יועץ מס (Yo'etz Mas — tax advisor) licensed in Israel — before filing or acting upon.
+
+The most up-to-date, verified version of this skill is maintained at [openaccountants.com](https://openaccountants.com). Log in to access the latest version, request a professional review from a licensed accountant, and track updates as tax law changes.

--- a/skills/international/israel/il-employee-tax-refund.md
+++ b/skills/international/israel/il-employee-tax-refund.md
@@ -1,0 +1,291 @@
+---
+name: il-employee-tax-refund
+description: Use this skill when advising salaried Israeli employees on voluntary tax refund claims. Trigger on phrases like "tax refund Israel employee", "החזר מס לשכירים", "Form 135", "טופס 135", "Form 106", "טופס 106", "miluim refund", "מילואים החזר מס", "nekudot zikui missed", "yishuv mezakeh", "ישוב מזכה", "Section 46 donations", "תרומות", "oleh chadash credit points", "maternity tax refund Israel", or any Israeli employee tax refund query. ALWAYS read this skill before advising on Israeli employee tax refunds.
+version: 1.0
+jurisdiction: IL
+tax_year: 2025-2026
+category: international
+---
+
+# Israel Employee Tax Refund Skill v1.0
+
+> **Based on work by [Skills IL](https://github.com/skills-il/tax-and-finance)**, licensed under MIT. Adapted for the OpenAccountants format.
+
+---
+
+## Section 1 — Quick reference
+
+| Field | Value |
+|---|---|
+| Country | Israel (מדינת ישראל) |
+| Scope | Voluntary tax refund claims for salaried employees |
+| Currency | NIS (Israeli New Shekel — ₪) |
+| Primary form | Form 135 (דוח שנתי מקוצר) or online refund portal |
+| Key document | Form 106 (אישור שנתי על משכורת ומס שנוכה) from employer |
+| Refund window | 6 years from end of tax year (Section 160, Income Tax Ordinance) |
+| Online portal | https://secapp.taxes.gov.il |
+| Credit point value (2026) | NIS 2,904/year (NIS 242/month) — frozen 2025–2027 |
+| Tax authority | Israel Tax Authority (ITA — רשות המיסים) |
+| Contributor | Open Accountants Community |
+| Validated by | Pending — requires sign-off by Israel-licensed רואה חשבון or יועץ מס |
+
+### Conservative defaults
+
+| Ambiguity | Default |
+|---|---|
+| Unknown credit point eligibility | Apply base resident points only |
+| Unknown whether tax coordination (Tium Mas) was filed | Assume it was not filed — calculate refund accordingly |
+| Unknown donation institution approval | Verify before claiming Section 46 credit |
+| Unknown Yishuv Mezakeh eligibility | Verify against annual ITA locality list |
+
+---
+
+## Section 2 — Refund window
+
+The retroactive refund window is 6 calendar years from the end of the tax year, per Section 160 of the Income Tax Ordinance:
+
+| Tax year | Last day to claim refund |
+|---|---|
+| 2020 | 31.12.2026 |
+| 2021 | 31.12.2027 |
+| 2022 | 31.12.2028 |
+| 2023 | 31.12.2029 |
+| 2024 | 31.12.2030 |
+| 2025 | 31.12.2031 |
+
+Years older than 2020 can no longer be claimed in 2026.
+
+---
+
+## Section 3 — Reading Form 106
+
+Form 106 (אישור שנתי על משכורת ומס שנוכה) is the annual income summary issued by the employer by March 31 of the following year.
+
+### Key fields
+
+| Field | Hebrew label | What it tells you |
+|---|---|---|
+| 042 | סה"כ מס שנוכה במקור | Total income tax withheld by this employer |
+| 158 / 172 | משכורת חייבת | Taxable salary — base for tax-due calculation |
+| 218 / 219 | הפקדה לקרן השתלמות | Keren Hishtalmut deposit |
+| Months worked | חודשי עבודה | If less than 12, partial-year work — common refund trigger |
+
+If the employee has multiple Form 106s from the same tax year (job change), sum field 042 across all forms.
+
+### Bituach Leumi income-replacement payments
+
+If the employee received BTL payments during the year, request the annual confirmation (אישור שנתי למס הכנסה) from Bituach Leumi:
+
+| BTL payment | Hebrew | Tax treatment |
+|---|---|---|
+| Maternity pay | דמי לידה | Fully taxable — add to 158/172 and 042 |
+| Unemployment pay | דמי אבטלה | Fully taxable — add to 158/172 and 042 |
+| Short-term work injury (up to 91 days) | דמי פגיעה | Fully taxable — add to 158/172 and 042 |
+| Pregnancy preservation pay | דמי שמירת היריון | Fully taxable — add to 158/172 and 042 |
+| Reserve duty pay | תגמולי מילואים | Usually inside Form 106 already; only add direct-from-BTL payments |
+
+**Common pattern:** The refund usually originates from the salary side, not the BTL side. BTL typically under-withholds tax, while the employer over-withholds during worked months (assuming full-year salary).
+
+---
+
+## Section 4 — Refund triggers
+
+| # | Trigger | When it applies | Statutory anchor |
+|---|---|---|---|
+| 1 | Mid-year job change / multiple employers | Two or more Form 106s for the same year and no Tium Mas was filed | Section 164 ITO |
+| 2 | Partial-year work / unemployment | Less than 12 months worked | Withholding over-projection |
+| 3 | Maternity / paternity leave | Received דמי לידה from Bituach Leumi | Section 9(6) ITO |
+| 4 | Military reserve duty (Miluim — מילואים) | 30+ days of reserve service in the prior tax year | Section 39B ITO (Amendment 283) |
+| 5 | Charitable donations | Total donations to Section 46-approved institutions ≥ NIS 207 (2026 minimum) | Section 46 ITO |
+| 6 | Yishuv Mezakeh (ישוב מזכה) | Center of life in eligible periphery locality for 12+ months | Section 11 ITO + Negev/Galilee Law |
+| 7 | New immigrant credit points | Oleh Chadash within first 54 months of Aliyah (post-2022) | Section 35 ITO + Amendment 262 |
+| 8 | Completed academic degree | BA: 1 point/year up to 3 years (graduates 2023+); MA: 0.5 point for 2 years | Section 40g ITO |
+| 9 | Single parent / alimony | Court judgment establishing single-parent status | Sections 64, 65, 66 ITO |
+| 10 | Disability exemption | 100% medical disability, blindness, or 90%+ multi-organ calculation | Section 9(5) ITO |
+| 11 | Self-deposit to pension beyond employer's deposit | Employee deposit to pension fund or life insurance | Sections 45A and 47 ITO |
+| 12 | Early Keren Hishtalmut withdrawal | Bank withheld 47% but real marginal rate is lower | Section 9(16a) + Section 164 ITO |
+| 13 | Missed child credit points | Custody changed but employer's Form 101 not updated | Section 40 ITO |
+| 14 | One-time bonus / 13th salary | Monthly over-withholding on large bonus; annual reconciliation produces refund | Regulation 6 of withholding regulations |
+
+---
+
+## Section 5 — Credit point calculations
+
+### 5.1 Reserve duty credit points (Section 39B, Amendment 283)
+
+Realized in the year AFTER the service (service in 2025 → claim on 2026 refund):
+
+| Days served in tax year | Points awarded | Annual value (NIS) |
+|---|---|---|
+| 30–39 | 0.5 | 1,452 |
+| 40–49 | 0.75 | 2,178 |
+| 50–54 | 1.0 | 2,904 |
+| Each additional 5 days | +0.25 | +726 |
+| Maximum | 4.0 | 11,616 |
+
+### 5.2 New immigrant schedule (post-2022, Amendment 262)
+
+| Period from Aliyah date | Monthly points | Annual rate |
+|---|---|---|
+| Months 1–12 | 1/12 | 1 point |
+| Months 13–30 (18 months) | 1/4 | 3 points |
+| Months 31–42 (12 months) | 1/6 | 2 points |
+| Months 43–54 (12 months) | 1/12 | 1 point |
+
+Total: 8.5 credit points over 54 months. For Olim who arrived before 1.1.2022, the pre-Amendment 262 schedule applies (7.5 points over 42 months).
+
+**Section 35 is for credit points only — there is no "Section 35 mortgage interest deduction for Olim."** Do not promise a mortgage refund under this section.
+
+### 5.3 Donation credit (Section 46)
+
+- Minimum donation: NIS 207 (2026)
+- Credit rate: 35% of donated amount
+- Annual ceiling: NIS 10,354,816 or 30% of taxable income, whichever is lower
+- Institution must hold active Section 46 approval for the year of donation
+- Valid receipt formats: original, certified copy, or electronic (marked מסמך ממוחשב)
+
+### 5.4 Yishuv Mezakeh
+
+Residents of eligible localities receive a percentage discount on tax due, capped at a NIS ceiling. The list of eligible localities and per-locality percentage is published annually by the ITA. Always verify against the current list for the relevant tax year.
+
+### 5.5 Disability exemption (Section 9(5))
+
+| Duration | Exempt earned income ceiling (2026) |
+|---|---|
+| 365+ days (long-term) | NIS 445,200/year |
+| 185–364 days (short-term) | NIS 81,960/year |
+| חוק הנכים / חוק נפגעי פעולות איבה pension | NIS 684,000/year |
+
+Qualifying conditions: 100% medical disability, blindness, or 90%+ via multi-organ-injury calculation (ועדה רפואית determination required).
+
+---
+
+## Section 6 — Estimating the refund
+
+**Formula:** Correct tax (under brackets and credits) − Tax actually withheld (sum of field 042 across all Form 106s)
+
+### 2026 income tax brackets for employees
+
+| Monthly salary band (NIS) | Annual band (NIS) | Rate |
+|---|---|---|
+| Up to 7,010 | Up to 84,120 | 10% |
+| 7,011 – 10,060 | 84,121 – 120,720 | 14% |
+| 10,061 – 19,000 | 120,721 – 228,000 | 20% |
+| 19,001 – 25,100 | 228,001 – 301,200 | 31% |
+| 25,101 – 46,690 | 301,201 – 560,280 | 35% |
+| 46,691 and above | 560,281 and above | 47% |
+| Plus surtax | Above 721,560 annual | Additional 3% |
+
+For prior tax years, use the brackets that applied to that year.
+
+Present the estimate as a range, not a single number, and note that the ITA's actual calculation may differ.
+
+---
+
+## Section 7 — Document checklist by trigger
+
+| Trigger | Required documents |
+|---|---|
+| All claims | Form 106 from every employer; Teudat Zehut (תעודת זהות) + Sipach; bank account confirmation (אישור ניהול חשבון) |
+| Multiple employers | All Form 106s — sum field 042 across them |
+| Partial year / unemployment | BTL annual confirmation listing months and amounts |
+| Maternity/paternity leave | BTL דמי לידה annual confirmation |
+| Reserve duty (Miluim) | Form 3010 (אישור על ימי מילואים) from IDF reserve unit |
+| Section 46 donations | Signed receipts from each approved institution |
+| Yishuv Mezakeh | אישור תושבות from local authority for each year (12+ months residence) |
+| New immigrant | Teudat Oleh (תעודת עולה) + Aliyah date |
+| Academic degree | Diploma + transcript (verifies completion year) |
+| Single parent / alimony | Court judgment + bank transfer records |
+| Disability | Medical board determination (ועדה רפואית) + ITA disability committee ratification |
+| Pension self-deposit | Annual deposit certificate from pension/insurance provider |
+| Keren Hishtalmut early withdrawal | תלוש משיכה showing 47% withholding |
+
+---
+
+## Section 8 — Submission channels
+
+| Channel | When to use | Where |
+|---|---|---|
+| Online refund portal | Not obligated to file Form 1301; has digital government identity; has scanned documents | https://secapp.taxes.gov.il |
+| Manual Form 135 | Prefers paper; online portal doesn't support the case; identity verification issues | https://www.gov.il/he/service/itc135 — submit at the assigned Misrad Shuma (משרד שומה) |
+
+**If the employee is required to file Form 1301** (income above surtax threshold, foreign income, capital gains), neither Form 135 nor the online portal applies. The refund computation must be integrated into Form 1301.
+
+---
+
+## Section 9 — Prospective fix (Form 101)
+
+If a refund trigger is ongoing (still a single parent, still an Oleh in credit-point window, still residing in Yishuv Mezakeh), the employee should update their Form 101 at the employer for the current and following year. Form 101 sets the credit-point basis the employer uses for withholding.
+
+Without this fix, the employee will file the same refund every year for the same missed credit. The retrospective refund returns last year's over-withholding; updating Form 101 stops the over-withholding going forward.
+
+---
+
+## Section 10 — Worked examples
+
+### Example 1 — Two jobs in 2024
+
+**Scenario:** Developer worked 6 months at Employer A (NIS 25,000/month) and 6 months at Employer B (NIS 22,000/month). No mid-year Tium Mas filed.
+
+**Working:**
+- Field 042: NIS 24,800 withheld at A + NIS 22,400 at B = NIS 47,200 total withheld
+- Aggregate annual income: NIS 282,000
+- Correct annual tax (2024 brackets, 2.75 default points for female): ~NIS 43,700
+- Estimated refund: NIS 3,100 – NIS 3,800
+- Trigger: #1 (mid-year job change)
+- Documents: both Form 106s, Teudat Zehut, bank confirmation
+- Deadline: 31.12.2030
+
+### Example 2 — Reserve duty 65 days in 2025
+
+**Scenario:** Teacher served 65 days of reserve duty in 2025.
+
+**Working:**
+- Section 39B schedule: 50 days = 1.0 point; 15 additional days (over 50) at +0.25 per 5 days = +0.75 points
+- Total: 1.75 points × NIS 2,904 = NIS 5,082 expected refund for 2026
+- Points are realized in the year AFTER service → claim on 2026 refund
+- Document: Form 3010 from reserve unit
+- Submit after 2026 Form 106 is issued (by 31.3.2027)
+
+### Example 3 — Section 46 donations for 2022
+
+**Scenario:** Employee donated NIS 6,000 to three Section 46-approved nonprofits in 2022.
+
+**Working:**
+- Credit: NIS 6,000 × 35% = NIS 2,100
+- Deadline: 31.12.2028 — still open
+- Documents: signed original receipts; verify each institution's Section 46 approval was active in 2022
+
+---
+
+## Section 11 — After submission
+
+- ITA must process and pay the refund within one year from the assessment date, or two years from the end of the tax year, whichever is later
+- Refunds paid after the statutory window accrue CPI linkage (הצמדה) plus 4% annual interest
+- If the ITA sends a "Drisha LeHashlamat Mismachim" (דרישה להשלמת מסמכים) — request for additional documents — respond within the stated deadline or the request closes
+
+---
+
+## Section 12 — Reference material
+
+| Resource | Reference |
+|---|---|
+| Tax Authority Form 135 | https://www.gov.il/he/service/itc135 |
+| Online refund portal | https://secapp.taxes.gov.il |
+| Kol Zchut — tax refund overview | https://www.kolzchut.org.il/he/החזר_מס_הכנסה |
+| Kol Zchut — credit points | https://www.kolzchut.org.il/he/נקודות_זיכוי |
+| Kol Zchut — reserve duty points | https://www.kolzchut.org.il/he/נקודות_זיכוי_ממס_הכנסה_ללוחמי_מילואים |
+| Kol Zchut — Section 46 donations | https://www.kolzchut.org.il/he/זיכוי_ממס_הכנסה_בשל_תרומה_(סעיף_46) |
+| Kol Zchut — Yishuv Mezakeh | https://www.kolzchut.org.il/he/זיכוי_ממס_הכנסה_לתושבים_בפריפריה |
+| Kol Zchut — disability exemption | https://www.kolzchut.org.il/he/פטור_ממס_הכנסה_לאנשים_עם_נכות |
+| Kol Zchut — Form 106 | https://www.kolzchut.org.il/he/טופס_106 |
+
+---
+
+## Disclaimer
+
+> **חשוב:** כל המידע בקובץ זה מיועד למטרות מידע וחישוב בלבד. יש לבדוק כל עמדה מול רואה חשבון (Ro'eh Cheshbon) או יועץ מס (Yo'etz Mas) מוסמך לפני הגשה או פעולה.
+
+This skill and its outputs are provided for informational and computational purposes only and do not constitute tax, legal, or financial advice. Open Accountants and its contributors accept no liability for any errors, omissions, or outcomes arising from the use of this skill. All outputs must be reviewed and signed off by a qualified professional — such as a רואה חשבון (Ro'eh Cheshbon — CPA) or יועץ מס (Yo'etz Mas — tax advisor) licensed in Israel — before filing or acting upon.
+
+The most up-to-date, verified version of this skill is maintained at [openaccountants.com](https://openaccountants.com). Log in to access the latest version, request a professional review from a licensed accountant, and track updates as tax law changes.

--- a/skills/international/israel/il-freelancer-ops.md
+++ b/skills/international/israel/il-freelancer-ops.md
@@ -1,0 +1,312 @@
+---
+name: il-freelancer-ops
+description: Use this skill when advising Israeli freelancers (עצמאים) on business operations, tax deadlines, threshold monitoring, invoice requirements, and accountant package preparation. Trigger on phrases like "osek patur threshold", "freelancer Israel taxes", "עוסק פטור", "עוסק מורשה", "עסק זעיר", "esek za'ir", "mkdamot", "מקדמות", "havila l'roe cheshbon", "bituach leumi self-employed", "ביטוח לאומי עצמאי", "freelancer deadlines Israel", or any Israel freelancer operations query. ALWAYS read this skill before advising on Israeli freelancer tax operations.
+version: 1.0
+jurisdiction: IL
+tax_year: 2025-2026
+category: international
+---
+
+# Israel Freelancer Operations Skill v1.0
+
+> **Based on work by [Skills IL](https://github.com/skills-il/tax-and-finance)**, licensed under MIT. Adapted for the OpenAccountants format.
+
+---
+
+## Section 1 — Quick reference
+
+| Field | Value |
+|---|---|
+| Country | Israel (מדינת ישראל) |
+| Scope | Freelancer tax operations, deadlines, threshold monitoring |
+| Currency | NIS (Israeli New Shekel — ₪) |
+| Business types | Osek Murshe (עוסק מורשה), Osek Patur (עוסק פטור), Esek Za'ir (עסק זעיר) |
+| VAT rate | 18% (effective January 2025) |
+| Osek Patur threshold (2025) | NIS 120,000 annual turnover |
+| Osek Patur threshold (2026) | NIS 122,833 annual turnover (CPI-indexed) |
+| Tax authority | Israel Tax Authority (ITA — רשות המיסים בישראל) |
+| Filing portal | Shaam Online — https://www.misim.gov.il |
+| Contributor | Open Accountants Community |
+| Validated by | Pending — requires sign-off by Israel-licensed רואה חשבון or יועץ מס |
+
+### Conservative defaults
+
+| Ambiguity | Default |
+|---|---|
+| Unknown business type | Treat as Osek Murshe (higher obligations) |
+| Unknown VAT filing frequency | Bi-monthly |
+| Revenue near threshold | Alert at 70% — do not wait until exceeded |
+| Unknown whether invoice requires allocation number | Include allocation number |
+| Unknown pension deposit status | Assume no deposit made — flag Dec 31 deadline |
+
+---
+
+## Section 2 — Freelancer business types
+
+### 2.1 Osek Murshe (עוסק מורשה) — Authorized dealer
+
+| Attribute | Detail |
+|---|---|
+| Registration | Registered for VAT at ITA |
+| VAT obligation | Must charge 18% VAT on all invoices |
+| Invoice type | Heshbonit Mas (חשבונית מס — tax invoice) |
+| Input VAT | Can deduct input VAT (Mas Tsumos — מס תשומות) on business expenses |
+| VAT filing | Bi-monthly (turnover < NIS 1.5M) or monthly (turnover > NIS 1.5M) |
+| Annual return | Form 1301 (דוח שנתי) required |
+| Advance payments | Mkdamot (מקדמות) — bi-monthly income tax advances |
+
+### 2.2 Osek Patur (עוסק פטור) — Exempt dealer
+
+| Attribute | Detail |
+|---|---|
+| Eligibility | Annual turnover below threshold (NIS 120,000 for 2025; NIS 122,833 for 2026) |
+| VAT obligation | Does NOT charge VAT |
+| Invoice type | Kabala (קבלה — receipt) only |
+| Input VAT | Cannot deduct input VAT on purchases |
+| VAT filing | No periodic VAT returns; annual turnover declaration by January 31 |
+| Annual return | Form 1301 still required for income tax |
+| Threshold monitoring | Must convert to Osek Murshe if threshold exceeded mid-year |
+
+### 2.3 Esek Za'ir (עסק זעיר) — Micro business
+
+Introduced in 2024 under Income Tax Ordinance Section 17א.
+
+| Attribute | Detail |
+|---|---|
+| Eligibility | Under the Osek Patur revenue threshold |
+| Key benefit | 30% normative expense deduction — no receipts needed |
+| Reporting | Simplified; exempt from annual income tax report in most cases |
+| Restriction | Cannot be a former employee of the invoiced client |
+| Restriction | No more than 25% of annual revenue from a single related party |
+| Threshold | Shared with Osek Patur (NIS 122,833 for 2026, CPI-indexed) |
+
+---
+
+## Section 3 — Invoice requirements
+
+### 3.1 General rules
+
+- Invoice numbering must be sequential with no gaps
+- All invoices must include the freelancer's Osek number (מספר עוסק — 9-digit taxpayer ID)
+- Osek Murshe: must issue Heshbonit Mas (tax invoice) showing VAT separately
+- Osek Patur: issues Kabala (receipt) only — must NOT show VAT
+
+### 3.2 Allocation numbers (Mispar Haktzaa — מספר הקצאה)
+
+From 2026, Osek Murshe must obtain an allocation number from the Tax Authority system for tax invoices:
+
+| Effective date | Invoice threshold (before VAT) |
+|---|---|
+| January 2026 | NIS 10,000 |
+| June 2026 | NIS 5,000 |
+
+Without an allocation number, the recipient cannot deduct input VAT. Flag any issued invoice above the threshold that is missing an allocation number.
+
+---
+
+## Section 4 — Tax deadline calendar
+
+### 4.1 Periodic deadlines
+
+| Deadline | Frequency | Date | Details |
+|---|---|---|---|
+| VAT filing (Osek Murshe, bi-monthly) | Bi-monthly | 15th of the month after the period | Mar 15, May 15, Jul 15, Sep 15, Nov 15, Jan 15 |
+| VAT filing (monthly filers) | Monthly | 15th of each month | For businesses exceeding the monthly threshold |
+| Detailed VAT report (Doch Meforat, report 874) | Monthly | 23rd of the following month | Required for annual turnover > NIS 500,000; forces monthly filing |
+| Bituach Leumi advances | Monthly | 15th of each month | National Insurance advance payments |
+| Mkdamot (income tax advances) — monthly filers | Monthly | 15th of the month after the period | Per Tax Authority assessment letter |
+| Mkdamot — bi-monthly filers | Bi-monthly | 19th of the month after the period | Per Tax Authority assessment letter |
+
+### 4.2 Annual deadlines
+
+| Deadline | Date | Details |
+|---|---|---|
+| Osek Patur annual turnover declaration | January 31 | Report previous year's turnover to VAT office |
+| Annual income tax report (Form 1301) — paper | May 31 | For tax year 2025 filed in 2026 |
+| Annual income tax report (Form 1301) — online | June 30 | Online filing mandatory for most filers |
+| Annual income tax report — CPA extension | July 31 or later | Via CPA association quota arrangement |
+| Self-employed pension deposit deadline | December 31 | Last day to deposit for that tax year's benefits |
+
+**If a deadline falls on Shabbat (Saturday), it moves to Sunday. If it falls on a Jewish holiday (Chag), check the ITA website for adjusted dates.**
+
+### 4.3 Pension contribution deadlines (December 31)
+
+Missing December 31 forfeits both tax benefits for the entire year:
+
+**Section 45א — 35% tax credit (Zikui)**
+- Credit on contributions up to 5.5% of business income
+- 2026 cap: approximately NIS 11,640 + NIS 1,164
+
+**Section 47 — Income deduction (Nikui)**
+- Deduction of up to 11% of qualifying income
+- 2026 qualifying-income ceiling: NIS 232,800; max deposit approximately NIS 25,608
+
+**Mandatory self-employed pension contribution (separate from 45א/47)**
+- 2026 rates: 4.45% on income up to half the average wage; 12.55% above it
+- Average wage 2026: NIS 13,769/month
+- This is a legal obligation, not just a tax benefit
+
+---
+
+## Section 5 — Osek Patur threshold monitoring
+
+### 5.1 Alert levels
+
+Track cumulative annual revenue against the Osek Patur threshold:
+
+| Alert level | Revenue (2026) | Action |
+|---|---|---|
+| Informational (70%) | ~NIS 86,000 | "You've reached 70% of the annual threshold. Consider planning for potential transition." |
+| Warning (85%) | ~NIS 104,400 | "Approaching threshold. Review implications of converting to Osek Murshe." |
+| Urgent (95%) | ~NIS 116,700 | "Very close to threshold. Conversion may be required soon." |
+
+### 5.2 Transition implications
+
+When the threshold is exceeded, the freelancer must:
+
+1. Register as Osek Murshe at the local Tax Authority office (Misrad Mas Hachnasa — משרד מס הכנסה)
+2. Begin charging VAT (18%) on all invoices
+3. Switch to issuing Heshbonit Mas (tax invoices) instead of Kabala (receipts)
+4. Register for the allocation number system (for invoices above the threshold)
+5. Begin filing periodic VAT returns
+6. Start tracking input VAT on business expenses for deductions
+7. Notify clients of new invoicing format
+8. Bituach Leumi payments may increase
+
+### 5.3 Esek Za'ir alternative
+
+If income is expected to stay near the threshold, the Esek Za'ir track offers a 30% normative expense deduction and simplified reporting but shares the same revenue ceiling as Osek Patur. It does not defer the obligation to convert to Osek Murshe if the threshold is exceeded.
+
+---
+
+## Section 6 — Bituach Leumi (National Insurance) for self-employed
+
+### 6.1 Contribution rates (2026)
+
+| Income range | NI rate | Health rate | Total |
+|---|---|---|---|
+| Up to NIS 7,703/month | 2.87% | 3.10% | 5.97% |
+| NIS 7,703 – NIS 51,910/month | 12.83% | 5.00% | 17.83% |
+
+- Minimum monthly advance: NIS 187
+- Maximum monthly advance: NIS 7,850
+- Minimum income floor: NIS 2,065/month
+- Direct-debit payers (הוראת קבע) get an automatic extension to the 22nd
+- 52% of the NI amount is tax-deductible for income tax purposes
+
+---
+
+## Section 7 — Accountant package (Havila L'Roe Cheshbon — חבילה לרואה חשבון)
+
+### 7.1 Package contents
+
+1. **Issued invoices** — all invoices/receipts issued during the period, sorted by date
+2. **Received invoices/receipts** — all expense documents (business purchases, subscriptions, equipment)
+3. **Bank statement summary** — transaction list matched to invoices where possible
+4. **Utility bills** — electricity, telecoms, water, organized by provider
+5. **Revenue summary** — running annual total with monthly breakdown
+6. **Cover sheet** — summary page with key figures
+
+### 7.2 Cover sheet fields
+
+| Field | Description |
+|---|---|
+| Period covered | Month / quarter / year |
+| Total revenue (Bruto — ברוטו) | Gross income for the period |
+| Total expenses | All deductible business expenses |
+| Net income (Neto — נטו) | Revenue minus expenses |
+| VAT collected | For Osek Murshe only |
+| VAT paid on expenses (Mas Tsumos) | For Osek Murshe only |
+| Net VAT payable/refundable | Output VAT minus Input VAT |
+| Running annual revenue total | Year-to-date cumulative |
+| Invoice count | Number of invoices issued and received |
+
+### 7.3 Folder structure
+
+Organize by period:
+- `YYYY-MM/invoices-issued/`
+- `YYYY-MM/invoices-received/`
+- `YYYY-MM/utility-bills/`
+- `YYYY-MM/bank-statements/`
+- Cover sheet at the root of each period folder
+
+---
+
+## Section 8 — Invoice aging tracker
+
+Track all issued invoices by payment status:
+
+| Bucket | Age | Recommended action |
+|---|---|---|
+| Current | 0–29 days | Monitor, no action needed |
+| 30-day | 30–59 days | Friendly reminder to client |
+| 60-day | 60–89 days | Formal follow-up with invoice copy and payment details |
+| 90+ day | 90+ days | Alert for escalation consideration |
+
+Track partial payments and maintain running totals: total outstanding, total overdue, by client.
+
+---
+
+## Section 9 — Worked examples
+
+### Example 1 — Osek Patur approaching threshold
+
+**Scenario:** Freelance web developer, Osek Patur, has earned NIS 95,000 by September with 3 months remaining.
+
+**Working:**
+- Average monthly income: NIS 95,000 ÷ 9 = ~NIS 10,556
+- Projected annual total: NIS 10,556 × 12 = ~NIS 126,667
+- 2025 threshold: NIS 120,000
+- Status: projected to exceed threshold by ~NIS 6,667
+
+**Action:** Alert at 85% level. Prepare transition checklist. Recommend consulting accountant before crossing the threshold.
+
+### Example 2 — Pension contribution deadline
+
+**Scenario:** Self-employed consultant, annual business income NIS 300,000. December 15, no pension deposits yet.
+
+**Working:**
+- Section 45א credit: 35% on up to 5.5% of NIS 300,000 = NIS 16,500 eligible → NIS 5,775 tax credit
+- Section 47 deduction: up to 11% of NIS 300,000 = NIS 33,000 deductible (marginal benefit depends on tax bracket)
+- Mandatory contribution: 4.45% on income up to half the average wage + 12.55% above it
+- Deadline: December 31 — missing it forfeits both benefits for the entire year
+
+**Action:** Urgent alert. Deposit to pension fund, Kupat Gemel, or insurance policy before December 31.
+
+---
+
+## Section 10 — Common errors and red flags
+
+| Error | Why it matters |
+|---|---|
+| Confusing Osek Murshe with Osek Patur | Different VAT obligations, invoice types, and filing requirements |
+| Skipping zero-revenue VAT returns | Osek Murshe must file bi-monthly returns even with no revenue; missing reports trigger penalties |
+| Gap in invoice numbering | Violates Tax Authority requirements; sequential numbering is mandatory |
+| Missing allocation number on invoices > NIS 10,000 | From 2026, recipient loses input VAT deduction |
+| Wrong annual report deadline | Form 1301 is due May 31 (paper) / June 30 (online) — not April 30 |
+| Confusing Section 45א credit with mandatory pension | They are separate: 45א/47 are voluntary tax benefits; mandatory contribution is a legal floor |
+| Using Bituach Leumi based on monthly actual revenue | BL advances are based on projected annual income, not actual monthly revenue |
+
+---
+
+## Section 11 — Reference material
+
+| Resource | Reference |
+|---|---|
+| Tax Authority — Form 1301 / annual report | https://www.gov.il/he/service/reporting-and-payment-2025-annual-tax-report-for-individuals |
+| Tax Authority — allocation numbers | https://www.gov.il/he/service/request-assignment-number-for-tax-invoice |
+| Kol Zchut — Osek Patur | https://www.kolzchut.org.il/he/עוסק_פטור |
+| Kol Zchut — Esek Za'ir | https://www.kolzchut.org.il/he/עסק_זעיר |
+| Kol Zchut — Section 45א pension credit | https://www.kolzchut.org.il/he/זיכוי_ממס_הכנסה_בגין_הפרשות_לביטוח_פנסיוני |
+| Bituach Leumi — self-employed rates | https://www.btl.gov.il/Insurance/National%20Insurance/type_list/Self_Employed/Pages/rates.aspx |
+| ITA filing portal (Shaam Online) | https://www.misim.gov.il |
+
+---
+
+## Disclaimer
+
+> **חשוב:** כל המידע בקובץ זה מיועד למטרות מידע וחישוב בלבד. יש לבדוק כל עמדה מול רואה חשבון (Ro'eh Cheshbon) או יועץ מס (Yo'etz Mas) מוסמך לפני הגשה או פעולה.
+
+This skill and its outputs are provided for informational and computational purposes only and do not constitute tax, legal, or financial advice. Open Accountants and its contributors accept no liability for any errors, omissions, or outcomes arising from the use of this skill. All outputs must be reviewed and signed off by a qualified professional — such as a רואה חשבון (Ro'eh Cheshbon — CPA) or יועץ מס (Yo'etz Mas — tax advisor) licensed in Israel — before filing or acting upon.
+
+The most up-to-date, verified version of this skill is maintained at [openaccountants.com](https://openaccountants.com). Log in to access the latest version, request a professional review from a licensed accountant, and track updates as tax law changes.

--- a/skills/international/israel/il-income-tax-returns.md
+++ b/skills/international/israel/il-income-tax-returns.md
@@ -1,0 +1,355 @@
+---
+name: il-income-tax-returns
+description: Use this skill when preparing, reviewing, or advising on Israeli annual income tax returns. Trigger on phrases like "doch shnati", "Form 1301", "Form 1214", "דוח שנתי", "mas hachnasa", "income tax Israel", "nekudot zikui", "נקודות זיכוי", "tax brackets Israel", "mas yesafim", "מס יסף", "surtax Israel", "mikdamot", "מקדמות", "Mas Shevach", "מס שבח", "capital gains Israel", "Form 6111", "Form 856", "Form 126", or any Israel income tax return query. ALWAYS read this skill before advising on Israeli income tax returns.
+version: 1.0
+jurisdiction: IL
+tax_year: 2025-2026
+category: international
+---
+
+# Israel Income Tax Returns Skill v1.0
+
+> **Based on work by [Skills IL](https://github.com/skills-il/tax-and-finance)**, licensed under MIT. Adapted for the OpenAccountants format.
+
+---
+
+## Section 1 — Quick reference
+
+| Field | Value |
+|---|---|
+| Country | Israel (מדינת ישראל) |
+| Scope | Annual income tax returns for individuals and companies |
+| Currency | NIS (Israeli New Shekel — ₪) |
+| Tax authority | Israel Tax Authority (ITA — Reshut HaMisim — רשות המיסים) |
+| Filing portal | Shaam Online — https://www.misim.gov.il |
+| Individual return | Form 1301 (דוח שנתי ליחיד) |
+| Short return (salaried refund) | Form 135 (דוח שנתי מקוצר) |
+| Corporate return | Form 1214 (דוח שנתי לחברה) |
+| Corporate tax rate | 23% flat |
+| Surtax threshold | NIS 721,560 (frozen 2025–2027) |
+| Credit point value | NIS 2,904/year (NIS 242/month) — frozen 2025–2027 |
+| Contributor | Open Accountants Community |
+| Validated by | Pending — requires sign-off by Israel-licensed רואה חשבון or יועץ מס |
+
+### Conservative defaults
+
+| Ambiguity | Default |
+|---|---|
+| Unknown filing obligation | Assume filing is required |
+| Unknown bracket year | Use the most recent confirmed brackets |
+| Unknown credit points | Apply base resident points only (2.25 male / 2.75 female) |
+| Unknown rental income track | Apply marginal rate (most conservative; highest potential tax) |
+| Unknown capital gains holding period | Apply 25% rate (no reduced rate exists in Israel regardless) |
+
+---
+
+## Section 2 — Return types and deadlines
+
+| Form | Hebrew | Who files | Deadline | Frequency |
+|---|---|---|---|---|
+| 1301 | דוח שנתי ליחיד | Individuals, sole proprietors, freelancers | June 30 online; May 31 paper (for tax year 2025 filed in 2026) | Annual |
+| 135 | דוח שנתי מקוצר | Salaried individuals claiming a refund | Within 6 years of the tax year end (Section 160) | On demand |
+| 1214 | דוח שנתי לחברה | Companies (Chevra Ba'am, Chevra Pratit) | May 31 (5 months after year end); extensions available | Annual |
+| 126 | דוח מעסיק על משכורות | Employers reporting employee salaries | April 30 | Annual |
+| 856 | דוח על תשלומים לספקים | Businesses reporting payments to suppliers | April 30 | Annual |
+| 6111 | דוח כספי אחיד | Businesses with turnover > NIS 300,000 (incl. VAT) | Submitted with 1301 or 1214 | Annual |
+| Mikdamot | מקדמות מס הכנסה | Self-employed and businesses with advance assessments | 15th of the month after the period | Bi-monthly |
+| Mas Shevach | הצהרת מס שבח | Anyone selling real estate in Israel | 30 days from sale (40 days if requesting exemption) | Per transaction |
+| 1322/1325 | דוח רווח הון מניירות ערך | Anyone with securities capital gains | 30 days from sale (or annually with Form 1301) | Per transaction or annual |
+
+**CPA-represented filers** typically receive automatic extensions through the CPA association's quota arrangement with the ITA (often to September 30 or later).
+
+---
+
+## Section 3 — Who must file Form 1301
+
+- Self-employed individuals (Osek Murshe or Osek Patur)
+- Individuals whose gross salary exceeded NIS 721,560 (surtax threshold)
+- Individuals with income from multiple employers
+- Individuals with foreign income or assets abroad exceeding reporting thresholds
+- Anyone who received capital gains during the tax year
+- Individuals who received rental income exceeding the exempt threshold
+
+---
+
+## Section 4 — Income tax brackets (2026)
+
+Brackets 1–2 and 6 frozen at 2025 values; brackets 3–5 expanded by the Economic Efficiency Law 2026 (approved March 30, 2026, retroactive to January 1, 2026):
+
+| Bracket | Annual income range (NIS) | Rate |
+|---|---|---|
+| 1 | 0 – 84,120 | 10% |
+| 2 | 84,121 – 120,720 | 14% |
+| 3 | 120,721 – 228,000 | 20% |
+| 4 | 228,001 – 301,200 | 31% |
+| 5 | 301,201 – 560,280 | 35% |
+| 6 | 560,281 – 721,560 | 47% |
+| Surtax | Above 721,560 | See Section 5 |
+
+### Monthly equivalent brackets
+
+| Monthly income (NIS) | Rate |
+|---|---|
+| Up to 7,010 | 10% |
+| 7,011 – 10,060 | 14% |
+| 10,061 – 19,000 | 20% |
+| 19,001 – 25,100 | 31% |
+| 25,101 – 46,690 | 35% |
+| 46,691 and above | 47% |
+
+---
+
+## Section 5 — Surtax (Mas Yesafim — מס יסף)
+
+Two-tier system from 2026:
+
+| Income type | Rate above NIS 721,560 | Effective top rate |
+|---|---|---|
+| Employment and active income | 3% | 50% (47% + 3%) |
+| Capital and passive income (dividends, interest, rent, capital gains) | 5% (3% base + 2% additional) | 30% (25% + 5%) for capital gains |
+
+From 2026, Mas Shevach (real estate capital gains) on investment properties is included in the surtax income calculation.
+
+The NIS 721,560 threshold is frozen through tax year 2027 — do not apply CPI uplifts.
+
+---
+
+## Section 6 — Nekudot Zikui (נקודות זיכוי — Tax credit points)
+
+Each point reduces the annual tax liability by NIS 2,904 (approximately NIS 242/month). Frozen 2025–2027.
+
+| Category | Points | Notes |
+|---|---|---|
+| Israeli resident (male) | 2.25 | Base entitlement |
+| Israeli resident (female) | 2.75 | Base (0.5 additional) |
+| New immigrant (Oleh Chadash — עולה חדש) | 3.0 year 1, 2.0 year 2, 1.0 year 3 | For 3.5 years from Aliyah date (post-2022: 8.5 points over 54 months) |
+| Returning resident (Toshav Chozer — תושב חוזר) | Same as Oleh Chadash | After 10+ years abroad |
+| Child born during tax year | 1.5 | Per child |
+| Children aged 1–5 | 2.5 per child | Per child |
+| Children aged 6–17 | 1.0 per child | Per child |
+| Child aged 18 | 0.5 | Last year of child credit |
+| Single parent | 1.0 | Divorced, widowed, or separated with custody |
+| Academic degree (BA) | 1.0 | Per year, up to 3 years matching study duration (graduates 2023+) |
+| Academic degree (MA) | 0.5 | For 2 years after completion (graduates 2023+) |
+| Vocational certificate | 1.0 | Per year, up to 3 years matching study duration (graduates 2023+) |
+| Disability (100% or blind) | 2.0 | Permanent |
+| Combat reserve soldiers | 0.5–1.0 | Based on reserve days (from 2026: 0.5 for 20+ days, 0.75 for 45+, 1.0 for 60+) |
+
+### Worked example
+
+Married woman (2.75 points) with two children aged 3 and 7 (2.5 + 1.0 = 3.5 points):
+- Total: 6.25 points × NIS 2,904 = **NIS 18,150** annual tax reduction
+
+---
+
+## Section 7 — Pension contribution credits
+
+### 7.1 Section 45א — 35% tax credit (Zikui)
+
+- Reduces tax liability directly by 35% of qualifying pension contribution
+- Applies to both employees and self-employed
+- Employee ceiling: qualifying contribution up to 7% of eligible salary (capped at NIS 23,232/month for 2026)
+- Self-employed ceiling: 5.5% of business income
+
+### 7.2 Section 47 — Pension deduction (Nikui)
+
+- Reduces taxable income by the contribution amount
+- Self-employed can deduct up to 11% of annual business income (capped at qualifying ceiling)
+- Employee contributions above the 7% Section 45א threshold can qualify
+
+### 7.3 Combined rule
+
+The same shekel cannot double-count. Self-employed filers typically structure deposits so part qualifies for 45א (credit) and part for 47 (deduction) within the 16.5% combined ceiling.
+
+### Worked example (self-employed, NIS 300,000 annual income)
+
+| Benefit | Calculation |
+|---|---|
+| Pension deposit | NIS 33,000 (11% of income) |
+| Section 47 deduction | Reduces taxable income by up to NIS 33,000 |
+| Section 45א credit | 35% of up to 5.5% of income = up to NIS 16,500 eligible → NIS 5,775 direct tax reduction |
+
+---
+
+## Section 8 — Rental income tax tracks
+
+Israeli law offers three options for taxing residential rental income:
+
+| Track | Rate | Conditions |
+|---|---|---|
+| Exempt | 0% | Monthly rent below NIS 5,654/month (2025–2027, frozen, no longer CPI-indexed) |
+| Flat rate | 10% | On gross rent, no deductions allowed. Payment by January 31 of following year |
+| Marginal | Progressive rates (10%–50%) | Full deduction of expenses (depreciation, mortgage interest, maintenance). Filed with Form 1301 |
+
+---
+
+## Section 9 — Capital gains
+
+### 9.1 Real estate (Mas Shevach — מס שבח)
+
+**Filing:** Within 30 days of sale (40 days if requesting exemption).
+
+**Calculation:**
+```
+Sale price
+− Original purchase price (adjusted for CPI)
+− Allowable deductions (purchase tax paid, legal fees, agent commission, renovation costs with receipts)
+= Real capital gain (Shevach Re'ali — שבח ריאלי)
+× 25% tax rate
+= Mas Shevach payable
+```
+
+**Single apartment exemption (Ptur Dira Yechida — פטור דירה יחידה):**
+- Seller's only residential property in Israel
+- Owned for at least 18 months
+- Sale price below NIS 5,008,000 (2024–2027, frozen)
+- Seller is an Israeli resident
+- Partial exemption applies proportionally above the ceiling
+
+**Linear method (Shita Liniarit — שיטה ליניארית):**
+For properties purchased before January 7, 2014, only the portion of gain attributable to the period after that date is taxed at 25%. The pre-2014 portion may be exempt or taxed at a lower historical rate.
+
+### 9.2 Securities (Forms 1322/1325)
+
+- 25% tax rate for individuals on traded securities
+- 30% if seller holds 10%+ of the company
+- Losses can offset gains within the same category in the same tax year
+- Capital losses carry forward to offset future capital gains (but not ordinary income)
+
+---
+
+## Section 10 — Advance tax payments (Mikdamot — מקדמות)
+
+### 10.1 How they work
+
+- The ITA sets a percentage rate based on prior year returns
+- Applied to bi-monthly turnover (total revenue excluding VAT)
+- New businesses receive a percentage based on industry statistics
+
+### 10.2 Payment schedule
+
+| Period | Months | Payment due |
+|---|---|---|
+| 1 | January – February | March 15 |
+| 2 | March – April | May 15 |
+| 3 | May – June | July 15 |
+| 4 | July – August | September 15 |
+| 5 | September – October | November 15 |
+| 6 | November – December | January 15 |
+
+### 10.3 Year-end reconciliation
+
+- Mikdamot paid > actual tax → refund (Hechzer Mas — החזר מס)
+- Mikdamot paid < actual tax → difference owed (plus possible interest)
+- Rate adjustment available mid-year if income changes significantly (Shinui Shiur Mikdamot — שינוי שיעור מקדמות)
+
+---
+
+## Section 11 — Corporate tax
+
+| Item | Rate / rule |
+|---|---|
+| Corporate tax rate | 23% flat on taxable profits |
+| Closely held company (Chevra Me'atim — חברה מעטים) | 2% annual tax on accumulated undistributed profits unless 6%+ distributed as dividends |
+| Form 6111 | Required for turnover > NIS 300,000 (including VAT) |
+| Deadline | May 31 (extensions available) |
+
+---
+
+## Section 12 — Form 6111 (standardized financial statements)
+
+Required for any business with annual turnover exceeding NIS 300,000 (including VAT).
+
+**Section A: Profit and Loss Statement**
+- Revenue by source, COGS, operating expenses, financial income/expenses, depreciation, net profit, tax adjustments
+
+**Section B: Balance Sheet**
+- Current assets, fixed assets, current liabilities, long-term liabilities, equity
+
+All amounts in NIS. Must match audited financial statements exactly. Submitted electronically via Shaam.
+
+---
+
+## Section 13 — Filing via Shaam online portal
+
+1. Register at misim.gov.il with Teudat Zehut (תעודת זהות) or company number
+2. Set up digital credentials (username + password + 2FA)
+3. Select the relevant form and tax year
+4. Enter data or upload from accounting software
+5. System validates data and flags errors
+6. Review calculated tax liability
+7. Submit electronically (receive confirmation number)
+8. Pay any tax owed via the payment portal
+
+**CPA authorization (Yipui Koach — ייפוי כוח):** Granted per-client, per-year via the Shaam portal. Allows CPA to submit returns and communicate with the ITA on behalf of the client.
+
+---
+
+## Section 14 — Worked examples
+
+### Example 1 — Freelancer annual return (Form 1301)
+
+**Scenario:** Male freelance developer (Osek Murshe), annual business revenue NIS 450,000, business expenses NIS 80,000, two children aged 4 and 8.
+
+**Working:**
+- Net business income: NIS 450,000 − NIS 80,000 = NIS 370,000
+- Credit points: 2.25 (resident) + 2.5 (child age 4) + 1.0 (child age 8) = 5.75 points
+- Tax credit: 5.75 × NIS 2,904 = NIS 16,698
+- Income tax (applying 2026 brackets to NIS 370,000):
+  - 10% on 84,120 = NIS 8,412
+  - 14% on 36,600 = NIS 5,124
+  - 20% on 107,280 = NIS 21,456
+  - 31% on 73,200 = NIS 22,692
+  - 35% on 68,800 = NIS 24,080
+  - **Gross tax: NIS 81,764**
+- Less credit points: NIS 81,764 − NIS 16,698 = **NIS 65,066 income tax**
+- Less mikdamot paid during year → net tax due or refund
+
+### Example 2 — Real estate capital gains (Mas Shevach)
+
+**Scenario:** Investment apartment sold for NIS 2,800,000, purchased in 2018 for NIS 1,600,000.
+
+**Working:**
+- Gross gain: NIS 2,800,000 − NIS 1,600,000 = NIS 1,200,000
+- Adjust for CPI change from 2018 to sale date
+- Deduct allowable expenses (purchase tax, legal fees, agent commission, documented renovation)
+- Real gain × 25% = Mas Shevach payable
+- File within 30 days of sale
+- Check surtax: if total annual income exceeds NIS 721,560, additional 5% on capital gain portion above threshold
+
+---
+
+## Section 15 — Common errors
+
+| Error | Why it matters |
+|---|---|
+| Using US form numbers (1040) | Israel uses Form 1301 for individuals |
+| Wrong deadline (April 30 for Form 1301) | April 30 is the legacy paper baseline; current online deadline is June 30 |
+| Single capital gains rate for everything | Securities: 25%; significant shareholders: 30%; real estate: varies |
+| Default credit point value without checking eligibility | Points vary by personal status; must calculate per individual |
+| Treating Mas Shevach and surtax as separate | From 2026, investment property Mas Shevach counts toward surtax income |
+| Forgetting Section 45א/47 pension credits | One of the most common filing errors for self-employed |
+
+---
+
+## Section 16 — Reference material
+
+| Resource | Reference |
+|---|---|
+| Tax Authority — Form 1301 service | https://www.gov.il/he/service/reporting-and-payment-2025-annual-tax-report-for-individuals |
+| Shaam filing portal | https://www.misim.gov.il |
+| Kol Zchut — income tax brackets | https://www.kolzchut.org.il/he/מדרגות_מס_הכנסה |
+| Kol Zchut — tax credit points | https://www.kolzchut.org.il/he/נקודות_זיכוי |
+| Kol Zchut — Mas Shevach | https://www.kolzchut.org.il/he/חישוב_מס_שבח |
+| Real estate taxation office | https://www.gov.il/he/departments/topics/land_taxation |
+| Income Tax Ordinance | https://www.nevo.co.il/law/70264 |
+
+---
+
+## Disclaimer
+
+> **חשוב:** כל המידע בקובץ זה מיועד למטרות מידע וחישוב בלבד. יש לבדוק כל עמדה מול רואה חשבון (Ro'eh Cheshbon) או יועץ מס (Yo'etz Mas) מוסמך לפני הגשה או פעולה.
+
+This skill and its outputs are provided for informational and computational purposes only and do not constitute tax, legal, or financial advice. Open Accountants and its contributors accept no liability for any errors, omissions, or outcomes arising from the use of this skill. All outputs must be reviewed and signed off by a qualified professional — such as a רואה חשבון (Ro'eh Cheshbon — CPA) or יועץ מס (Yo'etz Mas — tax advisor) licensed in Israel — before filing or acting upon.
+
+The most up-to-date, verified version of this skill is maintained at [openaccountants.com](https://openaccountants.com). Log in to access the latest version, request a professional review from a licensed accountant, and track updates as tax law changes.

--- a/skills/international/israel/il-tax-withholding.md
+++ b/skills/international/israel/il-tax-withholding.md
@@ -1,0 +1,243 @@
+---
+name: il-tax-withholding
+description: Use this skill when advising on Israeli tax withholding at source (ניכוי מס במקור — Nikui Mas BeMakor). Trigger on phrases like "withholding tax Israel", "nikui mas", "ishur nikui", "withholding certificate", "Form 856", "Form 102", "tium mas", "tax coordination", "ניכוי מס במקור", "אישור ניכוי", or any Israeli withholding tax query. Covers payments to suppliers, freelancers, landlords, and non-residents. ALWAYS read this skill before advising on Israeli withholding tax.
+version: 1.0
+jurisdiction: IL
+tax_year: 2025-2026
+category: international
+---
+
+# Israel Tax Withholding (Nikui Mas BeMakor — ניכוי מס במקור) Skill v1.0
+
+> **Based on work by [Skills IL](https://github.com/skills-il/tax-and-finance)**, licensed under MIT. Adapted for the OpenAccountants format.
+
+---
+
+## Section 1 — Quick reference
+
+| Field | Value |
+|---|---|
+| Country | Israel (מדינת ישראל) |
+| Scope | Withholding tax at source on payments to suppliers, freelancers, landlords, and non-residents |
+| Currency | NIS (Israeli New Shekel — ₪) |
+| Governing law | Income Tax Ordinance — Sections 164 and 170 |
+| Tax authority | Israel Tax Authority (ITA — רשות המיסים בישראל) |
+| Periodic report | Form 102 (טופס 102) — monthly or bi-monthly |
+| Annual reconciliation | Form 856 (טופס 856) — due April 30 |
+| Certificate verification | gmishurim service — https://taxinfo.taxes.gov.il/gmishurim/firstPage.aspx |
+| Contributor | Open Accountants Community |
+| Validated by | Pending — requires sign-off by Israel-licensed רואה חשבון or יועץ מס |
+
+### Conservative defaults
+
+| Ambiguity | Default |
+|---|---|
+| No withholding certificate provided | Apply default rate for payment type |
+| Certificate year not verified | Treat as expired — apply default rate |
+| Unknown whether payee is resident or non-resident | Treat as non-resident (25% rate) |
+| Payment type unclear | Apply 30% services default |
+| Unknown whether payer exceeds mandatory withholder threshold | Withhold to be safe |
+
+---
+
+## Section 2 — Default withholding rates
+
+### 2.1 Rates by payment type (no certificate)
+
+| Payment type | Hebrew | Default rate | ITO Section |
+|---|---|---|---|
+| Services — individuals, no certificate | שלומים עבור שירותים | 30% (up to ~47% for unverified payees) | 164 |
+| Services — companies, no certificate | שלומים עבור שירותים | 20–30% by ITA classification | 164 |
+| Rent — business/commercial property | שכירות נכסי נדל"ן | 35% | 170 |
+| Rent — residential property | שכר דירה למגורים | 30% | 170 |
+| Royalties | תמלוגים | 23% | 170 |
+| Interest | ריבית | 25% | 164 |
+| Dividends | דיבידנדים | 25–30% | 164 |
+| Payments to non-residents | תשלומים לתושבי חוץ | 25% | 170 |
+
+**The "20% flat" figure from older guidance is incorrect.** The ITA default for a service payment with no certificate is 30%, and the tax office can set it as high as ~47% for an unverified payee. A valid certificate is what brings the rate down (often to 0–5%).
+
+### 2.2 De minimis threshold
+
+A single payment to a payee below approximately NIS 5,520 (annually indexed) does not require withholding, unless cumulative payments to that payee cross the threshold. Always verify the current-year threshold.
+
+---
+
+## Section 3 — Withholding certificates
+
+### 3.1 Certificate types
+
+| Certificate | Hebrew | Purpose |
+|---|---|---|
+| Ishur Nikui Mas BeMakor | אישור ניכוי מס במקור | Reduced or zero withholding on payments received |
+| Ishur Tium Mas | אישור תיאום מס | Tax coordination for individuals with multiple payers/employers |
+| Ishur Nikui Mas Rechisha | אישור ניכוי מס רכישה | Real estate purchase tax withholding |
+
+### 3.2 Verifying a certificate
+
+When a payee presents a withholding certificate:
+
+1. **Verify the year** — certificates are valid for the current tax year (January–December) only
+2. **Verify the payee's identity** — business name, TIN (taxpayer identification number), and approved rate must match
+3. **Verify online** — use the ITA gmishurim service to confirm certificate status: https://taxinfo.taxes.gov.il/gmishurim/firstPage.aspx
+4. **Check validity period** — some certificates have shorter validity than the full year
+
+### 3.3 Obtaining a certificate
+
+1. Apply through the ITA online services (gmishurim system)
+2. Provide: TIN, financial statements, tax returns
+3. Certificate valid for the current tax year
+4. Renewal required annually — certificates expire December 31
+
+---
+
+## Section 4 — Withholding calculation
+
+### 4.1 Basic calculation
+
+```
+Payment amount (before VAT):    X NIS
+Withholding rate:               Y% (from certificate, or default)
+Withholding amount:             X × Y%
+Net payment to payee:           X − Withholding amount
+VAT (if applicable):            Calculated separately on the full pre-withholding amount
+```
+
+### 4.2 Worked example — Payment to freelancer
+
+**Scenario:** Business pays NIS 10,000 to a freelancer (Osek Murshe) for consulting, no certificate.
+
+| Line | Amount (NIS) |
+|---|---|
+| Gross payment (before VAT) | 10,000 |
+| Withholding (30% default) | 3,000 |
+| Net payment to freelancer | 7,000 |
+| VAT (18% on gross) | 1,800 |
+| Total paid by business | 8,800 (net 7,000 + VAT 1,800) |
+
+If the freelancer provides a valid certificate showing 2% withholding:
+
+| Line | Amount (NIS) |
+|---|---|
+| Gross payment (before VAT) | 10,000 |
+| Withholding (2% per certificate) | 200 |
+| Net payment to freelancer | 9,800 |
+| VAT (18% on gross) | 1,800 |
+| Total paid by business | 11,600 (net 9,800 + VAT 1,800) |
+
+### 4.3 Cross-border payments
+
+For payments to non-residents:
+- Default: 25% withholding
+- Tax treaty may reduce the rate — check the Israel–[country] treaty
+- Common treaties: US-Israel, UK-Israel, Germany-Israel, France-Israel
+- Treaty benefits require documentation and proper application
+- Treaty list: https://www.gov.il/he/departments/guides/taxation-agreements
+
+---
+
+## Section 5 — Periodic reporting (Form 102)
+
+### 5.1 Filing obligation
+
+Amounts withheld must be reported and paid to the ITA periodically:
+
+| Business size | Reporting frequency | Deadline |
+|---|---|---|
+| Small businesses | Bi-monthly | 15th of the month after the period |
+| Larger businesses / employers | Monthly | 15th of the following month |
+
+Late reporting and late payment carry penalties and indexation (הצמדה + ריבית).
+
+### 5.2 Mandatory withholder threshold
+
+Not every payer must withhold. A business becomes a mandatory withholding agent for service/asset payments once its turnover crosses the ITA's indexed turnover threshold. Below the threshold, withholding on service payments may not be required, but a business with employees still files Form 102 for payroll.
+
+---
+
+## Section 6 — Annual reconciliation (Form 856)
+
+### 6.1 Purpose
+
+Form 856 (טופס 856) is the annual withholding reconciliation for payments to suppliers and service providers. It is a detailed file listing every payee, the total paid, and the total withheld during the year, reconciled against the Form 102 deposits.
+
+### 6.2 Requirements
+
+| Field | Description |
+|---|---|
+| Supplier details | ID/company number, name, address |
+| Total payments | Gross amount paid during the year |
+| Tax withheld | Amount withheld at source |
+| Payment type | Services, goods, rent, commissions, etc. |
+
+### 6.3 Deadline
+
+**April 30** of the year following the reporting year.
+
+### 6.4 Workflow
+
+1. Deposit withheld amounts periodically via Form 102
+2. At year end, compile the per-payee detail file
+3. Submit Form 856 by April 30
+4. Form 856 is the PAYER's obligation as the withholding agent — separate from the payee's own annual return
+
+---
+
+## Section 7 — 2026 deduction-disallowance rule
+
+**Income Tax Circular 3/2026 (effective for payments made from 1.1.2026):**
+
+An expense or input-VAT deduction is disallowed where the payer:
+- Failed to withhold tax as required, OR
+- Failed to report the withholding as required, OR
+- Breached the Law for Reduction of the Use of Cash (cash over NIS 6,000 in a business-to-business transaction)
+
+**Treat a missed withholding or a cash-law breach as a deduction risk, not just a reporting issue.** The business loses the right to deduct the expense for income tax purposes AND loses the right to claim input VAT on the payment.
+
+---
+
+## Section 8 — Red flags and common errors
+
+| Error | Consequence |
+|---|---|
+| Using the legacy "20% for services" rate | Under-withholding; payer liable for the shortfall |
+| Not checking certificate expiry | Applying a reduced rate when certificate has expired |
+| Applying domestic rates to non-resident payments | Under-withholding; potential double taxation issues |
+| Using residential rent rate (30%) for commercial property | Should be 35% for commercial |
+| Cash payment over NIS 6,000 in B2B | Expense deduction disallowed under 2026 rules |
+| Missing Form 102 deadline | Penalties and indexation on late payment |
+| Not filing Form 856 by April 30 | Separate annual reconciliation penalty |
+
+---
+
+## Section 9 — Tier 2 items (require professional input)
+
+| Item | Why it needs a professional | What to ask |
+|---|---|---|
+| Tax treaty application | Treaty rates and documentation requirements vary by country | "Which country is the payee resident in? Provide the treaty article relied on." |
+| Withholding on real estate transactions | Complex exemption rules under Mas Rechisha | "Is this a residential or commercial property purchase?" |
+| Reclassification of payment type | ITA may challenge the classification | "Provide the service agreement or contract." |
+| Exemption claims by non-residents | Requires ITA approval and specific documentation | "Does the non-resident have a permanent establishment in Israel?" |
+
+---
+
+## Section 10 — Reference material
+
+| Resource | Reference |
+|---|---|
+| Israel Tax Authority (ITA) | https://www.gov.il/he/departments/israel_tax_authority |
+| Certificate lookup (gmishurim) | https://taxinfo.taxes.gov.il/gmishurim/firstPage.aspx |
+| Form 856 filing | https://www.gov.il/he/service/form-856 |
+| Income Tax Ordinance s.164/170 | https://www.nevo.co.il/law_html/law01/255_001.htm |
+| Tax treaty list | https://www.gov.il/he/departments/guides/taxation-agreements |
+| ITA filing portal (Shaam) | https://www.misim.gov.il |
+
+---
+
+## Disclaimer
+
+> **חשוב:** כל המידע בקובץ זה מיועד למטרות מידע וחישוב בלבד. יש לבדוק כל עמדה מול רואה חשבון (Ro'eh Cheshbon) או יועץ מס (Yo'etz Mas) מוסמך לפני הגשה או פעולה.
+
+This skill and its outputs are provided for informational and computational purposes only and do not constitute tax, legal, or financial advice. Open Accountants and its contributors accept no liability for any errors, omissions, or outcomes arising from the use of this skill. All outputs must be reviewed and signed off by a qualified professional — such as a רואה חשבון (Ro'eh Cheshbon — CPA) or יועץ מס (Yo'etz Mas — tax advisor) licensed in Israel — before filing or acting upon.
+
+The most up-to-date, verified version of this skill is maintained at [openaccountants.com](https://openaccountants.com). Log in to access the latest version, request a professional review from a licensed accountant, and track updates as tax law changes.

--- a/skills/international/japan/jp-bookkeeping.md
+++ b/skills/international/japan/jp-bookkeeping.md
@@ -1,0 +1,530 @@
+---
+name: jp-bookkeeping
+description: >
+  Use this skill whenever asked about bookkeeping or journal entries for a self-employed individual in Japan. Trigger on phrases like "bookkeeping Japan", "仕訳", "journal entry", "帳簿", "double-entry bookkeeping", "複式簿記", "general ledger", "勘定科目", "chart of accounts", "経費の記帳", "CSV import", "receipt recording", "レシート", "bank statement classification", "消費税区分", "tax classification", "家事按分", "business-personal split", "depreciation entry", "減価償却", "trial balance", "残高試算表", "settlement entries", "決算整理仕訳", or any question about recording transactions, classifying expenses, or maintaining books for a Japanese sole proprietorship. This skill covers the chart of accounts, journal entry patterns, consumption tax classification, CSV/receipt import workflows, and settlement adjustments. ALWAYS read this skill before touching any Japanese bookkeeping work.
+version: 1.0
+jurisdiction: JP
+tax_year: 2025
+category: international
+depends_on:
+  - jp-income-tax
+  - jp-consumption-tax
+---
+
+# Japan Bookkeeping (帳簿記帳) -- Self-Employed Skill v1.0
+
+> **Based on work by [Kazuki Nagata (@kazukinagata)](https://github.com/kazukinagata/shinkoku)**, licensed under MIT. Adapted for the OpenAccountants format.
+
+---
+
+## Section 1 -- Quick Reference
+
+| Field | Value |
+|---|---|
+| Country | Japan (日本) |
+| Bookkeeping Standard | Double-entry (複式簿記) for blue return JPY 650,000 deduction |
+| Fiscal Year | Calendar year (January 1 -- December 31) |
+| Currency | JPY only |
+| Legislation | Income Tax Act (所得税法), Consumption Tax Act (消費税法) |
+| Tax Authority | National Tax Agency (国税庁 NTA) |
+| Contributor | Open Accountants Community |
+| Validated by | Pending -- requires sign-off by a Japanese 税理士 (Zeirishi) |
+| Skill version | 1.0 |
+
+### Why This Matters
+
+| Bookkeeping Method | Blue Return Deduction | Requirements |
+|---|---|---|
+| Double-entry (複式簿記) + e-Tax | JPY 650,000 | Full general ledger, P/L, B/S, e-Tax filing |
+| Double-entry + paper filing | JPY 550,000 | Full general ledger, P/L, B/S |
+| Simplified bookkeeping (簡易簿記) | JPY 100,000 | Cash book, expense ledger |
+| White return (白色申告) | JPY 0 | Minimal records |
+
+---
+
+## Section 2 -- Chart of Accounts (勘定科目マスタ)
+
+### Account Code Structure
+
+| Range | Category | Japanese |
+|---|---|---|
+| 1xxx | Assets | 資産 |
+| 2xxx | Liabilities | 負債 |
+| 3xxx | Equity | 純資産 |
+| 4xxx | Revenue | 収益 |
+| 5xxx | Expenses | 費用 |
+
+### 1xxx -- Assets (資産)
+
+#### Current Assets (流動資産)
+
+| Code | Account Name | Japanese | Usage |
+|---|---|---|---|
+| 1001 | Cash | 現金 | Petty cash on hand |
+| 1002 | Ordinary deposit | 普通預金 | Business bank account |
+| 1003 | Checking deposit | 当座預金 | Business checking account |
+| 1004 | Time deposit | 定期預金 | Business fixed deposit |
+| 1010 | Accounts receivable | 売掛金 | Invoiced but unpaid sales |
+| 1020 | Notes receivable | 受取手形 | Received promissory notes |
+| 1030 | Inventory | 棚卸資産 | Stock, work-in-progress |
+| 1040 | Advance payments | 前払金 | Prepayments for goods/services |
+| 1041 | Prepaid expenses | 前払費用 | Insurance/rent paid in advance |
+| 1050 | Temporary payments | 立替金 | Amounts paid on behalf of others |
+| 1060 | Suspense payments | 仮払金 | Unclassified payments pending |
+| 1070 | Other receivables | 未収入金 | Non-trade receivables |
+| 1080 | Loans receivable | 貸付金 | Loans to others |
+| 1090 | Provisional consumption tax | 仮払消費税 | Input CT paid (general method only) |
+
+#### Fixed Assets (固定資産)
+
+| Code | Account Name | Japanese | Useful Life (typical) |
+|---|---|---|---|
+| 1100 | Buildings | 建物 | 22-47 years |
+| 1101 | Building fixtures | 建物附属設備 | 3-18 years |
+| 1110 | Machinery | 機械装置 | 4-17 years |
+| 1120 | Vehicles | 車両運搬具 | 6 years (standard) |
+| 1130 | Tools and equipment | 工具器具備品 | 4-15 years |
+| 1140 | Land | 土地 | Not depreciable |
+| 1150 | Software | ソフトウェア | 3-5 years |
+| 1160 | Lump-sum depreciation assets | 一括償却資産 | 3 years (uniform) |
+
+#### Owner's Account (事業主勘定)
+
+| Code | Account Name | Japanese | Usage |
+|---|---|---|---|
+| 1200 | Owner's draws | 事業主貸 | Business funds used personally |
+
+### 2xxx -- Liabilities (負債)
+
+| Code | Account Name | Japanese | Usage |
+|---|---|---|---|
+| 2001 | Accounts payable | 買掛金 | Unpaid purchases |
+| 2010 | Notes payable | 支払手形 | Issued promissory notes |
+| 2020 | Short-term borrowings | 短期借入金 | Loans due within 1 year |
+| 2030 | Accrued expenses | 未払金 | Unpaid operating expenses |
+| 2031 | Accrued liabilities | 未払費用 | Accrued but unpaid expenses |
+| 2040 | Advance receipts | 前受金 | Payments received before delivery |
+| 2050 | Withholding deposits | 預り金 | Withheld income tax, social insurance |
+| 2060 | Suspense receipts | 仮受金 | Unclassified receipts pending |
+| 2070 | Accrued consumption tax | 未払消費税 | CT due from final return |
+| 2080 | Accrued business tax | 未払事業税 | Enterprise tax payable |
+| 2100 | Long-term borrowings | 長期借入金 | Loans due after 1 year |
+
+### 3xxx -- Equity (純資産)
+
+| Code | Account Name | Japanese | Usage |
+|---|---|---|---|
+| 3001 | Capital | 元入金 | Opening capital (adjusted at year-start) |
+| 3010 | Owner's contributions | 事業主借 | Personal funds used for business |
+| 3020 | Pre-deduction income | 控除前所得金額 | Blue return pre-deduction income |
+
+### 4xxx -- Revenue (収益)
+
+| Code | Account Name | Japanese | CT Classification | Usage |
+|---|---|---|---|---|
+| 4001 | Sales | 売上 | Taxable (課税) | Primary business revenue |
+| 4010 | Sales returns/discounts | 売上値引・戻り | Taxable | Returns, discounts |
+| 4100 | Interest income | 受取利息 | Non-taxable (非課税) | Bank interest |
+| 4110 | Miscellaneous income | 雑収入 | Taxable | Non-core business income |
+| 4120 | Personal consumption | 家事消費等 | Taxable | Self-consumption of business goods |
+
+### 5xxx -- Expenses (費用)
+
+| Code | Account Name | Japanese | CT Classification | Notes |
+|---|---|---|---|---|
+| 5001 | Purchases | 仕入 | Taxable | Cost of goods |
+| 5100 | Taxes and dues | 租税公課 | Out of scope | Business tax, stamps, property tax |
+| 5110 | Packing and shipping | 荷造運賃 | Taxable (10%) | |
+| 5120 | Utilities | 水道光熱費 | Taxable (10%) | Home office: apportion |
+| 5130 | Travel and transportation | 旅費交通費 | Taxable (10%) | IC card records acceptable |
+| 5140 | Communication | 通信費 | Taxable (10%) | Phone, internet; apportion if mixed |
+| 5150 | Advertising | 広告宣伝費 | Taxable (10%) | |
+| 5160 | Entertainment | 接待交際費 | Taxable (10%) | Document attendees and purpose |
+| 5170 | Insurance | 損害保険料 | Non-taxable | Business insurance only |
+| 5180 | Repairs | 修繕費 | Taxable (10%) | |
+| 5190 | Consumables | 消耗品費 | Taxable (10%) | Items under JPY 100,000 |
+| 5200 | Depreciation | 減価償却費 | Out of scope | Year-end adjustment entry |
+| 5210 | Welfare | 福利厚生費 | Taxable | Not for sole proprietor personally |
+| 5220 | Salaries | 給料賃金 | Out of scope | Employee wages |
+| 5230 | Subcontracting | 外注工賃 | Taxable (10%) | |
+| 5240 | Interest expense | 利子割引料 | Non-taxable | Loan interest |
+| 5250 | Rent | 地代家賃 | Taxable (10%) | Business premises; residential is non-taxable |
+| 5260 | Bad debts | 貸倒金 | Out of scope | |
+| 5270 | Miscellaneous | 雑費 | Taxable (10%) | Bank fees, minor items |
+| 5280 | Family employee wages | 専従者給与 | Out of scope | Blue return family employees |
+| 5290 | Books and subscriptions | 新聞図書費 | Taxable | Newspapers (subscription) at 8% reduced |
+| 5300 | Training | 研修費 | Taxable (10%) | |
+| 5310 | Service fees | 支払手数料 | Taxable (10%) | Bank transfer fees, payment processor fees |
+| 5320 | Vehicle expenses | 車両費 | Taxable (10%) | Fuel, parking, tolls |
+| 5330 | Meeting expenses | 会議費 | Taxable | |
+| 5340 | Membership dues | 諸会費 | Taxable (10%) | Industry associations |
+| 5350 | Lease payments | リース料 | Taxable (10%) | |
+| 5360 | Office supplies | 事務用品費 | Taxable (10%) | |
+| 5370 | Software expenses | ソフトウェア費 | Taxable (10%) | SaaS subscriptions under JPY 100,000 |
+
+---
+
+## Section 3 -- Consumption Tax Classification Rules
+
+### Four Requirements for Taxability
+
+A transaction is subject to consumption tax only if ALL four conditions are met:
+
+1. **Domestic transaction** -- occurs within Japan
+2. **Performed by a business** -- as part of business operations
+3. **For consideration** -- payment is received/made
+4. **Transfer of goods, lease of assets, or provision of services**
+
+### Classification Decision Tree
+
+```
+Is the transaction domestic? ─── No ──→ Out of scope (不課税) or Export exempt (免税)
+        │
+       Yes
+        ↓
+Is it by a business for consideration? ─── No ──→ Out of scope (不課税)
+        │
+       Yes
+        ↓
+Is it listed as non-taxable (非課税)? ─── Yes ──→ Non-taxable
+        │
+       No
+        ↓
+Taxable (課税) at standard 10% or reduced 8%
+```
+
+### Reduced Rate (8%) Items
+
+| Category | Examples | Rate |
+|---|---|---|
+| Food and beverages (takeout) | Groceries, takeout meals, deliveries | 8% |
+| Subscription newspapers | Print newspapers delivered 2+ times/week | 8% |
+
+**NOT reduced rate (10%):** Alcohol, dine-in meals, catering, e-newspapers, bottled water from tap.
+
+### Home Office Apportionment (家事按分)
+
+These accounts commonly require business-personal splitting:
+
+| Account | Apportionment Method |
+|---|---|
+| Utilities (水道光熱費 5120) | Floor area ratio or time-based ratio |
+| Communication (通信費 5140) | Business usage time ratio |
+| Rent (地代家賃 5250) | Floor area ratio |
+| Vehicle expenses (車両費 5320) | Business mileage ratio |
+
+**NTA guidelines:** The apportionment method must be reasonable, documented, and applied consistently year to year. Typical range for full-time home workers: 20-50%.
+
+---
+
+## Section 4 -- Common Journal Entry Patterns
+
+### 4.1 Revenue Entries
+
+**Client payment received (売上入金):**
+```
+Debit:  1002 普通預金 (Ordinary deposit)     110,000
+Credit: 4001 売上 (Sales)                    110,000
+Memo: ○○社 Web制作費 Invoice #2025-001  CT: 10%
+```
+
+**Invoiced but unpaid (売掛金計上):**
+```
+Debit:  1010 売掛金 (Accounts receivable)    110,000
+Credit: 4001 売上 (Sales)                    110,000
+Memo: ○○社 コンサル料 Invoice #2025-002  CT: 10%
+```
+
+**Subsequent collection of receivable:**
+```
+Debit:  1002 普通預金                        110,000
+Credit: 1010 売掛金                          110,000
+Memo: ○○社 Invoice #2025-002 入金
+```
+
+**Payment with withholding (源泉徴収あり):**
+```
+Debit:  1002 普通預金                         89,790
+Debit:  1070 未収入金 (Withholding credit)    10,210
+Credit: 4001 売上                            100,000
+Memo: △△社 デザイン料 10.21% withholding  CT: 10%
+```
+
+### 4.2 Expense Entries
+
+**Expense from business account (事業用口座から):**
+```
+Debit:  5190 消耗品費 (Consumables)            5,500
+Credit: 1002 普通預金                          5,500
+Memo: Amazon ワイヤレスキーボード  CT: 10%
+```
+
+**Expense paid from personal funds (事業主借):**
+```
+Debit:  5130 旅費交通費 (Travel)               1,200
+Credit: 3010 事業主借 (Owner's contribution)   1,200
+Memo: JR 新宿→渋谷 Client meeting roundtrip  CT: 10%
+```
+
+**Business funds used personally (事業主貸):**
+```
+Debit:  1200 事業主貸 (Owner's draw)          50,000
+Credit: 1002 普通預金                         50,000
+Memo: Personal living expense withdrawal
+```
+
+**SaaS subscription (月額サービス):**
+```
+Debit:  5370 ソフトウェア費 (Software)         2,200
+Credit: 1002 普通預金                          2,200
+Memo: Adobe Creative Cloud monthly  CT: 10%
+```
+
+**Rent with home office apportionment (家事按分あり):**
+```
+Debit:  5250 地代家賃 (Rent) -- 30% business   36,000
+Debit:  1200 事業主貸 -- 70% personal          84,000
+Credit: 1002 普通預金                         120,000
+Memo: 家賃 1月分 按分率30%  CT: 10% (business portion)
+```
+
+### 4.3 Social Insurance & Tax Payments
+
+**National pension (国民年金):**
+```
+Debit:  1200 事業主貸                         16,590
+Credit: 1002 普通預金                         16,590
+Memo: 国民年金保険料 4月分
+```
+*National pension is an income deduction (所得控除), NOT a business expense. Record as owner's draw.*
+
+**National health insurance (国民健康保険):**
+```
+Debit:  1200 事業主貸                         35,000
+Credit: 1002 普通預金                         35,000
+Memo: 国民健康保険料 1期分
+```
+*Same treatment -- income deduction, not business expense.*
+
+**Income tax / resident tax payments:**
+```
+Debit:  1200 事業主貸                        150,000
+Credit: 1002 普通預金                        150,000
+Memo: 所得税 確定申告分 -- not deductible
+```
+
+### 4.4 Fixed Asset Entries
+
+**Asset purchase under JPY 100,000 (少額減価償却):**
+```
+Debit:  5190 消耗品費                         88,000
+Credit: 1002 普通預金                         88,000
+Memo: Printer purchase -- immediate expense  CT: 10%
+```
+
+**Asset purchase JPY 100,000--299,999 (blue return special expensing):**
+```
+Debit:  5200 減価償却費                      250,000
+Credit: 1130 工具器具備品                    250,000
+Memo: MacBook Air -- blue return immediate expensing (aggregate ≤ JPY 3M)
+```
+
+**Asset purchase JPY 300,000+ (standard depreciation):**
+```
+Purchase:
+Debit:  1130 工具器具備品                    350,000
+Credit: 1002 普通預金                        350,000
+Memo: Desktop PC  CT: 10%
+
+Year-end depreciation (declining balance, 4-year, rate 0.500):
+Debit:  5200 減価償却費                      175,000
+Credit: 1130 工具器具備品                    175,000
+Memo: PC depreciation Y1 (350,000 × 0.500)
+```
+
+---
+
+## Section 5 -- Depreciation Rules (減価償却)
+
+### Methods Available
+
+| Method | Japanese | Default For |
+|---|---|---|
+| Declining balance | 定率法 | Most assets for sole proprietors |
+| Straight-line | 定額法 | Buildings acquired after April 2016 |
+
+### Common Useful Lives and Rates
+
+| Asset | Useful Life | Declining Balance Rate | Straight-Line Rate |
+|---|---|---|---|
+| Personal computers | 4 years | 0.500 | 0.250 |
+| Servers | 5 years | 0.400 | 0.200 |
+| Office furniture (metal) | 15 years | 0.133 | 0.067 |
+| Office furniture (wood) | 8 years | 0.250 | 0.125 |
+| Motor vehicles (standard) | 6 years | 0.333 | 0.167 |
+| Software (purchased) | 5 years | 0.400 | 0.200 |
+| Software (internally developed) | 3 years | 0.667 | 0.333 |
+
+### Expensing Thresholds
+
+| Acquisition Cost | Treatment |
+|---|---|
+| Under JPY 100,000 | Expense immediately (少額減価償却資産) |
+| JPY 100,000 -- 199,999 | Option: 3-year uniform depreciation (一括償却資産) |
+| Under JPY 300,000 (blue return) | Option: immediate expensing, aggregate limit JPY 3,000,000/year |
+| JPY 300,000+ | Standard depreciation over useful life |
+
+### Rounding
+
+All depreciation amounts are rounded down to the nearest JPY 1 (1円未満切捨て). Business-use apportionment is also rounded down to JPY 1.
+
+---
+
+## Section 6 -- Settlement Adjustments (決算整理仕訳)
+
+At year-end (December 31), record the following adjustments:
+
+### 6.1 Depreciation (減価償却)
+
+Record annual depreciation for all fixed assets. See Section 5 for rates.
+
+### 6.2 Prepaid Expenses (前払費用)
+
+If insurance, rent, or subscriptions are paid in advance beyond December 31:
+```
+Debit:  1041 前払費用                         XX,XXX
+Credit: 5250 地代家賃 (or other expense)      XX,XXX
+Memo: January rent paid in December -- reverse to next year
+```
+
+### 6.3 Accrued Expenses (未払費用)
+
+For expenses incurred but not yet paid by December 31:
+```
+Debit:  5120 水道光熱費                       XX,XXX
+Credit: 2031 未払費用                         XX,XXX
+Memo: December electricity bill -- to be paid in January
+```
+
+### 6.4 Inventory (棚卸)
+
+If you hold physical inventory, count and value it at December 31:
+```
+Year-end inventory:
+Debit:  1030 棚卸資産                        XXX,XXX
+Credit: 5001 仕入 (Purchases)               XXX,XXX
+Memo: Closing inventory valuation
+```
+
+### 6.5 Bad Debt Allowance (貸倒引当金)
+
+Blue return filers may set aside an allowance for doubtful accounts (up to 5.5% of receivables for certain businesses):
+```
+Debit:  5260 貸倒金                          XX,XXX
+Credit: (Allowance account)                  XX,XXX
+Memo: Bad debt allowance year-end
+```
+
+### 6.6 Consumption Tax Settlement (消費税の精算)
+
+For general method (本則課税) taxpayers, settle provisional CT accounts:
+```
+Debit:  2070 未払消費税                      XXX,XXX
+Credit: 1090 仮払消費税                      XXX,XXX
+Memo: CT settlement -- net payable transferred
+```
+
+---
+
+## Section 7 -- Data Import Workflows
+
+### 7.1 CSV Bank Statement Import
+
+**Workflow:**
+1. Export CSV from your bank (see bank formats in `jp-income-tax` skill, Section 8)
+2. Identify columns: date (日付/取引日), description (摘要/内容), debit (支払/出金), credit (入金/預入), balance (残高)
+3. Classify each transaction using the pattern library in `jp-income-tax` skill, Section 3
+4. Generate journal entries and review before recording
+5. Check for duplicates if importing from multiple sources
+
+### 7.2 Receipt / Invoice Processing
+
+**For each receipt or invoice:**
+1. Extract: date, vendor, amount, tax amount, item description
+2. Determine account code based on expense category
+3. Check for qualified invoice elements (T-number, rate-separated amounts) if claiming input tax credit
+4. Record the journal entry
+5. Store the receipt image/PDF for record retention (7 years for blue return filers)
+
+### 7.3 Account Code Estimation Rules
+
+| Transaction Description Pattern | Suggested Account |
+|---|---|
+| 電車, バス, タクシー, JR, 新幹線 | 5130 旅費交通費 |
+| Amazon, ヨドバシ, ビックカメラ | 5190 消耗品費 or 5360 事務用品費 |
+| ドコモ, au, ソフトバンク, 楽天モバイル | 5140 通信費 |
+| NURO, フレッツ, インターネット | 5140 通信費 |
+| 東京電力, ガス, 水道 | 5120 水道光熱費 |
+| 家賃, 賃料, オフィス | 5250 地代家賃 |
+| Adobe, Microsoft, Google Workspace | 5370 ソフトウェア費 |
+| Google Ads, Meta Ads, 広告 | 5150 広告宣伝費 |
+| 振込手数料, 決済手数料 | 5310 支払手数料 |
+| 飲食, レストラン, 接待 | 5160 接待交際費 or 5330 会議費 |
+
+---
+
+## Section 8 -- Validation Checklist
+
+Before closing the books for the year, verify:
+
+- [ ] All bank transactions reconcile with the general ledger
+- [ ] Accounts receivable balance matches outstanding invoices
+- [ ] Accounts payable balance matches unpaid bills
+- [ ] Depreciation is recorded for all fixed assets
+- [ ] Home office apportionment is consistent with prior year
+- [ ] National pension and health insurance are NOT recorded as business expenses
+- [ ] Owner's draws and contributions balance is reasonable
+- [ ] Consumption tax classification is correct for all entries
+- [ ] Inventory is counted and valued (if applicable)
+- [ ] Trial balance (残高試算表) debits = credits
+- [ ] B/S: total assets = total liabilities + equity
+
+---
+
+## Section 9 -- Record Retention Requirements
+
+| Document Type | Retention Period | Notes |
+|---|---|---|
+| General ledger (総勘定元帳) | 7 years | Blue return requirement |
+| Journal (仕訳帳) | 7 years | Blue return requirement |
+| Cash book (現金出納帳) | 7 years | |
+| Invoices issued (請求書控え) | 7 years | |
+| Invoices received (請求書) | 7 years | Must retain qualified invoices for input tax credit |
+| Receipts (領収書) | 7 years | |
+| Bank statements (通帳) | 7 years | |
+| Contracts (契約書) | 7 years | |
+| Withholding certificates (源泉徴収票) | 7 years | |
+
+**Electronic bookkeeping (電子帳簿保存法):** From January 2024, electronic transaction records (e-invoices, e-receipts) must be stored electronically. Paper printouts alone are no longer sufficient for electronic transactions.
+
+---
+
+## PROHIBITIONS
+
+- NEVER record national pension (国民年金) or health insurance (国民健康保険) as a business expense -- they are income deductions (所得控除), recorded through owner's draws (事業主貸)
+- NEVER record income tax or resident tax as a business expense -- they are not deductible
+- NEVER allow a debit/credit mismatch in any journal entry
+- NEVER use an account code not in the chart of accounts without explicit confirmation
+- NEVER skip the home office apportionment for mixed-use expenses
+- NEVER claim input tax credit (仕入税額控除) without a qualified invoice (from October 2023 onward, subject to transitional measures)
+- NEVER apply the 8% reduced rate to dine-in meals, alcohol, or catering
+- NEVER auto-record entries without explicit confirmation from the taxpayer
+- NEVER present bookkeeping outputs as final -- all entries should be reviewed by a 税理士
+
+---
+
+## Disclaimer
+
+This skill and its outputs are provided for informational and computational purposes only and do not constitute tax, legal, or financial advice. Open Accountants and its contributors accept no liability for any errors, omissions, or outcomes arising from the use of this skill. All outputs must be reviewed and signed off by a qualified professional (such as a 税理士 or equivalent licensed practitioner in Japan) before filing or acting upon.
+
+The most up-to-date, verified version of this skill is maintained at [openaccountants.com](https://openaccountants.com). Log in to access the latest version, request a professional review from a licensed accountant, and track updates as tax law changes.

--- a/skills/international/japan/jp-etax-filing.md
+++ b/skills/international/japan/jp-etax-filing.md
@@ -1,0 +1,499 @@
+---
+name: jp-etax-filing
+description: >
+  Use this skill whenever asked about filing a Japanese tax return electronically via e-Tax (確定申告書等作成コーナー). Trigger on phrases like "e-Tax", "電子申告", "e-Tax filing", "確定申告書等作成コーナー", "how to file taxes in Japan online", "e-Tax submission", "マイナンバーカード認証", "QR code authentication e-Tax", "blue return financial statements", "決算書入力", "所得税申告書", "consumption tax return filing", "消費税申告書作成", or any question about the step-by-step process of filing income tax or consumption tax returns electronically in Japan. This skill covers the complete e-Tax workflow: authentication, financial statement entry (決算書), income tax return entry (申告書B), consumption tax return entry, and electronic submission. ALWAYS read this skill before assisting with any Japan e-Tax filing work.
+version: 1.0
+jurisdiction: JP
+tax_year: 2025
+category: international
+depends_on:
+  - jp-income-tax
+  - jp-consumption-tax
+---
+
+# Japan e-Tax Filing (電子申告) -- Self-Employed Skill v1.0
+
+> **Based on work by [Kazuki Nagata (@kazukinagata)](https://github.com/kazukinagata/shinkoku)**, licensed under MIT. Adapted for the OpenAccountants format.
+
+---
+
+## Section 1 -- Quick Reference
+
+| Field | Value |
+|---|---|
+| Country | Japan (日本) |
+| System | e-Tax (国税電子申告・納税システム) |
+| Portal URL | https://www.keisan.nta.go.jp/ |
+| Portal Name | 確定申告書等作成コーナー (Tax Return Preparation Corner) |
+| Authentication | My Number Card (マイナンバーカード) via smartphone QR code or IC card reader |
+| Tax Authority | National Tax Agency (国税庁 NTA) |
+| Filing Deadline (Income Tax) | 15 March of the following year |
+| Filing Deadline (Consumption Tax) | 31 March of the following year |
+| Contributor | Open Accountants Community |
+| Validated by | Pending -- requires sign-off by a Japanese 税理士 (Zeirishi) |
+| Skill version | 1.0 |
+
+---
+
+## Section 2 -- Prerequisites
+
+Before starting the e-Tax filing process, ensure:
+
+1. **Income tax calculations are complete** -- use the `jp-income-tax` skill to compute all figures
+2. **Financial statements (決算書) are prepared** -- P/L (損益計算書) and B/S (貸借対照表) for blue return filers
+3. **Consumption tax calculations are complete** (if applicable) -- use the `jp-consumption-tax` skill
+4. **Taxpayer profile is ready** -- name, address, My Number (マイナンバー), tax office name, business type, trade name (屋号)
+5. **Authentication method is available** -- My Number Card + smartphone with マイナポータル app, or IC card reader
+
+### Required Documents at Hand
+
+| Document | Japanese Name | Purpose |
+|---|---|---|
+| My Number Card | マイナンバーカード | Authentication + electronic signature |
+| Withholding certificates | 源泉徴収票 | Employment income data |
+| Payment records | 支払調書 | Business withholding data |
+| Insurance premium certificates | 控除証明書 | Deduction claims |
+| Prior year return (optional) | 前年の確定申告書 | Reference for estimated tax |
+| Bank account details | 口座情報 | Refund account or payment method |
+
+---
+
+## Section 3 -- e-Tax Screen Flow Overview
+
+The 確定申告書等作成コーナー follows this overall flow:
+
+```
+Step 1: Submission Method Selection (CC-AA-010)
+    ↓
+Step 2: Return Type Selection (CC-AE-090)
+    ↓
+Step 3: My Number Portal Linkage (CC-AE-600)
+    ↓
+Step 4: Pre-submission Confirmation (CC-AA-024)
+    ↓
+Step 5: QR Code Authentication (CC-AA-440) ★ Manual step
+    ↓
+Step 6: Financial Statements Entry (決算書コーナー)
+    ├── P/L Entry (損益計算書)
+    ├── Blue Return Deduction (青色申告特別控除)
+    ├── B/S Entry (貸借対照表)
+    ├── Income Confirmation (所得確認)
+    └── Address/Name Entry (住所・氏名)
+    ↓
+Step 7: Income Tax Return Entry (所得税コーナー)
+    ├── Income Type Selection (所得選択)
+    ├── Income Entry by Type (収入入力)
+    ├── Deductions Entry -- Part 1 (控除入力1/2)
+    ├── Deductions Entry -- Part 2 (控除入力2/2)
+    ├── Calculation Result Confirmation (計算結果確認)
+    ├── Payment Method (納付方法)
+    ├── Resident Tax Settings (住民税)
+    ├── Personal Information (基本情報)
+    └── My Number Entry (マイナンバー)
+    ↓
+Step 8: Consumption Tax Return (消費税コーナー) -- if applicable
+    ├── Method Determination (条件判定)
+    ├── Income Category Selection (所得区分選択)
+    ├── Sales Entry (売上入力)
+    └── Calculation Result (計算結果)
+    ↓
+Step 9: Electronic Signature & Submission ★ Manual step
+    ↓
+Step 10: Data File Save (.data)
+```
+
+---
+
+## Section 4 -- Step-by-Step Filing Workflow
+
+### 4.1 Submission Method Selection (提出方法の選択)
+
+**Screen: CC-AA-010**
+
+| Question | Answer |
+|---|---|
+| Do you have a My Number Card (マイナンバーカード)? | Yes (はい) |
+| Do you have a compatible smartphone or IC card reader? | Yes (はい) |
+| Method | Select "Use Smartphone" (スマートフォンを使用する) |
+
+### 4.2 Return Type Selection (申告書等の選択)
+
+**Screen: CC-AE-090**
+
+Select the appropriate return type for the tax year:
+
+| Option | When to Select |
+|---|---|
+| Income Tax (所得税) | Salary income only, no business income |
+| Financial Statements + Income Tax (決算書・収支内訳書＋所得税) | **Self-employed with business income** -- most common |
+| Consumption Tax (消費税) | File separately after income tax |
+| Gift Tax (贈与税) | Gift tax only |
+
+**For self-employed taxpayers, select "Financial Statements + Income Tax".**
+
+### 4.3 My Number Portal Linkage
+
+**Screen: CC-AE-600**
+
+Select "Do not use My Number Portal linkage" (マイナポータル連携を利用しない) unless you have already configured the linkage.
+
+### 4.4 Pre-submission Confirmation
+
+**Screen: CC-AA-024**
+
+Review the terms of use and click "Agree and proceed" (利用規約に同意して次へ).
+
+### 4.5 QR Code Authentication (QRコード認証)
+
+**Screen: CC-AA-440**
+
+**This requires manual action by the taxpayer:**
+
+1. A QR code appears on screen
+2. Open the マイナポータル app on your smartphone
+3. Scan the QR code displayed on the computer screen
+4. Authenticate with your My Number Card (hold card to phone's NFC reader)
+5. Enter your 4-digit PIN (利用者証明用電子証明書の暗証番号)
+6. The screen will automatically proceed after successful authentication
+
+**Troubleshooting:** If the QR code does not display, ensure you are using a supported browser (Chrome or Edge on Windows, Safari on macOS). Linux is not officially supported.
+
+---
+
+## Section 5 -- Financial Statements Entry (決算書コーナー)
+
+This section applies to self-employed taxpayers filing a blue return (青色申告).
+
+### 5.1 Select Statement Type
+
+| Option | When to Select |
+|---|---|
+| Blue Return Financial Statements (青色申告決算書) | Blue return filers (most common) |
+| Income/Expense Statement (収支内訳書) | White return filers |
+| Blue Return -- Cash Basis (青色申告決算書・現金主義用) | Cash-basis filers (rare) |
+
+### 5.2 Profit & Loss Statement (損益計算書) Entry
+
+Enter the fiscal period (typically January 1 -- December 31) and the following data:
+
+**Revenue Section:**
+- Monthly sales breakdown (月別売上) -- 12 months
+- Monthly cost of goods sold (月別仕入) -- if applicable
+- Personal consumption (家事消費等)
+- Miscellaneous income (雑収入)
+
+**Expense Section (経費):**
+
+| Line | Expense Category | Japanese Name |
+|---|---|---|
+| 8 | Taxes and public charges | 租税公課 |
+| 9 | Packing and shipping | 荷造運賃 |
+| 10 | Utilities | 水道光熱費 |
+| 11 | Travel and transportation | 旅費交通費 |
+| 12 | Communication | 通信費 |
+| 13 | Advertising | 広告宣伝費 |
+| 14 | Entertainment | 接待交際費 |
+| 15 | Insurance | 損害保険料 |
+| 16 | Repairs | 修繕費 |
+| 17 | Consumables | 消耗品費 |
+| 18 | Depreciation | 減価償却費 (sub-form entry) |
+| 19 | Welfare | 福利厚生費 |
+| 20 | Salaries | 給料賃金 (sub-form entry) |
+| 21 | Subcontracting | 外注工賃 |
+| 22 | Interest | 利子割引料 (sub-form entry) |
+| 23 | Rent | 地代家賃 (sub-form entry) |
+| 24 | Bad debts | 貸倒金 |
+| 25 | Tax adviser fees | 税理士等の報酬 |
+| 26-30 | Custom expense categories | 任意科目 |
+| 31 | Miscellaneous | 雑費 |
+
+### 5.3 Blue Return Special Deduction (青色申告特別控除)
+
+The system presents a Q&A to determine the deduction amount:
+
+| Deduction | Conditions |
+|---|---|
+| JPY 650,000 | Double-entry bookkeeping + e-Tax submission (required for this amount) |
+| JPY 550,000 | Double-entry bookkeeping + paper submission |
+| JPY 100,000 | Simplified bookkeeping |
+
+**If filing via e-Tax and selecting JPY 650,000, the system will verify e-Tax submission is being used. Paper filing with this selection will trigger error KS-E10089.**
+
+### 5.4 Balance Sheet (貸借対照表) Entry
+
+Enter opening and closing balances for:
+
+**Assets (資産の部):**
+Cash, deposits, accounts receivable, securities, inventory, prepayments, buildings, equipment, vehicles, tools/fixtures, land, and custom asset accounts.
+
+**Liabilities & Equity (負債・資本の部):**
+Notes payable, accounts payable, borrowings, accrued expenses, deposits received, allowance for bad debts, capital (元入金), owner's draws (事業主貸), owner's contributions (事業主借), and pre-deduction income.
+
+**The system will reject the entry (error KS-E40003) if total assets ≠ total liabilities + equity at year-end.**
+
+### 5.5 Address and Name Entry (住所・氏名等)
+
+Enter personal details, business information, and the submitting tax office:
+
+| Field | Details |
+|---|---|
+| Postal code | 7-digit postal code |
+| Prefecture and address | Full residential address |
+| Business address | If different from home |
+| Tax office | Submitting tax office name (所轄税務署) |
+| Full name | In kanji |
+| Business type | e.g., IT consultant, designer, writer |
+| Trade name (屋号) | If applicable |
+| Submission date | Date of filing |
+
+---
+
+## Section 6 -- Income Tax Return Entry (所得税コーナー)
+
+After completing financial statements, the system transitions to the income tax return.
+
+### 6.1 Income Type Selection (所得種類の選択)
+
+Check all applicable income types:
+
+| Income Type | Japanese | Typical Selection |
+|---|---|---|
+| Employment | 給与 | If also employed |
+| Business (commercial) | 事業（営業等） | **Self-employed: always check** |
+| Business (agriculture) | 事業（農業） | If applicable |
+| Real estate | 不動産 | If rental income |
+| Miscellaneous (business/other) | 雑（業務・その他） | Side income, crypto |
+| Public pension | 公的年金等 | If receiving pension |
+| Retirement | 退職金 | If received |
+| Stocks/dividends | 株式等 | If applicable |
+| Temporary income | 一時 | Insurance payouts, prizes |
+
+### 6.2 Income Entry by Type
+
+For each selected income type, enter the relevant data through dedicated sub-forms:
+
+**Employment income (給与所得):** Enter data from withholding certificates (源泉徴収票) -- payment amount, withheld tax, social insurance premiums, and employer details.
+
+**Business income (事業所得):** Automatically populated from the financial statements entered in Step 5.
+
+**Miscellaneous income (雑所得):** Enter revenue, expenses, and payer details for each item.
+
+### 6.3 Deductions Entry -- Part 1 (支出系控除)
+
+| Deduction | Japanese | Data Source |
+|---|---|---|
+| Social insurance premiums | 社会保険料控除 | Partially from withholding certificate |
+| Small enterprise mutual aid | 小規模企業共済等掛金控除 | iDeCo, mutual aid contribution certificates |
+| Life insurance premiums | 生命保険料控除 | Insurance premium certificates |
+| Earthquake insurance | 地震保険料控除 | Insurance certificates |
+| Casualty losses | 雑損控除 | If applicable |
+| Medical expenses | 医療費控除 | Medical expense summary |
+| Charitable donations | 寄附金控除 | Furusato nozei + other donation receipts |
+
+### 6.4 Deductions Entry -- Part 2 (人的控除・住宅控除等)
+
+| Deduction | Japanese | Notes |
+|---|---|---|
+| Spouse deduction | 配偶者（特別）控除 | Based on spouse's income |
+| Dependent deduction | 扶養控除 | By age category |
+| Widow/single parent | 寡婦・ひとり親控除 | If applicable |
+| Working student | 勤労学生控除 | If applicable |
+| Disability | 障害者控除 | If applicable |
+| Basic deduction | 基礎控除 | Calculated automatically |
+| Housing loan deduction | 住宅借入金等特別控除 | First year requires details |
+| Estimated tax paid | 予定納税額 | If advance payments were made |
+| Loss carryforward | 繰越損失額 | Blue return only, up to 3 years |
+
+### 6.5 Calculation Result Confirmation (計算結果の確認)
+
+The system displays the computed tax:
+
+| Item | What to Verify |
+|---|---|
+| Total income (合計所得金額) | Matches your working paper |
+| Total deductions (所得控除合計) | Matches your calculations |
+| Taxable income (課税所得金額) | Rounded down to nearest JPY 1,000 |
+| Computed tax (算出税額) | Rate table correctly applied |
+| Tax credits | Housing loan, dividend credits |
+| Reconstruction surtax (復興特別所得税) | 2.1% of base income tax |
+| Total tax (所得税及び復興特別所得税) | Sum of income tax + reconstruction tax |
+| Withholding credits (源泉徴収税額) | All withholding properly credited |
+| Tax due or refund (申告納税額/還付) | Final amount to pay or receive |
+
+**Cross-check all figures against your income tax working paper. Any discrepancy should be investigated before proceeding.**
+
+### 6.6 Payment Method (納付方法)
+
+If tax is due:
+
+| Method | Japanese | Notes |
+|---|---|---|
+| Account transfer | 振替納税 | Auto-debit from bank account |
+| Electronic payment | 電子納税 | Direct debit or internet banking |
+| Credit card | クレジットカード納付 | Fee applies |
+| Convenience store | コンビニ納付 | For amounts under JPY 300,000 |
+| Bank counter | 金融機関等での窓口納付 | Traditional method |
+
+If a refund is due, enter bank account details (bank name, branch, account number, account holder).
+
+### 6.7 Personal Information & My Number
+
+Enter personal details (name in kana and kanji, phone number, address, tax office, occupation, trade name) and your 12-digit My Number (マイナンバー). The system validates the check digit.
+
+---
+
+## Section 7 -- Consumption Tax Return (消費税コーナー)
+
+If you are a taxable business (課税事業者) for consumption tax, file the consumption tax return after completing the income tax return.
+
+### 7.1 Method Determination (条件判定)
+
+| Field | What to Enter |
+|---|---|
+| Base period taxable sales (基準期間の課税売上高) | Sales from 2 years prior |
+| Qualified invoice issuer (インボイス発行事業者) | Yes/No |
+| Simplified taxation elected (簡易課税) | Yes/No |
+| Accounting method | Tax-inclusive (税込) or tax-exclusive (税抜) |
+
+The system determines which computation route to use:
+
+| Condition | Route |
+|---|---|
+| Invoice registrant + 20% special measure elected | 2割特例 route |
+| Simplified taxation elected + base sales ≤ JPY 50M | 簡易課税 route |
+| All other cases | 本則課税 (general) route |
+
+### 7.2 Sales Entry
+
+Enter total sales broken down by:
+- Taxable sales amount (tax-inclusive total)
+- Reduced rate (8%) portion (軽減税率適用分)
+- Tax-exempt sales (免税売上)
+- Non-taxable sales (非課税売上)
+- Returns/allowances by rate category
+
+### 7.3 Calculation Result (計算結果)
+
+The system displays:
+
+| Item | Description |
+|---|---|
+| Taxable base amount (課税標準額) | Sales ÷ 1.10 (or 1.08), rounded down to JPY 1,000 |
+| National consumption tax (消費税額) | Base × 7.8% (standard) or 6.24% (reduced) |
+| Input tax credit (控除税額) | Varies by method |
+| Differential tax (差引税額) | Output tax − input tax credit, rounded down to JPY 100 |
+| Local consumption tax (地方消費税) | Differential × 22/78, rounded down to JPY 100 |
+| Total tax due (合計納付税額) | National + local |
+
+### 7.4 Taxpayer Information
+
+Enter address, tax office, name, My Number, and payment method for the consumption tax return.
+
+---
+
+## Section 8 -- Electronic Signature and Submission
+
+### 8.1 Save Input Data (Strongly Recommended)
+
+Before submitting, save input data as a `.data` file using the "Save input data" (入力データの一時保存) button. This file allows you to:
+- Resume filing if interrupted
+- Reference data for next year's return
+- Restore data if a correction filing (修正申告) is needed
+
+### 8.2 Electronic Signature
+
+Sign the return electronically using your My Number Card:
+1. Enter your signature PIN (署名用パスワード -- 6-16 alphanumeric characters)
+2. Hold your My Number Card to the smartphone's NFC reader
+3. Wait for confirmation
+
+### 8.3 Submission
+
+**Review the final confirmation page carefully before submitting.**
+
+After confirming all figures are correct, click the submit button. Record the receipt number (受付番号) displayed after successful submission.
+
+### 8.4 Post-Submission
+
+1. **Save the post-submission `.data` file** -- it contains the receipt number and submission timestamp
+2. **Check your e-Tax message box** for the receipt notification (受信通知)
+3. **If consumption tax return is pending**, proceed to file it after the income tax submission
+4. **Note payment deadlines:** Income tax by March 15, consumption tax by March 31
+
+---
+
+## Section 9 -- Common Errors and Troubleshooting
+
+| Error Code | Description | Resolution |
+|---|---|---|
+| KS-E10089 | e-Tax submission required for JPY 650,000 deduction | Must submit electronically, not on paper |
+| KS-E10001 | Required field missing | Check all mandatory fields are filled |
+| KS-E40003 | Balance sheet does not balance | Verify total assets = total liabilities + equity |
+| KS-W10035 | Print confirmation | Acknowledge with OK to proceed |
+| KS-W90011 | Data will be reset | Acknowledge with OK if intentional |
+
+### QR Code Not Displaying
+
+If the QR code does not appear on the authentication screen:
+- Ensure you are using a supported browser (Chrome/Edge on Windows, Safari on macOS)
+- Linux is not officially supported by the NTA
+- Try refreshing the page
+
+### Authentication Failures
+
+- Ensure the My Number Card is not expired
+- Check that the correct PIN is being used (4-digit user authentication PIN, not the 6-16 digit signature PIN)
+- Hold the card steady against the phone's NFC reader for several seconds
+
+---
+
+## Section 10 -- Key Deadlines and Calendar
+
+| Item | Deadline | Notes |
+|---|---|---|
+| Income tax filing | March 15 | 確定申告 deadline |
+| Income tax payment | March 15 | Same as filing |
+| Consumption tax filing | March 31 | Sole proprietors |
+| Consumption tax payment | March 31 | Same as filing |
+| Account transfer (振替納税) date | Late April (income tax), late April (consumption tax) | Exact date announced annually |
+| Estimated tax 1st instalment | July 31 | If prior year tax > JPY 150,000 |
+| Estimated tax 2nd instalment | November 30 | If prior year tax > JPY 150,000 |
+
+---
+
+## Section 11 -- Data File Management
+
+### The `.data` File
+
+The 確定申告書等作成コーナー allows saving and loading `.data` files at any point during the process.
+
+| Action | When to Use |
+|---|---|
+| Save during entry | To create a checkpoint before complex sections |
+| Save before submission | To preserve a pre-submission backup |
+| Save after submission | To preserve receipt number and submission details |
+| Load saved data | To resume from a previous session via "保存データを利用して作成" |
+
+**Best practice:** Save `.data` files at three points: (1) after completing financial statements, (2) before electronic submission, and (3) after successful submission.
+
+---
+
+## PROHIBITIONS
+
+- NEVER submit a tax return without the taxpayer's explicit confirmation of all figures
+- NEVER enter the electronic signature PIN -- this must be done by the taxpayer personally
+- NEVER click the final submission button -- this must be done by the taxpayer personally
+- NEVER select the JPY 650,000 blue return deduction for paper filing (will cause error KS-E10089)
+- NEVER skip the balance sheet balance check -- assets must equal liabilities + equity
+- NEVER proceed past the QR code authentication step without confirmation that authentication succeeded
+- NEVER present e-Tax filing as a substitute for professional review -- all returns should be reviewed by a 税理士
+
+---
+
+## Disclaimer
+
+This skill and its outputs are provided for informational and computational purposes only and do not constitute tax, legal, or financial advice. Open Accountants and its contributors accept no liability for any errors, omissions, or outcomes arising from the use of this skill. All outputs must be reviewed and signed off by a qualified professional (such as a 税理士 or equivalent licensed practitioner in Japan) before filing or acting upon.
+
+The 確定申告書等作成コーナー screen layout and form fields are maintained by the National Tax Agency and may change without notice. Always verify against the live system.
+
+The most up-to-date, verified version of this skill is maintained at [openaccountants.com](https://openaccountants.com). Log in to access the latest version, request a professional review from a licensed accountant, and track updates as tax law changes.

--- a/skills/international/japan/jp-incorporation.md
+++ b/skills/international/japan/jp-incorporation.md
@@ -1,0 +1,492 @@
+---
+name: jp-incorporation
+description: >
+  Use this skill whenever asked about incorporating in Japan -- transitioning from sole proprietorship (個人事業主) to a corporation (法人). Trigger on phrases like "incorporation Japan", "法人成り", "会社設立", "should I incorporate", "法人化", "株式会社", "合同会社", "KK vs GK", "corporate tax vs income tax", "法人税", "when to incorporate", "法人成りのタイミング", "micro corporation", "マイクロ法人", "officer compensation", "役員報酬", "social insurance comparison", "社会保険", "個人事業 vs 法人", "定期同額給与", "consumption tax exemption reset", "消費税の免税リセット", or any question about whether, when, and how a Japanese sole proprietor should form a company. This skill covers tax burden comparison, breakeven analysis, corporate form selection, establishment procedures, filing deadlines, officer compensation strategy, and social insurance optimization. ALWAYS read this skill before advising on Japanese incorporation.
+version: 1.0
+jurisdiction: JP
+tax_year: 2025
+category: international
+depends_on:
+  - jp-income-tax
+  - jp-consumption-tax
+---
+
+# Japan Incorporation (法人成り) -- Self-Employed Skill v1.0
+
+> **Based on work by [Kazuki Nagata (@kazukinagata)](https://github.com/kazukinagata/shinkoku)**, licensed under MIT. Adapted for the OpenAccountants format.
+
+---
+
+## Section 1 -- Quick Reference
+
+| Field | Value |
+|---|---|
+| Country | Japan (日本) |
+| Topic | Sole proprietor → Corporation transition (法人成り) |
+| Legislation | Companies Act (会社法), Corporate Tax Act (法人税法), Income Tax Act (所得税法), Consumption Tax Act (消費税法) |
+| Tax Authority | National Tax Agency (国税庁 NTA), Legal Affairs Bureau (法務局) |
+| Contributor | Open Accountants Community |
+| Validated by | Pending -- requires sign-off by a Japanese 税理士 (Zeirishi) |
+| Skill version | 1.0 |
+| Tax year basis | 2025 (令和7年) |
+
+### Key Decision Thresholds
+
+| Business Income | Recommendation |
+|---|---|
+| Under JPY 5,000,000 | Stay as sole proprietor |
+| JPY 6,000,000 -- 7,000,000 | Sole proprietor slightly favorable; prepare for future incorporation |
+| ~JPY 8,000,000 | **Breakeven point** -- evaluate with social insurance benefits |
+| JPY 9,000,000 -- 10,000,000 | Corporation slightly favorable |
+| Over JPY 10,000,000 | Corporation clearly favorable |
+| Over JPY 15,000,000 | Strong case for incorporation |
+
+---
+
+## Section 2 -- Tax Burden Comparison: Sole Proprietor vs Corporation
+
+### 2.1 Sole Proprietor Tax Structure
+
+| Tax | Rate/Rule | Legislation |
+|---|---|---|
+| Income tax (所得税) | Progressive 5%--45% on taxable income | Income Tax Act Art. 89 |
+| Reconstruction surtax (復興特別所得税) | Income tax × 2.1% (through 2037) | Reconstruction Finance Act Art. 13 |
+| Resident tax (住民税) | 10% of taxable income + per-capita levy ~JPY 5,000 | Local Tax Act |
+| Enterprise tax (個人事業税) | 3%--5% on income over JPY 2,900,000 (deduction) | Local Tax Act Art. 72-49-17 |
+| National health insurance (国民健康保険) | Income-based + per-capita; cap ~JPY 1,090,000/year (2025) | Per municipality |
+| National pension (国民年金) | Flat JPY 17,510/month (JPY 210,120/year, 2025) | National Pension Act |
+
+**Total formula:** Income tax + reconstruction surtax + resident tax + enterprise tax + NHI + national pension
+
+### 2.2 Corporate Tax Structure
+
+| Tax | Rate | Legislation |
+|---|---|---|
+| Corporate tax (法人税) -- income ≤ JPY 8M | 15% (reduced rate for SMEs) | Corporate Tax Act Art. 66; Special Measures Art. 42-3-2 |
+| Corporate tax -- income > JPY 8M | 23.2% | Corporate Tax Act Art. 66 |
+| Local corporate tax (地方法人税) | Corporate tax × 10.3% | Local Corporate Tax Act Art. 6 |
+| Corporate inhabitant tax (法人住民税) -- tax portion | Corporate tax × ~7% | Local Tax Act |
+| Corporate inhabitant tax -- per-capita (均等割) | JPY 70,000/year minimum (capital ≤ JPY 10M, ≤ 50 employees) | Local Tax Act |
+| Enterprise tax (法人事業税) | 3.5%--7.0% (progressive by income bracket) | Local Tax Act Art. 72-24-7 |
+| Special enterprise tax (特別法人事業税) | Enterprise tax × 37% | |
+| Social insurance (健康保険 + 厚生年金) | ~28--30% of officer compensation (split employer/employee) | Health Insurance Act; Employees' Pension Insurance Act |
+
+**Total formula:** Corporate taxes + officer's personal income tax/resident tax + social insurance (both halves)
+
+### 2.3 Enterprise Tax Brackets (Corporate)
+
+| Taxable Income | Rate | With surcharge |
+|---|---|---|
+| Up to JPY 4,000,000 | 3.5% | 3.75% |
+| JPY 4,000,001 -- 8,000,000 | 5.3% | 5.665% |
+| Over JPY 8,000,000 | 7.0% | 7.48% |
+
+---
+
+## Section 3 -- Breakeven Simulations
+
+### Assumptions
+
+- Sole proprietor: blue return (JPY 650,000 deduction), single, no dependents
+- Corporation: capital JPY 1,000,000, single-person company, one officer
+- Social insurance: Kyokai Kenpo (Tokyo), under 40 (no nursing care insurance)
+- Officer compensation optimized to keep corporate profit under JPY 8,000,000
+- Consumption tax excluded (same for both)
+
+### 3.1 Business Income JPY 5,000,000 -- Sole Proprietor Wins
+
+| | Sole Proprietor | Corporation (officer comp. JPY 4M) |
+|---|---|---|
+| Income/corporate tax + surtaxes | ~JPY 620,000 | ~JPY 516,000 |
+| Social insurance | ~JPY 610,000 (NHI + pension) | ~JPY 1,200,000 (both halves) |
+| **Total burden** | **~JPY 1,230,000** | **~JPY 1,764,000** |
+
+**Verdict:** Sole proprietor saves ~JPY 530,000. Social insurance costs overwhelm the corporate tax advantage.
+
+### 3.2 Business Income JPY 8,000,000 -- Breakeven
+
+| | Sole Proprietor | Corporation (officer comp. JPY 6M) |
+|---|---|---|
+| Income/corporate tax + surtaxes | ~JPY 1,398,000 | ~JPY 870,000 |
+| Social insurance | ~JPY 910,000 | ~JPY 1,500,000 |
+| **Total burden** | **~JPY 2,308,000** | **~JPY 2,370,000** |
+
+**Verdict:** Nearly equal. Factor in social insurance benefits (disability coverage, employer pension, sick pay) to tip the decision.
+
+### 3.3 Business Income JPY 10,000,000 -- Corporation Wins
+
+| | Sole Proprietor | Corporation (officer comp. JPY 7M) |
+|---|---|---|
+| Income/corporate tax + surtaxes | ~JPY 2,188,000 | ~JPY 1,240,000 |
+| Social insurance | ~JPY 1,110,000 | ~JPY 1,700,000 |
+| **Total burden** | **~JPY 3,298,000** | **~JPY 2,940,000** |
+
+**Verdict:** Corporation saves ~JPY 360,000.
+
+### 3.4 Business Income JPY 15,000,000 -- Corporation Clearly Wins
+
+| | Sole Proprietor | Corporation (officer comp. JPY 9M) |
+|---|---|---|
+| Income/corporate tax + surtaxes | ~JPY 3,938,000 | ~JPY 2,250,000 |
+| Social insurance | ~JPY 1,270,000 | ~JPY 2,200,000 |
+| **Total burden** | **~JPY 5,208,000** | **~JPY 4,450,000** |
+
+**Verdict:** Corporation saves ~JPY 760,000.
+
+### 3.5 Business Income JPY 20,000,000+ -- Corporation Strongly Wins
+
+| | Sole Proprietor | Corporation (officer comp. JPY 10M) |
+|---|---|---|
+| Income/corporate tax + surtaxes | ~JPY 5,518,000 | ~JPY 3,620,000 |
+| Social insurance | ~JPY 1,270,000 | ~JPY 2,400,000 |
+| **Total burden** | **~JPY 7,638,000** | **~JPY 6,020,000** |
+
+**Verdict:** Corporation saves ~JPY 1,620,000.
+
+---
+
+## Section 4 -- Corporate Forms: KK vs GK
+
+### 4.1 Comparison Table
+
+| Feature | Kabushiki Kaisha (株式会社/KK) | Godo Kaisha (合同会社/GK) |
+|---|---|---|
+| Legal basis | Companies Act Art. 25+ | Companies Act Art. 575+ |
+| Establishment cost (electronic articles) | ~JPY 200,000 | ~JPY 60,000 |
+| Establishment cost (paper articles) | ~JPY 240,000 | ~JPY 100,000 |
+| Articles of incorporation notarization | Required (notary public) | Not required |
+| Registration tax (minimum) | JPY 150,000 | JPY 60,000 |
+| Social credibility | High | Moderate (less recognized in B2B) |
+| Decision-making | Shareholders meeting + directors | Majority of members (flexible) |
+| Financial statement disclosure | Required (official gazette, etc.) | Not required |
+| Officer term | Up to 10 years (private company), re-registration required | No term limit |
+| Profit distribution | Based on shareholding ratio | Freely determined by articles |
+| IPO possibility | Yes | No |
+| Transfer of interest | Share transfer (relatively easy) | Requires all members' consent |
+
+### 4.2 Establishment Cost Breakdown
+
+**Kabushiki Kaisha (electronic articles):**
+
+| Item | Amount |
+|---|---|
+| Notarization fee | JPY 30,000--50,000 (depends on capital amount) |
+| Certified copy fee | ~JPY 2,000 |
+| Registration tax | JPY 150,000 (or capital × 0.7%, whichever is higher) |
+| **Total** | **~JPY 182,000--202,000** |
+
+**Godo Kaisha (electronic articles):**
+
+| Item | Amount |
+|---|---|
+| Notarization fee | Not required |
+| Registration tax | JPY 60,000 (or capital × 0.7%, whichever is higher) |
+| **Total** | **~JPY 60,000** |
+
+Paper articles add JPY 40,000 in revenue stamps for both forms.
+
+### 4.3 When to Choose Which
+
+**Choose KK when:**
+- B2B sales where counterparties conduct credit checks
+- Future financing, capital raising, or IPO is planned
+- Hiring multiple employees
+- "Kabushiki Kaisha" brand recognition matters to customers
+
+**Choose GK when:**
+- Minimizing startup costs
+- Solo or very small team (1--3 people)
+- B2C business where corporate form is invisible to customers (IT, consulting)
+- Faster decision-making and lower administrative overhead
+
+---
+
+## Section 5 -- Officer Compensation Strategy (役員報酬)
+
+### 5.1 Fixed Monthly Compensation Rule (定期同額給与)
+
+To deduct officer compensation as a corporate expense, it must be paid monthly in equal amounts (Corporate Tax Act Art. 34, para. 1, item 1).
+
+| Rule | Detail |
+|---|---|
+| Amount must be equal each month | Set once at the start of the fiscal year |
+| Change window | Within 3 months of fiscal year start (at shareholders' meeting) |
+| Mid-year changes | Prohibited except for extraordinary reasons |
+| Bonuses to officers | Not deductible unless pre-registered (事前確定届出給与) |
+
+### 5.2 Employment Income Deduction Advantage (給与所得控除)
+
+This is the key advantage of incorporation. Sole proprietors only get the blue return deduction (max JPY 650,000), but officers get the employment income deduction:
+
+| Annual Compensation | Employment Income Deduction (2025) |
+|---|---|
+| Up to JPY 1,625,000 | JPY 650,000 (minimum) |
+| JPY 1,625,001 -- 1,800,000 | Compensation × 40% − JPY 100,000 |
+| JPY 1,800,001 -- 3,600,000 | Compensation × 30% + JPY 80,000 |
+| JPY 3,600,001 -- 6,600,000 | Compensation × 20% + JPY 440,000 |
+| JPY 6,600,001 -- 8,500,000 | Compensation × 10% + JPY 1,100,000 |
+| Over JPY 8,500,000 | JPY 1,950,000 (cap) |
+
+### 5.3 Optimal Compensation Targets
+
+| Business Profit | Officer Compensation Target | Corporate Profit Target | Rationale |
+|---|---|---|---|
+| JPY 8,000,000 | JPY 6,000,000 | JPY 2,000,000 | Keep personal tax at 20% bracket |
+| JPY 10,000,000 | JPY 7,000,000 | JPY 3,000,000 | Good balance of deduction and rate |
+| JPY 12,000,000 | JPY 8,000,000 | JPY 4,000,000 | Maximize deduction; corporate profit at 15% rate |
+| JPY 15,000,000 | JPY 9,000,000 | JPY 6,000,000 | Watch social insurance upper bounds |
+| JPY 20,000,000 | JPY 10,000,000 | JPY 10,000,000 | Retain profits in corporation |
+| JPY 30,000,000 | JPY 12,000,000 | JPY 18,000,000 | Significant corporate retention |
+
+**Optimization principles:**
+1. Keep corporate profit ≤ JPY 8,000,000 for the 15% reduced rate
+2. Maximize employment income deduction (peaks at JPY 1,950,000 for comp. over JPY 8,500,000)
+3. Consider social insurance cap: pension tops out at standard monthly compensation JPY 650,000 (~JPY 7,800,000 annual)
+4. Balance personal progressive tax rates against flat corporate rate
+
+### 5.4 Family Income Splitting
+
+A corporation can pay salaries to family members as employees or directors, achieving income splitting:
+
+| Scenario | Effect |
+|---|---|
+| Sole proprietor: all JPY 12M to owner | Owner at ~23% marginal rate |
+| Corporation: JPY 9M to owner + JPY 3M to spouse | Owner at ~20%, spouse at ~5% |
+| **Tax savings** | **~JPY 570,000/year** |
+
+**Requirements:** Family employees must have genuine work duties. Compensation must be reasonable for the role. No-work salary payments will be denied as a deductible expense.
+
+---
+
+## Section 6 -- Social Insurance Comparison
+
+### 6.1 Sole Proprietor vs Corporation
+
+| Feature | Sole Proprietor (NHI + National Pension) | Corporation (Kyokai Kenpo + Employees' Pension) |
+|---|---|---|
+| Basis | Prior year income | Standard monthly compensation |
+| Dependent coverage | None (each family member pays) | Yes (dependents covered at no extra cost) |
+| Sick pay (傷病手当金) | None | 2/3 of daily comp. for up to 18 months |
+| Maternity pay (出産手当金) | None | 2/3 of daily comp. |
+| Pension benefit | Basic pension only (~JPY 810,000/year at full) | Basic + employees' pension (income-proportional) |
+| Premium cap | NHI: ~JPY 1,090,000; pension: flat | Standard compensation table cap |
+
+### 6.2 Social Insurance Rates (2025)
+
+| Insurance | Rate | Burden |
+|---|---|---|
+| Health insurance (Kyokai Kenpo, national avg.) | ~10.00% | Split 50/50 employer/employee |
+| Nursing care (age 40--64) | 1.59% | Split 50/50 |
+| Employees' pension (厚生年金) | 18.3% | Split 50/50 |
+| Child-rearing contribution | 0.36% | 100% employer |
+| **Total (under 40)** | **~28.66%** | **~14.33% each** |
+| **Total (40 and over)** | **~30.25%** | **~15.125% each** |
+
+### 6.3 Social Insurance Cap
+
+| Insurance | Standard Monthly Comp. Cap | Annual Comp. Equivalent |
+|---|---|---|
+| Health insurance | JPY 1,390,000 (Grade 50) | ~JPY 16,680,000 |
+| Employees' pension | JPY 650,000 (Grade 32) | ~JPY 7,800,000 |
+
+Above the pension cap (~JPY 7,800,000 annual compensation), pension premiums stop increasing. Health insurance premiums stop at ~JPY 16,680,000.
+
+---
+
+## Section 7 -- Consumption Tax Exemption Reset
+
+### 7.1 The Two-Year Exemption
+
+A newly established corporation with capital under JPY 10,000,000 is generally exempt from consumption tax for the first two fiscal years (Consumption Tax Act Art. 12-2).
+
+**Conditions:**
+1. Capital under JPY 10,000,000
+2. First fiscal period: no base period exists → exempt
+3. Second fiscal period: exempt IF specified-period taxable sales (or wages) ≤ JPY 10,000,000
+4. Not a "specified newly established corporation" (特定新規設立法人)
+
+### 7.2 Maximizing the Exemption Period
+
+| Strategy | Effect |
+|---|---|
+| Set capital below JPY 10,000,000 (e.g., JPY 9,990,000) | Qualifies for exemption |
+| Make first fiscal period ≤ 7 months | Eliminates specified-period test for 2nd year |
+| Delay qualified invoice registration | Preserves exemption (but may lose clients who need invoices) |
+
+**Example:** Establish on October 1 with March fiscal year-end → first period = 6 months → no specified period → second period also exempt → up to ~19 months exempt.
+
+### 7.3 Invoice Registration Caution
+
+If the sole proprietor was already a qualified invoice issuer:
+- The corporation needs its own new invoice registration
+- Registering makes the corporation taxable from the registration date, losing the exemption
+- The individual's registration does NOT automatically cancel -- submit a cancellation notice (適格請求書発行事業者の登録の取消しを求める届出書)
+- The 20% special measure (2割特例) may apply to the new corporation through periods ending September 2026
+
+---
+
+## Section 8 -- Establishment Procedure
+
+### Step 1: Pre-establishment Decisions
+
+| Decision | Considerations |
+|---|---|
+| Corporate form | KK vs GK (see Section 4) |
+| Trade name (商号) | Check for conflicts at Legal Affairs Bureau |
+| Business purpose | List broadly in articles (include future activities) |
+| Registered office | Home address or office |
+| Capital amount | Under JPY 10,000,000 for CT exemption |
+| Fiscal year-end | Avoid March (tax adviser busy season); optimize for CT exemption |
+| Incorporators | Confirm contributing members |
+| Seals (印鑑) | Representative seal, bank seal, square seal |
+
+### Step 2: Draft and Authenticate Articles of Incorporation
+
+**KK:** Create articles → notarize at public notary office (公証役場)
+**GK:** Create articles → no notarization required
+
+### Step 3: Capital Contribution
+
+1. Transfer capital to the incorporator's personal bank account
+2. Prepare a copy of the bankbook page showing the transfer
+3. Create a certificate of capital contribution (払込証明書)
+
+### Step 4: Registration at Legal Affairs Bureau
+
+Submit: registration application, articles, capital contribution proof, officer acceptance letters, seal registration form. Pay registration tax.
+
+Processing time: typically 1--2 weeks. Obtain certificate of registered matters (登記事項証明書) and seal certificate (印鑑証明書) after completion.
+
+### Step 5: Post-Establishment Filings
+
+#### Tax Office (税務署)
+
+| Filing | Deadline | Notes |
+|---|---|---|
+| Corporate establishment notice (法人設立届出書) | Within 2 months of establishment | Attach articles + registration certificate |
+| Blue return approval application (青色申告の承認申請書) | Within 3 months of establishment OR fiscal year end (whichever is earlier) | **Highest priority -- missing this means white return** |
+| Payroll office opening notice (給与支払事務所等の開設届出書) | Within 1 month | Required if paying officer compensation |
+| Special withholding payment approval (源泉所得税の納期の特例) | As soon as possible | Allows semi-annual withholding deposits (≤10 employees) |
+| CT taxable business election (消費税課税事業者選択届出書) | By end of fiscal year | If registering for invoices |
+| Qualified invoice registration (適格請求書発行事業者の登録申請書) | Any time | If clients require invoices |
+
+#### Prefectural/Municipal Tax Office
+
+| Filing | Deadline |
+|---|---|
+| Corporate establishment notice (prefectural) | 15 days to 2 months (varies by municipality) |
+| Corporate establishment notice (municipal) | 15 days to 2 months (Tokyo 23 wards: file with Tokyo Metropolitan) |
+
+#### Pension Office (年金事務所)
+
+| Filing | Deadline | Notes |
+|---|---|---|
+| New workplace application (健康保険・厚生年金保険 新規適用届) | Within 5 days | Mandatory for all corporations |
+| Insured person qualification (被保険者資格取得届) | Within 5 days | Officers are also covered |
+| Dependent notification (被扶養者異動届) | Within 5 days | If there are dependents |
+
+#### Labor Insurance (only if hiring employees)
+
+| Filing | Submit To | Deadline |
+|---|---|---|
+| Insurance relationship establishment (保険関係成立届) | Labor Standards Office | Within 10 days of hiring |
+| Employment insurance workplace (雇用保険 適用事業所設置届) | Hello Work | Within 10 days of hiring |
+| Employment insurance qualification (雇用保険 被保険者資格取得届) | Hello Work | By 10th of following month |
+
+*Not required for single-person corporations with no employees.*
+
+---
+
+## Section 9 -- Closing the Sole Proprietorship
+
+If not maintaining a dual structure, file these to close the sole proprietorship:
+
+| Filing | Submit To | Deadline |
+|---|---|---|
+| Business opening/closing notice (開業・廃業等届出書) | Tax office | Within 1 month of closure |
+| Blue return cessation (青色申告の取りやめ届出書) | Tax office | By March 15 of following year |
+| Business cessation notice (CT) (事業廃止届出書) | Tax office | Promptly |
+| Invoice registration cancellation (適格請求書発行事業者の登録取消届出書) | Tax office | 15 days before start of desired cancellation period |
+| Payroll office closure (給与支払事務所等の廃止届出書) | Tax office | Within 1 month |
+| Enterprise tax cessation (個人事業税の事業廃止届出書) | Prefectural tax office | Promptly |
+
+**Important notes:**
+- File the final year's individual income tax return (確定申告) as usual
+- Transfer inventory to the corporation at fair market value
+- Transfer fixed assets at book value or fair market value (beware of below-market transfers)
+- Settle all receivables/payables between individual and corporation
+- Consider filing for estimated tax reduction (予定納税の減額申請)
+
+---
+
+## Section 10 -- Micro Corporation + Sole Proprietorship ("Two-Sword" Strategy)
+
+### Overview
+
+Maintain the sole proprietorship while also establishing a micro corporation (マイクロ法人). The corporation pays minimal officer compensation to access corporate social insurance at the lowest tier.
+
+### Structure
+
+```
+Micro Corporation:
+  → Officer compensation: ~JPY 63,000/month (JPY 756,000/year)
+  → Social insurance: enrolled at minimum tier
+  → Annual social insurance (personal share): ~JPY 107,000
+
+Sole Proprietorship (continued):
+  → Business income filed via 確定申告
+  → No NHI or national pension obligation (covered by corporate insurance)
+
+Compared to sole proprietor only at JPY 10,000,000 income:
+  NHI + national pension: ~JPY 1,100,000/year
+  Micro corp social insurance (both shares): ~JPY 210,000/year
+  Potential savings: ~JPY 890,000/year
+```
+
+### Risk Factors
+
+| Risk | Description |
+|---|---|
+| Tax denial | If the corporation has no real business activity, it may be treated as a paper company |
+| Same business split | Splitting the same client work between personal and corporate is high-risk for denial |
+| Zero revenue corporation | A corporation existing solely for social insurance access may be challenged |
+| Audit exposure | Cannot explain a reasonable business separation |
+
+**Acceptable examples:** Personal = freelance engineering (main); Corporation = SaaS product development (separate business). **Unacceptable:** Both entities doing the same programming work for the same clients.
+
+---
+
+## Section 11 -- Optimal Timing
+
+| Factor | Recommended Timing | Reason |
+|---|---|---|
+| Income tax optimization | Mid-year | Split income between individual (first half) and corporation |
+| Consumption tax reset | Before becoming a taxable business | Maximize exemption period |
+| Accounting simplicity | January 1 | Clean separation of individual fiscal year and corporate fiscal year |
+| Client relationships | Start of quarter | Smoother invoice/contract transition |
+| Fiscal year-end choice | Avoid March | Tax advisers are busiest in March; consider September or December |
+
+---
+
+## PROHIBITIONS
+
+- NEVER present incorporation as universally beneficial -- at lower income levels, sole proprietorship is cheaper
+- NEVER recommend specific officer compensation amounts as definitive -- individual circumstances vary
+- NEVER ignore social insurance costs in the comparison -- they are often the largest single factor
+- NEVER assume consumption tax exemption applies if the corporation registers for qualified invoices
+- NEVER recommend the "two-sword" strategy without prominently disclosing tax denial risks
+- NEVER omit the annual JPY 70,000+ corporate inhabitant tax (均等割) from cost projections -- it applies even when the corporation has no profit
+- NEVER forget to mention tax adviser fees (~JPY 300,000--500,000/year) as a fixed cost of incorporation
+- NEVER present simulations as definitive -- always label as estimated and direct to a 税理士 for confirmation
+
+---
+
+## Disclaimer
+
+This skill and its outputs are provided for informational and computational purposes only and do not constitute tax, legal, or financial advice. Open Accountants and its contributors accept no liability for any errors, omissions, or outcomes arising from the use of this skill.
+
+Incorporation involves tax, legal, and social insurance considerations that vary significantly based on individual circumstances. All decisions must be reviewed and confirmed by qualified professionals (税理士 for tax, 司法書士 for company registration, 社会保険労務士 for social insurance) before acting upon.
+
+Information is based on the 2025 tax year (令和7年分) tax system. Tax laws, social insurance rates, and registration fees change annually.
+
+The most up-to-date, verified version of this skill is maintained at [openaccountants.com](https://openaccountants.com). Log in to access the latest version, request a professional review from a licensed accountant, and track updates as tax law changes.

--- a/skills/international/netherlands/nl-corporate-tax.md
+++ b/skills/international/netherlands/nl-corporate-tax.md
@@ -1,0 +1,291 @@
+---
+name: nl-corporate-tax
+description: >
+  Use this skill whenever asked about Dutch corporate income tax (vennootschapsbelasting / VPB) for BV entities. Trigger on phrases like "vennootschapsbelasting", "VPB aangifte", "corporate tax Netherlands", "BV belasting", "fiscal unity", "fiscale eenheid", "innovatiebox", "verliesverrekening", "carry forward losses", "DGA salary", "gebruikelijk loon", "deelnemingsvrijstelling", "participation exemption", "fiscal profit bridge", "commercial to fiscal result", "liquidatieverliesregeling", or any question about computing or filing corporate income tax for a Dutch BV or NV. Also trigger when preparing annual accounts-to-tax reconciliation, computing VPB liability, or advising on fiscal adjustments. This skill covers VPB rates, fiscal profit computation, loss relief, fiscal unity, the innovation box, participation exemption, DGA salary rules, filing deadlines, and penalties. ALWAYS read this skill before touching any Dutch corporate tax work.
+version: 1.0
+jurisdiction: NL
+tax_year: 2025
+category: international
+depends_on:
+  - income-tax-workflow-base
+---
+
+# Netherlands Corporate Income Tax — Vennootschapsbelasting (VPB) v1.0
+
+> **Based on work by [John in 't Hout (@johnhout)](https://github.com/johnhout/knowledge-work-belastingzaken)**, licensed under MIT. Adapted for the OpenAccountants format.
+
+---
+
+## Section 1 — Quick Reference
+
+| Field | Value |
+|---|---|
+| Country | Netherlands (Koninkrijk der Nederlanden) |
+| Tax | Vennootschapsbelasting (VPB) — corporate income tax |
+| Currency | EUR only |
+| Tax year | Financial year (typically calendar year; alternative book years allowed) |
+| Primary legislation | Wet op de vennootschapsbelasting 1969 (Wet Vpb 1969) |
+| Tax authority | Belastingdienst |
+| Filing portal | Mijn Belastingdienst / Aangifte vennootschapsbelasting |
+| Filing deadline | 5 months after end of financial year (1 June for calendar year); extension possible up to 5 additional months |
+| Contributor | Open Accountants Community |
+| Validated by | Pending — requires sign-off by a qualified Dutch belastingadviseur or AA/RA accountant |
+| Skill version | 1.0 |
+
+### VPB Rates 2025 [T1]
+
+| Taxable Profit (EUR) | Rate | Notes |
+|---|---|---|
+| 0 — 200,000 | 19.0% | Lower bracket (schijf 1) |
+| Over 200,000 | 25.8% | Upper bracket (schijf 2) |
+
+**Formula:** VPB = EUR 200,000 × 19% + (taxable profit − EUR 200,000) × 25.8%
+
+**Rate history (for comparison/audit):**
+
+| Year | Lower bracket | Lower rate | Upper rate |
+|---|---|---|---|
+| 2023 | EUR 200,000 | 19.0% | 25.8% |
+| 2024 | EUR 200,000 | 19.0% | 25.8% |
+| 2025 | EUR 200,000 | 19.0% | 25.8% |
+
+### Fiscal Profit Bridge (Commercial → Fiscal) [T1]
+
+The fiscal profit starts from the commercial accounting result and applies mandatory adjustments:
+
+| Step | Adjustment | Direction |
+|---|---|---|
+| 1 | Commercial net result (jaarrekening) | Starting point |
+| 2 | Add back: non-deductible expenses (entertaining 73.5% non-deductible portion, fines, bribes) | + |
+| 3 | Add back: excessive interest (earnings stripping — see below) | + |
+| 4 | Deduct: participation exemption income (deelnemingsvrijstelling) | − |
+| 5 | Apply: different depreciation rules (fiscal vs commercial) | ± |
+| 6 | Apply: fiscal reserves (herinvesteringsreserve, etc.) | ± |
+| 7 | Deduct: loss carry-forward (if applicable) | − |
+| 8 | = Belastbaar bedrag (taxable amount) | Result |
+
+### Earnings Stripping (Renteaftrekbeperking) [T1]
+
+| Rule | Value |
+|---|---|
+| Threshold | Higher of: EUR 1,000,000 or 20% of fiscal EBITDA |
+| Scope | Net interest expense (interest paid − interest received) |
+| Legislation | Article 15b Wet Vpb 1969 |
+
+Net interest exceeding the threshold is non-deductible and carried forward indefinitely.
+
+### Loss Relief (Verliesverrekening) [T1]
+
+| Direction | Rule |
+|---|---|
+| Carry-back | 1 year |
+| Carry-forward | Indefinite, but limited per year |
+| Annual cap | EUR 1,000,000 + 50% of taxable profit exceeding EUR 1,000,000 |
+
+**Example:** If taxable profit before loss relief = EUR 3,000,000:
+- Maximum utilisation = EUR 1,000,000 + 50% × (EUR 3,000,000 − EUR 1,000,000) = EUR 2,000,000
+
+### Participation Exemption (Deelnemingsvrijstelling) [T1]
+
+| Requirement | Detail |
+|---|---|
+| Minimum holding | ≥ 5% of nominal share capital |
+| Effect | Dividends and capital gains from qualifying participation are fully exempt |
+| Legislation | Articles 13–13l Wet Vpb 1969 |
+| Anti-abuse | Passive investment holdings excluded (beleggingsdeelneming) unless subject to ≥ 10% effective tax |
+
+### Fiscal Unity (Fiscale Eenheid) [T1]
+
+| Requirement | Detail |
+|---|---|
+| Ownership | Parent holds ≥ 95% of shares in subsidiary |
+| Jurisdiction | Both entities must be NL-resident (or deemed resident with NL PE) |
+| Effect | Consolidated VPB return; intercompany results eliminated |
+| Legislation | Articles 15–15aj Wet Vpb 1969 |
+| Risk | If conditions cease to be met, unity breaks — potential recapture |
+
+### Innovation Box (Innovatiebox) [T1]
+
+| Parameter | Value |
+|---|---|
+| Effective rate | 9.0% on qualifying innovation profits |
+| Qualification | Profits from self-developed intangible assets (with WBSO declaration or patent) |
+| Threshold | First EUR 25,000 qualifying profit exempt from regular VPB (drempel) |
+| Legislation | Article 12b Wet Vpb 1969 |
+
+### DGA Salary — Gebruikelijk Loon [T1]
+
+| Parameter | Value 2025 |
+|---|---|
+| Minimum salary | EUR 56,000 (2025) |
+| Rule | DGA must receive at least the higher of: minimum threshold, 100% of comparable employees, or highest employee salary |
+| Deviation | Allowed only if taxpayer demonstrates that a lower salary is "gebruikelijk" given circumstances |
+| Legislation | Article 12a Wet op de loonbelasting 1964 |
+
+### Key Deadlines [T1]
+
+| Obligation | Deadline |
+|---|---|
+| Filing VPB return | 1 June (calendar year entities); extension up to 1 November |
+| Provisional assessment request | Before end of financial year (to manage cash flow) |
+| Objection (bezwaar) | 6 weeks after date on assessment |
+| Payment final assessment | 6 weeks after date on assessment |
+
+### Conservative Defaults [T1]
+
+| Situation | Default Assumption |
+|---|---|
+| Uncertain deductibility of expense | Non-deductible — flag for advisor |
+| Participation exemption qualification unclear | Do NOT apply — include income; flag |
+| Innovation box eligibility unclear | Do NOT apply — use standard rates; flag |
+| Fiscal unity status unclear | Treat as standalone entity; flag |
+| DGA salary below EUR 56,000 | Flag as non-compliant; compute at minimum |
+| Loss carry-forward amount unconfirmed | Do NOT apply — flag for prior-year reconciliation |
+
+### Red Flag Thresholds [T1]
+
+| Flag | Threshold |
+|---|---|
+| DGA salary below minimum | EUR 56,000 (2025) — compliance risk |
+| Intercompany loan without documentation | Transfer pricing risk — flag |
+| Net interest > EUR 1,000,000 | Earnings stripping analysis required |
+| Holding with < 5% participation | Participation exemption denied — gains taxable |
+| Fiscal unity entity becoming non-resident | Unity break risk — recapture |
+| Profit > EUR 200,000 in lower bracket | Verify no profit splitting arrangements |
+
+---
+
+## Section 2 — Required Inputs and Refusal Catalogue
+
+### Required Inputs
+
+**Minimum viable:** Annual accounts (jaarrekening) including profit & loss and balance sheet. Confirmation of entity type (BV/NV) and financial year.
+
+**Recommended:** Trial balance, prior-year VPB assessment (aanslag), loss carry-forward schedule, details of intercompany transactions, shareholding structure.
+
+**Ideal:** Complete administration including fixed asset register, loan documentation, WBSO declarations, fiscal unity decree, prior-year fiscal adjustments, transfer pricing documentation.
+
+### Refusal Catalogue
+
+**R-VPB-1 — No annual accounts available.** "Cannot compute VPB without financial statements. Provide at minimum a trial balance and P&L statement."
+
+**R-VPB-2 — Entity structure unclear.** "Cannot determine standalone vs. fiscal unity treatment without confirmed shareholding structure. Escalate."
+
+**R-VPB-3 — Intercompany transactions without documentation.** "Transfer pricing risk. Cannot determine arm's length pricing without documentation. Flag for belastingadviseur."
+
+**R-VPB-4 — Innovation box claimed without WBSO.** "Cannot apply 9% rate without confirmed WBSO declaration or patent. Apply standard rates."
+
+**R-VPB-5 — Cross-border element present.** "International tax treaty analysis required. Stop and escalate to international tax specialist."
+
+---
+
+## Section 3 — Computation Workflow
+
+### Step-by-Step VPB Computation
+
+```
+1. Start with commercial net result (per annual accounts)
+2. Identify and add back non-deductible expenses:
+   - Entertainment/representation: 73.5% non-deductible (or choose EUR 5,100 fixed amount)
+   - Fines and penalties: 100% non-deductible
+   - Bribes: 100% non-deductible
+   - Excessive interest (earnings stripping): non-deductible portion
+3. Apply fiscal depreciation differences:
+   - Buildings: max depreciation to 100% WOZ value (own use) or 50% WOZ (investment)
+   - Goodwill: max 10% per year fiscally
+4. Apply participation exemption (if qualifying):
+   - Remove dividends and gains from ≥5% participations
+5. Apply innovation box (if WBSO/patent confirmed):
+   - Separate qualifying profits; apply 9% rate
+6. Determine taxable amount before loss relief
+7. Apply loss carry-forward:
+   - Max EUR 1,000,000 + 50% of excess
+8. Compute VPB:
+   - First EUR 200,000 × 19%
+   - Remainder × 25.8%
+9. Deduct provisional payments already made
+10. = VPB payable / refundable
+```
+
+### Non-Deductible Expenses Detail
+
+| Category | Non-deductible portion | Alternative |
+|---|---|---|
+| Food, drink, entertainment | 73.5% | OR fixed EUR 5,100/year non-deductible |
+| Gifts > EUR 227 per recipient | Only portion above EUR 227 deductible per occasion | — |
+| Fines (bestuurlijke boetes) | 100% | — |
+| Bribes | 100% | — |
+| VPB itself | 100% | — |
+| Dividend distributions | 100% (not an expense) | — |
+
+### Fiscal Depreciation Limits
+
+| Asset | Fiscal Rule |
+|---|---|
+| Buildings (own use) | Depreciate to max 100% of WOZ value (bodemwaarde) |
+| Buildings (investment) | Depreciate to max 50% of WOZ value |
+| Goodwill | Max 10% per year (minimum 10-year life) |
+| Other intangibles | Based on useful economic life |
+| Tangible fixed assets | Based on economic life; no minimum |
+
+---
+
+## Section 4 — Filing Process
+
+### VPB Return Sections (Aangifte Vpb)
+
+| Section | Content |
+|---|---|
+| General information | Entity, financial year, contact details |
+| Fiscal balance sheet | Assets and liabilities at fiscal values |
+| Fiscal P&L | Revenue, costs, and adjustments at fiscal treatment |
+| Reconciliation | Commercial → fiscal bridge |
+| Participation exemption | Details of qualifying holdings |
+| Loss relief | Carry-back/carry-forward schedule |
+| Innovation box | Qualifying profit computation |
+| Fiscal unity | Consolidation details (if applicable) |
+
+### Common Errors to Check
+
+| Error | Consequence |
+|---|---|
+| Forgot to add back entertainment costs | Understated taxable profit |
+| Applied participation exemption to < 5% holding | Incorrectly excluded gains |
+| Used commercial depreciation instead of fiscal | Incorrect taxable profit |
+| Carried forward loss without applying cap | Excess deduction |
+| DGA salary below EUR 56,000 without justification | Penalty risk on loonbelasting |
+| Filed after deadline without extension | Estimated assessment (ambtshalve aanslag) and potential fine |
+
+---
+
+## Section 5 — Official Source Verification Requirements
+
+Before any rate, threshold, or deadline is used in output:
+
+1. Verify practical filing instructions on `belastingdienst.nl/vpb`
+2. Verify statutory text on `wetten.overheid.nl` (Wet Vpb 1969)
+3. Record exact URL and retrieval date (YYYY-MM-DD)
+4. If source unavailable or conflicting: mark as **UNVERIFIED** and require professional confirmation
+
+---
+
+## Section 6 — Escalation Points
+
+Escalate to a qualified belastingadviseur when:
+
+- Fiscal unity formation, termination, or cross-border elements exist
+- Transfer pricing disputes or documentation gaps
+- Innovation box qualification is borderline
+- Material uncertain tax positions (> EUR 50,000 impact)
+- Mergers, demergers, or share transactions
+- International dividend/royalty flows (withholding tax implications)
+- Entity is part of a multinational group (Country-by-Country Reporting obligations)
+
+---
+
+**⚠️ DISCLAIMER: This skill provides workflow support only and does not constitute tax advice. All positions must be reviewed and signed off by a qualified Dutch belastingadviseur before filing. Tax rules change annually — verify all rates and thresholds against belastingdienst.nl before use.**
+
+---
+
+*OpenAccountants — open-source tax computation skills*
+*openaccountants.com*

--- a/skills/international/netherlands/nl-deductions.md
+++ b/skills/international/netherlands/nl-deductions.md
@@ -1,0 +1,364 @@
+---
+name: nl-deductions
+description: >
+  Use this skill whenever asked about Dutch tax deductions and special schemes (aftrekposten en regelingen) beyond self-employed deductions. Trigger on phrases like "aftrekposten", "belastingaftrek", "deductions Netherlands", "hypotheekrenteaftrek", "mortgage interest deduction", "eigenwoningforfait", "specifieke zorgkosten", "giftenaftrek", "studiekosten", "alimentatie aftrek", "persoonsgebonden aftrek", "partnerregeling", "heffingskorting", "ouderenkorting", "jonggehandicaptenkorting", "levensloopvrijstelling", "box 3 vrijstelling", "groene belegging", "ANBI", "kom ik in aanmerking", "tax deduction check NL", or any question about Dutch individual or business tax deductions, credits, or special regimes. This skill covers persoonsgebonden aftrek, hypotheekrenteaftrek, zorgkosten, giften, heffingskortingen, and business investment schemes. ALWAYS read this skill before advising on Dutch deduction eligibility.
+version: 1.0
+jurisdiction: NL
+tax_year: 2025
+category: international
+depends_on:
+  - income-tax-workflow-base
+---
+
+# Netherlands Tax Deductions & Schemes — Aftrekposten en Regelingen v1.0
+
+> **Based on work by [John in 't Hout (@johnhout)](https://github.com/johnhout/knowledge-work-belastingzaken)**, licensed under MIT. Adapted for the OpenAccountants format.
+
+---
+
+## Section 1 — Quick Reference
+
+| Field | Value |
+|---|---|
+| Country | Netherlands (Koninkrijk der Nederlanden) |
+| Scope | Personal deductions (persoonsgebonden aftrek), property deductions, tax credits (heffingskortingen), special schemes |
+| Currency | EUR only |
+| Tax year | Calendar year (1 January — 31 December) |
+| Primary legislation | Wet inkomstenbelasting 2001 (Wet IB 2001), Chapters 6 (persoonsgebonden aftrek) and 8 (heffingskortingen) |
+| Tax authority | Belastingdienst |
+| Filing portal | Mijn Belastingdienst via DigiD |
+| Contributor | Open Accountants Community |
+| Validated by | Pending — requires sign-off by a qualified Dutch belastingadviseur |
+| Skill version | 1.0 |
+
+### Deduction Categories Overview [T1]
+
+| Category | Type | Where Claimed |
+|---|---|---|
+| Hypotheekrenteaftrek (mortgage interest) | Aftrekbare kosten eigen woning | Box 1 — Section eigen woning |
+| Persoonsgebonden aftrek | Individual deduction | Deducted from total Box 1/2/3 income |
+| Ondernemersaftrek | Business deduction | Box 1 — profit from enterprise |
+| Heffingskortingen (tax credits) | Reduce tax payable | Reduces computed tax (not income) |
+| Investment schemes (Box 3) | Reduced rate or exemption | Box 3 |
+
+---
+
+## Section 2 — Eigen Woning (Owner-Occupied Property)
+
+### Hypotheekrenteaftrek — Mortgage Interest Deduction [T1]
+
+| Parameter | Rule 2025 |
+|---|---|
+| Deductible | Interest paid on acquisition debt (eigenwoningschuld) for primary residence |
+| Maximum mortgage term | 30 years from first mortgage start date |
+| Repayment requirement | Annuity or linear repayment required (for mortgages from 2013+) |
+| Rate limitation | Deduction limited to max 36.97% effective rate (2025) — "Hillen" phase-in |
+| Maximum acquisition debt | No cap on amount, but only for primary residence (eigen woning) |
+| Legislation | Articles 3.110–3.123 Wet IB 2001 |
+
+### Eigenwoningforfait (Imputed Rental Value) [T1]
+
+| WOZ Value (EUR) | Percentage | Addition to Income |
+|---|---|---|
+| 0 — 12,500 | 0.00% | EUR 0 |
+| 12,500 — 25,000 | 0.10% | Variable |
+| 25,000 — 50,000 | 0.20% | Variable |
+| 50,000 — 75,000 | 0.30% | Variable |
+| 75,000 — 1,310,000 | 0.35% | Variable |
+| Above 1,310,000 | EUR 4,585 + 2.35% of excess | High-value surcharge |
+
+**Net effect:** Eigenwoningforfait is added to income; mortgage interest is subtracted. If interest > forfait, net deduction exists.
+
+### Aftrek geen of geringe eigenwoningschuld (Hillen-aftrek) [T1]
+
+If eigenwoningforfait exceeds mortgage interest (e.g., mortgage fully repaid), the excess used to be fully eliminated. This is being phased out:
+
+| Year | Hillen reduction percentage |
+|---|---|
+| 2024 | 83.33% of excess eliminated |
+| 2025 | 80.00% of excess eliminated |
+| 2026 | 76.67% |
+| ... | Declining ~3.33% per year |
+| 2048 | 0% (Hillen fully eliminated) |
+
+---
+
+## Section 3 — Persoonsgebonden Aftrek (Personal Deductions)
+
+These deductions are subtracted from taxable income across all boxes (in order: Box 1, Box 3, Box 2).
+
+### 3.1 Alimentatie (Maintenance Payments) [T1]
+
+| Rule | Detail |
+|---|---|
+| Deductible | Periodic spousal maintenance (partneralimentatie) |
+| NOT deductible | Child maintenance (kinderalimentatie) — not since 2015 |
+| Rate limitation | Deductible at max 36.97% (2025) |
+| Evidence required | Court order or notarial agreement + proof of payment |
+| Legislation | Article 6.3 Wet IB 2001 |
+
+### 3.2 Specifieke Zorgkosten (Medical Expenses) [T1]
+
+| Rule | Detail |
+|---|---|
+| Scope | Expenses not reimbursed by insurance: dental, physiotherapy, prescribed medication, disability aids, transport to medical care, dietary requirements (dietist-prescribed) |
+| Threshold | Only excess above income-dependent drempel is deductible |
+| Drempel calculation | Based on drempelinkomen (threshold income); ranges from 1.65% to 13.3% |
+| Multiplication factor | Some costs multiplied by factor (e.g., specific chronic illness costs ×1.13 or ×1.40) |
+| Legislation | Articles 6.16–6.20 Wet IB 2001 |
+
+**Drempel (threshold) 2025:**
+
+| Drempelinkomen (EUR) | Threshold |
+|---|---|
+| Up to EUR 9,344 | 1.65% |
+| EUR 9,344 — EUR 46,724 | EUR 154 + 5.75% of income above EUR 9,344 |
+| Above EUR 46,724 | EUR 2,303 + 1.65% of income above EUR 46,724 |
+
+### 3.3 Giftenaftrek (Charitable Donations) [T1]
+
+| Type | Rule |
+|---|---|
+| Gewone giften (regular donations) | Deductible above 1% of drempelinkomen (min EUR 60); max 10% of drempelinkomen |
+| Periodieke giften (periodic donations) | Fully deductible; no floor or ceiling |
+| Requirement for periodieke giften | Written agreement (notarieel or onderhandse akte) for ≥5 years |
+| Qualifying recipients | ANBI-registered institutions; SBBI for periodic |
+| Rate limitation | Deductible at max 36.97% (2025) |
+| Legislation | Articles 6.32–6.39 Wet IB 2001 |
+
+### 3.4 Studiekosten (Study Expenses) [T1]
+
+| Rule | Detail |
+|---|---|
+| Status 2025 | ABOLISHED since 2022. Replaced by STAP-budget (government scheme, not tax deduction) |
+| Exception | If study costs were committed before 2022 under old rules, transitional rules may apply — flag for advisor |
+
+### 3.5 Weekenduitgaven Gehandicapten (Disabled Dependents) [T1]
+
+| Rule | Detail |
+|---|---|
+| Deductible | Extra costs of caring for a severely disabled person (21+) who regularly visits |
+| Amount | Fixed amounts per day/overnight; depends on age and frequency |
+| Legislation | Article 6.25 Wet IB 2001 |
+
+---
+
+## Section 4 — Heffingskortingen (Tax Credits)
+
+Tax credits reduce the computed tax (not the taxable income). They are applied after tax computation.
+
+### Main Credits 2025 [T1]
+
+| Credit | Maximum Amount (EUR) | Phase-out | Notes |
+|---|---|---|---|
+| Algemene heffingskorting | 3,068 | Phases out from EUR 24,813 to EUR 76,817 income | Universal; reduces to EUR 0 at top |
+| Arbeidskorting (employment credit) | 5,174 | Phases out above EUR 43,071 | For those with employment/business income |
+| Inkomensafhankelijke combinatiekorting (IACK) | 2,950 | Requires youngest child < 12 and > EUR 6,073 income | Working parent credit |
+| Ouderenkorting (elderly credit) | 2,010 | Phases out above EUR 44,770 | For those at/above AOW age |
+| Alleenstaande-ouderenkorting | 524 | No phase-out | Single elderly receiving AOW supplement |
+| Jonggehandicaptenkorting | 898 | No phase-out | For those with Wajong benefit |
+| Levensloopverlofkorting | EUR 238 × participation years | Max based on years deposited | Transitional; levensloop scheme ended |
+| Korting groene beleggingen | 0.7% of Box 3 green investment value | Max EUR 65,072 per person | For green investment funds |
+
+### Algemene Heffingskorting Phase-Out Formula [T1]
+
+```
+If income ≤ EUR 24,813: full EUR 3,068
+If income between EUR 24,813 and EUR 76,817:
+  Reduction = 5.902% × (income − EUR 24,813)
+  Credit = EUR 3,068 − reduction
+If income ≥ EUR 76,817: EUR 0
+```
+
+### Arbeidskorting Phase-Out Formula [T1]
+
+```
+If income ≤ EUR 11,491: 8.425% × income
+If EUR 11,491 – EUR 24,821: EUR 968 + 29.861% × (income − EUR 11,491)
+If EUR 24,821 – EUR 43,071: EUR 4,947 + 1.248% × (income − EUR 24,821)
+If EUR 43,071 – EUR 124,935: EUR 5,174 − 6.317% × (income − EUR 43,071)
+If income > EUR 124,935: EUR 0
+```
+
+---
+
+## Section 5 — Business Investment Deductions
+
+### KIA — Kleinschaligheidsinvesteringsaftrek [T1]
+
+| Total Investment (EUR) | Deduction |
+|---|---|
+| 0 — 2,900 | No deduction |
+| 2,901 — 70,602 | 28% of investment amount |
+| 70,603 — 130,744 | EUR 19,769 (fixed) |
+| 130,745 — 392,230 | EUR 19,769 minus 7.56% of amount exceeding EUR 130,744 |
+| > 392,230 | No deduction |
+
+**Conditions:**
+- Per qualifying asset: minimum EUR 450 investment
+- Excludes: land, residential property, passenger cars, securities, goodwill
+- Legislation: Article 3.41 Wet IB 2001
+
+### EIA — Energie-investeringsaftrek (Energy Investment) [T1]
+
+| Parameter | Value 2025 |
+|---|---|
+| Rate | 45.5% of qualifying investment |
+| Minimum per asset | EUR 2,500 |
+| Maximum total per year | EUR 136,000,000 (per entity; effectively unlimited for SME) |
+| Qualification | Must be on Energielijst (published annually by RVO) |
+| Application | Within 3 months of commitment (opdrachtbevestiging) to RVO |
+| Legislation | Article 3.42 Wet IB 2001 |
+
+### MIA/Vamil — Milieu-investeringsaftrek / Willekeurige Afschrijving [T1]
+
+| Scheme | Benefit |
+|---|---|
+| MIA | 27%, 36%, or 45% additional deduction on qualifying environmental investments |
+| Vamil | Accelerated depreciation (75% in year 1) on qualifying investments |
+| Qualification | Must be on Milieulijst (published annually by RVO) |
+| Application | Within 3 months of purchase commitment to RVO |
+| Legislation | Articles 3.42a–3.42b Wet IB 2001 |
+
+### WBSO — R&D Tax Credit [T1]
+
+| Parameter | Value 2025 |
+|---|---|
+| First bracket rate | 32% on first EUR 350,000 R&D costs |
+| Second bracket rate | 16% on excess above EUR 350,000 |
+| Starters bonus | 40% first bracket rate (first 5 years) |
+| Benefit type | Reduction in payroll tax liability (loonheffingen) |
+| Application | RVO — before start of R&D period |
+| Legislation | Wet vermindering afdracht loonbelasting en premie voor de volksverzekeringen (WVA) |
+
+---
+
+## Section 6 — Box 3 Relevant Deductions & Exemptions
+
+### Box 3 Tax-Free Allowance 2025 [T1]
+
+| Parameter | Value |
+|---|---|
+| Heffingsvrij vermogen (per person) | EUR 57,000 |
+| Fiscal partners (combined) | EUR 114,000 |
+
+### Green Investment Exemption [T1]
+
+| Parameter | Value |
+|---|---|
+| Exempt amount (Box 3) | Up to EUR 65,072 per person in qualifying green funds |
+| Tax credit | 0.7% of exempt green investment value (separate from Box 3 exemption) |
+| Qualification | Investment must be in certified groene instelling |
+
+---
+
+## Section 7 — Evidence Requirements and Conservative Defaults
+
+### Evidence Checklist Per Deduction [T1]
+
+| Deduction | Required Evidence |
+|---|---|
+| Hypotheekrenteaftrek | Mortgage deed, annual interest statement (jaaropgave), WOZ description |
+| Specifieke zorgkosten | Medical invoices, insurance rejection letters, prescriptions, dietist declaration |
+| Giften (regular) | Bank statements showing payments to ANBI, donation receipts |
+| Giften (periodic) | Signed donation agreement (≥5 year), bank statements |
+| Alimentatie | Court order or notarial deed, bank transfer proof |
+| KIA | Purchase invoices (≥ EUR 450 per asset), asset register |
+| EIA/MIA | RVO confirmation (meldingsnummer), invoice, Energie/Milieulijst reference |
+
+### Conservative Defaults [T1]
+
+| Ambiguity | Default |
+|---|---|
+| Mortgage type unclear (pre/post 2013) | Apply strictest rules (annuity repayment required) — flag |
+| Medical expense reimbursement status unknown | Assume reimbursed (not deductible) — flag for client to confirm |
+| ANBI status of charity unconfirmed | Do NOT deduct — verify on belastingdienst.nl ANBI register |
+| Gift agreement duration unclear | Treat as regular gift (with floor and ceiling) — flag |
+| Investment qualifying for EIA/MIA not confirmed | Do NOT apply — verify on RVO Energielijst/Milieulijst |
+| Partner allocation unclear | Do NOT split deductions — flag for client |
+| Eigenwoningforfait WOZ value unknown | Cannot compute — request WOZ-beschikking |
+
+### Red Flags [T1]
+
+| Flag | Issue |
+|---|---|
+| Mortgage interest > 30% of gross income | High debt burden — verify loan documentation |
+| Medical deductions > EUR 5,000 | Verify all items have supporting documentation |
+| Charitable gifts > 10% of income | Exceeds ceiling for regular gifts — check if periodic |
+| KIA claimed on passenger car | Not eligible — exclude |
+| EIA/MIA without RVO confirmation number | Cannot claim — not valid without meldingsnummer |
+| Multiple homes claimed as eigen woning | Only ONE primary residence qualifies |
+| Deductions claimed for non-resident with no NL income | Kwalificerende buitenlandse belastingplichtige status needed |
+
+---
+
+## Section 8 — Computation Order
+
+### Complete Deduction Application Order [T1]
+
+```
+1. Compute gross income per box:
+   - Box 1: employment + business + property (eigen woning)
+   - Box 2: substantial interest (aanmerkelijk belang)
+   - Box 3: savings and investments (forfaitair)
+
+2. Apply Box 1 business deductions (if applicable):
+   - Zelfstandigenaftrek → Startersaftrek → MKB-winstvrijstelling
+   - KIA, EIA, MIA (investment deductions)
+
+3. Apply eigen woning saldo:
+   - Eigenwoningforfait (add) − mortgage interest (subtract) = saldo
+   - If negative: Box 1 deduction
+   - If positive: Hillen-aftrek may eliminate part
+
+4. Determine persoonsgebonden aftrek:
+   - Sum of: alimentatie + zorgkosten (above drempel) + giften (above floor, within ceiling)
+   - Deduct from Box 1 first; if Box 1 insufficient → Box 3 → Box 2
+
+5. Compute tax per box at applicable rates
+
+6. Apply heffingskortingen (tax credits):
+   - Algemene heffingskorting (phase-out based on Box 1 income)
+   - Arbeidskorting (if employment/business income exists)
+   - Other applicable credits (IACK, ouderenkorting, etc.)
+
+7. Final tax payable = Sum box taxes − total credits
+   - Minimum EUR 0 (credits cannot create negative tax)
+```
+
+---
+
+## Section 9 — Official Source Verification Requirements
+
+Before any deduction amount, threshold, or eligibility criterion is used:
+
+1. Verify practical deduction rules on `belastingdienst.nl/aftrek`
+2. Verify statutory text on `wetten.overheid.nl` (Wet IB 2001, relevant articles)
+3. For investment schemes: verify qualifying lists on `rvo.nl`
+4. For ANBI status: verify on `belastingdienst.nl/anbi`
+5. Record exact URL and retrieval date (YYYY-MM-DD)
+6. If source unavailable or conflicting: mark as **UNVERIFIED** and require professional confirmation
+
+---
+
+## Section 10 — Escalation Points
+
+Escalate to a qualified belastingadviseur when:
+
+- Eigen woning qualification disputed (e.g., two residences, partial rental)
+- Complex mortgage structures (multiple loans, box migration)
+- Non-resident taxpayer claiming deductions (kwalificerende buitenlandse belastingplichtige)
+- High-value medical expense claims requiring medical evidence review
+- Partner allocation optimisation (fiscal partnership choices)
+- Investment deduction eligibility disputes with Belastingdienst
+- Anti-abuse provisions triggered (e.g., recycling box migration)
+- Transitional rules from abolished deductions (study costs, FOR)
+
+---
+
+**⚠️ DISCLAIMER: This skill provides workflow support only and does not constitute tax advice. All deduction positions must be reviewed and signed off by a qualified Dutch belastingadviseur before filing. Thresholds and amounts change annually — verify all figures against belastingdienst.nl for the applicable tax year.**
+
+---
+
+*OpenAccountants — open-source tax computation skills*
+*openaccountants.com*

--- a/skills/international/netherlands/nl-payroll-tax.md
+++ b/skills/international/netherlands/nl-payroll-tax.md
@@ -1,0 +1,292 @@
+---
+name: nl-payroll-tax
+description: >
+  Use this skill whenever asked about Dutch payroll taxes (loonheffingen) or the work cost scheme (werkkostenregeling / WKR). Trigger on phrases like "loonheffingen", "payroll tax Netherlands", "werkkostenregeling", "WKR", "loonbelasting", "premies volksverzekeringen", "premies werknemersverzekeringen", "wage tax NL", "eindheffing", "vrije ruimte", "salary administration", "loonadministratie", "werkgeverslasten", "employer costs NL", "payroll period filing", "loonstrook", "jaarloonopgave", "UWV premies", "WAO/WIA", "ZW premie", "AWf premie", "Whk premie", or any question about Dutch employer withholding, social contributions, or employee benefit taxation. Also trigger when reviewing payroll runs, computing employer costs, or advising on WKR allocation. ALWAYS read this skill before touching any Dutch payroll tax work.
+version: 1.0
+jurisdiction: NL
+tax_year: 2025
+category: international
+depends_on:
+  - income-tax-workflow-base
+---
+
+# Netherlands Payroll Tax — Loonheffingen & Werkkostenregeling (WKR) v1.0
+
+> **Based on work by [John in 't Hout (@johnhout)](https://github.com/johnhout/knowledge-work-belastingzaken)**, licensed under MIT. Adapted for the OpenAccountants format.
+
+---
+
+## Section 1 — Quick Reference
+
+| Field | Value |
+|---|---|
+| Country | Netherlands (Koninkrijk der Nederlanden) |
+| Tax | Loonheffingen (wage tax + social insurance contributions) |
+| Currency | EUR only |
+| Period | Per pay period (month/4-week); annual reconciliation (loonaangifte) |
+| Primary legislation | Wet op de loonbelasting 1964 (Wet LB); Wet financiering sociale verzekeringen (Wfsv) |
+| WKR legislation | Articles 31, 31a Wet LB 1964 |
+| Tax authority | Belastingdienst |
+| Filing portal | Loonaangifte via payroll software or Mijn Belastingdienst |
+| Contributor | Open Accountants Community |
+| Validated by | Pending — requires sign-off by a qualified Dutch belastingadviseur or salarisadministrateur |
+| Skill version | 1.0 |
+
+### Components of Loonheffingen [T1]
+
+| Component | Paid by | Rate/Notes |
+|---|---|---|
+| Loonbelasting (wage tax) | Employee (withheld by employer) | Progressive rates aligned with Box 1 IB |
+| Premie volksverzekeringen (AOW/Anw/Wlz) | Employee (withheld by employer) | Combined ~27.65% on first bracket |
+| Premie werknemersverzekeringen (WW/WIA/ZW) | Employer | Various rates; see table below |
+| Inkomensafhankelijke bijdrage Zvw | Employer | 6.57% (2025) |
+
+### Volksverzekeringen Rates 2025 [T1]
+
+| Premium | Rate | Max income (EUR) |
+|---|---|---|
+| AOW (state pension) | 17.90% | EUR 38,441 |
+| Anw (survivors) | 0.10% | EUR 38,441 |
+| Wlz (long-term care) | 9.65% | EUR 38,441 |
+| **Total** | **27.65%** | **EUR 38,441** |
+
+These are withheld from the employee's gross salary (combined with wage tax in bracket 1 rate of 35.82%).
+
+### Werknemersverzekeringen (Employer Contributions) 2025 [T1]
+
+| Premium | Rate | Max salary base (EUR) | Notes |
+|---|---|---|---|
+| AWf (unemployment — general) | 2.64% (fixed) / 7.64% (flex) | EUR 66,956 | Fixed contract = lower rate |
+| Whk (disability — differentiated) | Sector-dependent (avg ~1.5%) | EUR 66,956 | Based on sector and claims history |
+| Aof (disability — basic) | 6.18% (large) / 5.82% (small employer) | EUR 66,956 | Small = < 25× avg premium base |
+| **Zvw (health insurance)** | **6.57%** | **EUR 66,956** | Employer-paid (not withheld from employee) |
+
+### AWf Premium — Contract Type Distinction [T1]
+
+| Contract type | AWf rate 2025 |
+|---|---|
+| Permanent contract (vast contract, schriftelijk) | 2.64% |
+| Flexible contract (bepaalde tijd, oproep, uitzend) | 7.64% |
+
+**Conditions for low rate:**
+- Written permanent contract (schriftelijke arbeidsovereenkomst voor onbepaalde tijd)
+- Not an on-call contract (geen oproepovereenkomst)
+- Employee works ≥ contracted hours (no excessive overtime correction needed)
+
+### Wage Tax Tables 2025 [T1]
+
+The loonbelasting/premie volksverzekeringen are computed using Belastingdienst-provided tax tables:
+
+| Table type | Application |
+|---|---|
+| White table (witte tabel) | Standard employment |
+| Green table (groene tabel) | One-off payments, holiday allowance, bonuses |
+| Anonymous table | No BSN or ID provided — 52% flat rate |
+| Table for DGA | DGA monthly minimum salary |
+
+---
+
+## Section 2 — Werkkostenregeling (WKR) — Work Cost Scheme
+
+### Concept [T1]
+
+The WKR allows employers to provide tax-free benefits to employees within a "free space" (vrije ruimte) budget. Benefits exceeding the free space are subject to 80% flat-rate employer tax (eindheffing).
+
+### Vrije Ruimte 2025 [T1]
+
+| Fiscal wage base (loonsom) | Free space percentage |
+|---|---|
+| First EUR 400,000 | 1.92% |
+| Above EUR 400,000 | 1.18% |
+
+**Example:** Employer with EUR 1,000,000 wage base:
+- Free space = EUR 400,000 × 1.92% + EUR 600,000 × 1.18% = EUR 7,680 + EUR 7,080 = EUR 14,760
+
+### WKR Categories [T1]
+
+| Category | Treatment | Examples |
+|---|---|---|
+| Gerichte vrijstellingen (targeted exemptions) | Fully exempt — do NOT count against vrije ruimte | Travel allowance (max EUR 0.23/km), training costs, verhuiskostenvergoeding, extraterritoriale kosten (30% ruling) |
+| Nihilwaarderingen (nil valuations) | Valued at EUR 0 — do NOT count against vrije ruimte | Workplace facilities (coffee, fruit), work clothing required for job, tools used at workplace |
+| Vrije ruimte (free space) | Counts against budget; excess taxed at 80% | Christmas gifts, company parties, non-targeted benefits, staff outings |
+| Individueel belast (individually taxed) | Taxed as employee wage (not WKR) | Benefits employee chooses to have taxed individually |
+
+### Gerichte Vrijstellingen — Key Amounts 2025 [T1]
+
+| Exemption | Amount/Rule |
+|---|---|
+| Travel allowance (reiskostenvergoeding) | Max EUR 0.23 per km (no cap on distance) |
+| Relocation allowance (verhuiskostenvergoeding) | Max EUR 7,750 + actual moving costs |
+| Study/training costs | Fully exempt if related to (future) employment |
+| Meals at workplace (maaltijden) | Valued at EUR 3.55 per meal (2025); excess over employee contribution = WKR |
+| Extraterritoriale kosten (30% ruling) | 30% of salary exempt or actual extraterritorial costs |
+| Work-from-home allowance (thuiswerkvergoeding) | EUR 2.35 per day (2025) |
+| Internet/phone (if partly business) | Reasonable business portion exempt |
+
+### Eindheffing (Flat-Rate Tax on Excess) [T1]
+
+| Situation | Rate |
+|---|---|
+| Benefits exceeding vrije ruimte | 80% eindheffing (paid by employer) |
+| Benefits exceeding EUR 2,400/occasion (gebruikelijkheidstoets) | Cannot use WKR — must be individually taxed |
+
+**Gebruikelijkheidstoets:** A single benefit provision cannot exceed EUR 2,400 per employee per occasion under the WKR. If it does, it must be individually taxed or split.
+
+---
+
+## Section 3 — Filing Obligations and Deadlines
+
+### Periodic Filing [T1]
+
+| Obligation | Frequency | Deadline |
+|---|---|---|
+| Loonaangifte (payroll tax return) | Per pay period (monthly or 4-weekly) | Last day of month following pay period |
+| Payment of loonheffingen | Per pay period | Same as filing deadline |
+| Correctie loonaangifte | As needed | Within 5 years; penalties may apply after initial filing |
+
+### Annual Obligations [T1]
+
+| Obligation | Deadline | Notes |
+|---|---|---|
+| Jaaropgave (annual statement to employees) | 28 February | Employer provides to each employee |
+| WKR eindheffing determination | In first payroll return of following year | Determine if vrije ruimte exceeded; report 80% tax |
+| Renseignementen (information returns) | Various | Third-party payments > EUR 5,000/year |
+
+### Key Dates [T1]
+
+| Event | Date |
+|---|---|
+| Payroll return deadline (monthly) | Last day of month + 1 month |
+| Annual employer statement (jaaropgave) | 28 February |
+| WKR assessment moment | 31 December (assess full year usage) |
+| Report eindheffing | First return period of new year |
+
+---
+
+## Section 4 — Required Inputs and Refusal Catalogue
+
+### Required Inputs
+
+**Minimum viable:** Payroll run summary for the period. Employee count and contract types. Gross salary totals.
+
+**Recommended:** Detailed payroll journal, WKR administration (benefits provided per category), sector classification for Whk, AWf contract type split.
+
+**Ideal:** Full payroll software export, employment contracts, WKR policy document, expense claim registers, prior-year WKR reconciliation, UWV correspondence.
+
+### Refusal Catalogue
+
+**R-LH-1 — No payroll data available.** "Cannot compute loonheffingen without payroll run data. Provide at minimum gross salary totals per period."
+
+**R-LH-2 — Contract types unclear.** "Cannot determine AWf rate (2.64% vs 7.64%) without confirmed contract types. Flag all employees as flex rate (conservative) until confirmed."
+
+**R-LH-3 — WKR allocation undocumented.** "Cannot confirm vrije ruimte compliance without benefit-by-benefit administration. Flag for payroll advisor."
+
+**R-LH-4 — Anonymous employee (no BSN).** "Must apply 52% anonymous rate. Cannot file normally without BSN and ID copy."
+
+**R-LH-5 — 30% ruling status unclear.** "Cannot apply extraterritorial exemption without confirmed Belastingdienst ruling. Apply standard treatment."
+
+---
+
+## Section 5 — Computation Examples
+
+### Example: Monthly Payroll Tax Computation
+
+```
+Given:
+- Gross monthly salary: EUR 5,000
+- Employee: permanent contract, below AOW age
+- No special deductions
+
+Step 1: Determine loonbelasting + premie volksverzekeringen
+  → Use white monthly table from Belastingdienst
+  → Approximate: EUR 5,000 × 35.82% = EUR 1,791 (first bracket)
+  → Actual amount per tax table (includes heffingskortingen)
+
+Step 2: Employer premiums:
+  → AWf (permanent): EUR 5,000 × 2.64% = EUR 132
+  → Aof: EUR 5,000 × 5.82% = EUR 291 (small employer)
+  → Whk: EUR 5,000 × 1.50% = EUR 75 (example sector rate)
+  → Zvw: EUR 5,000 × 6.57% = EUR 328.50
+
+Step 3: Total employer cost above gross:
+  → EUR 132 + EUR 291 + EUR 75 + EUR 328.50 = EUR 826.50
+
+Step 4: Employee net (approximate):
+  → EUR 5,000 − EUR 1,791 + heffingskortingen (from table) = net salary
+```
+
+### Example: WKR Assessment
+
+```
+Given:
+- Annual wage base (fiscale loonsom): EUR 800,000
+- Benefits provided: Christmas packages EUR 8,000, staff party EUR 5,000, bicycle scheme EUR 3,000
+
+Step 1: Calculate vrije ruimte:
+  → EUR 400,000 × 1.92% = EUR 7,680
+  → EUR 400,000 × 1.18% = EUR 4,720
+  → Total: EUR 12,400
+
+Step 2: Determine which benefits count:
+  → Christmas packages: EUR 8,000 (vrije ruimte)
+  → Staff party: EUR 5,000 (vrije ruimte)
+  → Bicycle scheme: EUR 3,000 (vrije ruimte — not a gerichte vrijstelling)
+  → Total allocated: EUR 16,000
+
+Step 3: Excess:
+  → EUR 16,000 − EUR 12,400 = EUR 3,600
+
+Step 4: Eindheffing:
+  → EUR 3,600 × 80% = EUR 2,880 (employer pays)
+```
+
+---
+
+## Section 6 — Control Checks and Red Flags
+
+| Check | Issue if triggered |
+|---|---|
+| AWf rate mismatch vs contract type | Incorrect premium — back-payment risk |
+| WKR benefit > EUR 2,400 per person per occasion | Gebruikelijkheidstoets failed — must individually tax |
+| Vrije ruimte exceeded without eindheffing | Missing tax payment |
+| Employee hours > 130% of contracted hours | AWf low rate at risk (herzieningsregeling) |
+| Late filing (> 1 month) | EUR 65 fine per return; escalates |
+| Missing jaaropgave | Employee cannot file IB return correctly |
+| DGA on payroll below EUR 56,000 | Gebruikelijk loon non-compliance |
+| No written employment contracts | All employees default to flex AWf rate |
+
+---
+
+## Section 7 — Official Source Verification Requirements
+
+Before any rate, threshold, or deadline is used in output:
+
+1. Verify payroll filing instructions on `belastingdienst.nl/loonheffingen`
+2. Verify premium rates in the annual "Nieuwsbrief Loonheffingen" (Belastingdienst)
+3. Verify statutory text on `wetten.overheid.nl` (Wet LB 1964, Wfsv)
+4. Record exact URL and retrieval date (YYYY-MM-DD)
+5. If source unavailable or conflicting: mark as **UNVERIFIED** and require professional confirmation
+
+---
+
+## Section 8 — Escalation Points
+
+Escalate to a qualified salarisadviseur or belastingadviseur when:
+
+- Employee/contractor classification (dienstverband vs. opdracht) is unclear
+- 30% ruling eligibility or application questions
+- Cross-border employment (posting, frontier worker, split payroll)
+- Payroll corrections affecting multiple prior periods
+- Werknemersverzekeringen premium disputes with UWV
+- WKR exceeds vrije ruimte by material amount (> EUR 10,000)
+- Reorganisation or mass dismissal payroll implications
+- Expatriate or DGA compensation structuring
+
+---
+
+**⚠️ DISCLAIMER: This skill provides workflow support only and does not constitute tax or payroll advice. All positions must be reviewed and signed off by a qualified Dutch belastingadviseur or salarisadministrateur before filing. Rates and thresholds change annually — verify against the current year's Nieuwsbrief Loonheffingen from belastingdienst.nl.**
+
+---
+
+*OpenAccountants — open-source tax computation skills*
+*openaccountants.com*

--- a/skills/international/netherlands/nl-tax-objection.md
+++ b/skills/international/netherlands/nl-tax-objection.md
@@ -1,0 +1,349 @@
+---
+name: nl-tax-objection
+description: >
+  Use this skill whenever asked about Dutch tax objection procedures (bezwaar) or tax correspondence with the Belastingdienst. Trigger on phrases like "bezwaar", "bezwaarschrift", "objection letter", "tax objection Netherlands", "reactie op aanslag", "aanslag betwisten", "bezwaartermijn", "6 weken termijn", "ambtshalve vermindering", "beroep belastingrechter", "motiveringsbrief", "tax appeal NL", "machtiging belastingdienst", "pro forma bezwaar", "uitspraak op bezwaar", "hoorzitting", or any question about objecting to a Dutch tax assessment, responding to Belastingdienst correspondence, or preparing tax dispute documentation. This skill covers the bezwaar procedure, deadlines, required elements, escalation to beroep, and correspondence templates. ALWAYS read this skill before drafting any Dutch tax objection or Belastingdienst correspondence.
+version: 1.0
+jurisdiction: NL
+tax_year: 2025
+category: international
+depends_on:
+  - income-tax-workflow-base
+---
+
+# Netherlands Tax Objection — Bezwaar & Correspondentie v1.0
+
+> **Based on work by [John in 't Hout (@johnhout)](https://github.com/johnhout/knowledge-work-belastingzaken)**, licensed under MIT. Adapted for the OpenAccountants format.
+
+---
+
+## Section 1 — Quick Reference
+
+| Field | Value |
+|---|---|
+| Country | Netherlands (Koninkrijk der Nederlanden) |
+| Procedure | Bezwaar (objection) against tax assessments and decisions |
+| Currency | EUR only |
+| Primary legislation | Algemene wet bestuursrecht (Awb), Chapter 6 & 7; Algemene wet inzake rijksbelastingen (AWR) |
+| Tax authority | Belastingdienst |
+| Portal | Mijn Belastingdienst / Post bezwaar (or postal submission) |
+| Contributor | Open Accountants Community |
+| Validated by | Pending — requires sign-off by a qualified Dutch belastingadviseur |
+| Skill version | 1.0 |
+
+### Key Deadlines [T1]
+
+| Deadline | Rule |
+|---|---|
+| Bezwaartermijn | 6 weeks from date on assessment (dagtekening van de aanslag/beschikking) |
+| Pro forma bezwaar | Within 6 weeks; motivation can follow within reasonable term set by inspector |
+| Belastingdienst response deadline | They must decide within 6 weeks (or extended: max 6 months after receiving complete objection) |
+| Beroep (appeal) deadline | 6 weeks from uitspraak op bezwaar (decision on objection) |
+| Ambtshalve vermindering | Within 5 years from end of the tax year to which assessment relates |
+
+### Procedure Overview [T1]
+
+```
+Assessment received (aanslag/beschikking)
+        │
+        ▼ (within 6 weeks)
+   File BEZWAAR
+        │
+        ├─── Inspector reviews (may invite for hoorzitting)
+        │
+        ▼
+   UITSPRAAK OP BEZWAAR (decision)
+        │
+        ├─── Fully granted → assessment corrected
+        ├─── Partially granted → partial correction
+        └─── Denied (afgewezen) → option to file BEROEP
+                    │
+                    ▼ (within 6 weeks)
+               BEROEP bij Rechtbank (tax court)
+                    │
+                    ▼
+               HOGER BEROEP bij Gerechtshof
+                    │
+                    ▼
+               CASSATIE bij Hoge Raad
+```
+
+### Types of Objectable Decisions [T1]
+
+| Decision Type | Dutch Term | Example |
+|---|---|---|
+| Income tax assessment | Aanslag inkomstenbelasting | Annual IB assessment |
+| Corporate tax assessment | Aanslag vennootschapsbelasting | Annual VPB assessment |
+| VAT assessment | Naheffingsaanslag omzetbelasting | BTW correction |
+| Penalty decision | Boetebeschikking | Late filing penalty |
+| Interest charge | Beschikking belastingrente | Interest on assessment |
+| Provisional assessment | Voorlopige aanslag | If disagree with estimate |
+| Loss determination | Verliesvaststellingsbeschikking | Denied or reduced loss |
+| WOZ valuation | WOZ-beschikking | Property value dispute |
+
+---
+
+## Section 2 — Bezwaar Requirements
+
+### Mandatory Elements (Article 6:5 Awb) [T1]
+
+A valid bezwaar MUST contain:
+
+| Element | Detail |
+|---|---|
+| Name and address | Full name and postal address of taxpayer |
+| Date | Date of the bezwaar letter |
+| Description of decision | Aanslagnummer (assessment number) and date of decision being objected to |
+| Grounds (gronden) | The reasons why the decision is incorrect — factual AND legal basis |
+| Signature | Handwritten or digital signature |
+| Power of attorney (if representative) | Machtiging signed by taxpayer authorising representative |
+
+### Optional but Recommended Elements [T1]
+
+| Element | Purpose |
+|---|---|
+| Request for postponement of payment (uitstel van betaling) | Prevents collection during objection procedure |
+| Request for hoorzitting (hearing) | Right to be heard before decision |
+| Supporting documents (bijlagen) | Evidence supporting the objection grounds |
+| Summary of financial impact | Quantifies the disputed amount |
+| Preferred remedy | What outcome the taxpayer requests |
+
+### Pro Forma Bezwaar [T1]
+
+If the 6-week deadline is approaching and full grounds cannot yet be prepared:
+
+| Step | Action |
+|---|---|
+| 1 | File bezwaar within 6 weeks stating it is "pro forma" |
+| 2 | State: "De gronden van het bezwaar volgen zo spoedig mogelijk" |
+| 3 | Inspector will set a reasonable deadline for motivation (usually 4–6 weeks) |
+| 4 | File full motivation before the set deadline |
+| 5 | If deadline for motivation is missed: bezwaar may be declared niet-ontvankelijk |
+
+---
+
+## Section 3 — Bezwaar Letter Structure
+
+### Template Structure (Dutch) [T1]
+
+```
+[Naam en adres afzender]
+[Datum]
+
+Belastingdienst / [kantoornaam]
+[Adres]
+[Postcode + Plaats]
+
+Betreft: Bezwaarschrift [type aanslag/beschikking]
+Aanslagnummer: [nummer]
+Dagtekening: [datum aanslag]
+Belastingjaar: [jaar]
+BSN: [burgerservicenummer]
+
+Geachte heer/mevrouw,
+
+Hierbij maak ik bezwaar tegen de bovengenoemde [aanslag/beschikking] 
+van [datum dagtekening].
+
+[GRONDEN VAN HET BEZWAAR]
+
+1. Feitelijke grond: [beschrijving feit dat onjuist is verwerkt]
+2. Juridische grond: [wetsartikel / beleid dat van toepassing is]
+3. Gewenste correctie: [welk bedrag en waarom]
+
+[ONDERBOUWING]
+Ter onderbouwing verwijs ik naar de bijgevoegde stukken:
+- Bijlage 1: [omschrijving]
+- Bijlage 2: [omschrijving]
+
+[VERZOEKEN]
+- Ik verzoek u de aanslag te verminderen met EUR [bedrag].
+- Ik verzoek om uitstel van betaling voor het betwiste bedrag 
+  op grond van artikel 25 Invorderingswet 1990.
+- Ik wens te worden gehoord op grond van artikel 7:2 Awb.
+
+Hoogachtend,
+
+[Handtekening]
+[Naam]
+```
+
+### Letter Quality Checklist [T1]
+
+| Check | Required |
+|---|---|
+| Within 6-week deadline? | YES — or letter is niet-ontvankelijk |
+| Assessment number included? | YES — identifies the specific decision |
+| Factual grounds stated? | YES — what fact is wrong |
+| Legal grounds stated? | YES — what law/rule supports the objection |
+| Quantified impact? | Recommended — EUR amount in dispute |
+| Supporting documents attached? | Recommended — strengthens position |
+| Payment postponement requested? | Recommended — prevents collection |
+| Hearing requested? | Optional — right under Awb |
+| Signed? | YES — mandatory |
+| Power of attorney attached (if representative)? | YES if advisor files on behalf |
+
+---
+
+## Section 4 — Specific Objection Scenarios
+
+### 4.1 Objection to IB Assessment [T1]
+
+| Common grounds | Evidence needed |
+|---|---|
+| Deduction not applied (aftrek niet verwerkt) | Proof of expense, eligibility documentation |
+| Income incorrectly included | Correct annual statement (jaaropgave), bank records |
+| Wrong box classification | Documentation proving correct classification |
+| Credits not applied (heffingskortingen) | Evidence of eligibility (e.g., working parent, AOW) |
+| Estimated assessment (geschatte aanslag) | Actual income documentation |
+
+### 4.2 Objection to Penalty (Boete) [T1]
+
+| Ground | Argument |
+|---|---|
+| Reasonable cause (afwezigheid van alle schuld) | Circumstances beyond control prevented timely filing |
+| Disproportionate penalty | Amount is unreasonable given circumstances |
+| Procedural error | Penalty not properly motivated by inspector |
+| Voluntarily corrected (inkeer) | Filed correction before discovery — reduced penalty |
+
+**Penalty reduction factors:**
+
+| Circumstance | Effect |
+|---|---|
+| First offense | Often reduced to warning (no financial penalty) |
+| Plausible cause (pleitbaar standpunt) | Penalty reduced or eliminated |
+| Voluntary disclosure (inkeer) | Significant reduction (0% if within 2 years) |
+| Financial hardship | Payment arrangement or reduction |
+
+### 4.3 Objection to WOZ Valuation [T1]
+
+| Ground | Evidence |
+|---|---|
+| Value too high compared to sale prices | Comparable sales data (vergelijkingsobjecten) |
+| Structural defects not accounted for | Expert report (taxatierapport) |
+| Value date vs condition date mismatch | Documentation of changes since valuation date (1 Jan prior year) |
+| Wrong object characteristics | Correct surface area, number of rooms, etc. |
+
+---
+
+## Section 5 — Uitstel van Betaling (Payment Postponement)
+
+### During Bezwaar [T1]
+
+| Rule | Detail |
+|---|---|
+| Automatic for disputed portion | If bezwaar includes payment postponement request, collection is suspended for the disputed amount |
+| Undisputed portion | Must still be paid by original deadline |
+| Interest | Belastingrente continues to accrue during postponement |
+| Legislation | Article 25 Invorderingswet 1990 |
+| How to request | Include in bezwaar letter OR separately to invordering department |
+
+---
+
+## Section 6 — After the Bezwaar Decision
+
+### Possible Outcomes [T1]
+
+| Outcome | Next Step |
+|---|---|
+| Fully granted (gegrond) | Assessment corrected; any overpayment refunded |
+| Partially granted | Review residual difference; consider beroep for remainder |
+| Denied (ongegrond) | File beroep at Rechtbank within 6 weeks |
+| Not admissible (niet-ontvankelijk) | Usually deadline missed — consider ambtshalve vermindering |
+
+### Beroep (Court Appeal) [T1]
+
+| Parameter | Rule |
+|---|---|
+| Deadline | 6 weeks from uitspraak op bezwaar |
+| Court | Rechtbank (sector bestuursrecht / belastingkamer) |
+| Court fee (griffierecht) | EUR 53 (individuals) / EUR 365 (legal entities) — 2025 |
+| Process | Written procedure; may include oral hearing (zitting) |
+| Representation | Not mandatory but strongly recommended |
+| Possible outcomes | Assessment corrected, partially corrected, or confirmed |
+| Higher appeal | Gerechtshof (6 weeks after Rechtbank decision) |
+| Cassation | Hoge Raad — only on legal grounds (no new facts) |
+
+### Ambtshalve Vermindering (Ex Officio Reduction) [T1]
+
+| Situation | Rule |
+|---|---|
+| When | Bezwaar deadline missed OR new facts emerge |
+| Deadline | Within 5 years from end of relevant tax year |
+| Standard | Must demonstrate assessment is "onmiskenbaar onjuist" (manifestly incorrect) |
+| No right of appeal | If denied, no beroep at court — only Nationale Ombudsman |
+| Legislation | Article 9.6 Wet IB 2001; Besluit Fiscaal Bestuursrecht |
+
+---
+
+## Section 7 — Required Inputs and Refusal Catalogue
+
+### Required Inputs
+
+**Minimum viable:** Copy of the assessment/decision being objected to (aanslag/beschikking). Date of assessment (dagtekening). Taxpayer's BSN and contact details. Description of what is disputed and why.
+
+**Recommended:** Supporting calculations, relevant correspondence from Belastingdienst, prior-year filings, evidence documents for disputed items.
+
+**Ideal:** Complete dossier including all prior correspondence, professional advisor's analysis, quantified alternative computation, and legal basis memo.
+
+### Refusal Catalogue
+
+**R-BZ-1 — No assessment copy available.** "Cannot draft bezwaar without the actual assessment document. Provide aanslag or beschikking including number and date."
+
+**R-BZ-2 — Deadline possibly expired.** "Bezwaartermijn is 6 weeks from dagtekening. If deadline has passed, regular bezwaar is niet-ontvankelijk. Consider ambtshalve vermindering instead."
+
+**R-BZ-3 — No factual grounds identifiable.** "A bezwaar requires concrete grounds (gronden). Cannot draft without knowing what specific item is disputed and why."
+
+**R-BZ-4 — Complex legal interpretation required.** "The grounds involve contested legal interpretation. Escalate to a belastingadviseur or tax lawyer (belastingadvocaat)."
+
+**R-BZ-5 — High financial exposure (> EUR 25,000 disputed).** "Given the amount in dispute, professional representation is strongly recommended before filing."
+
+---
+
+## Section 8 — Conservative Defaults
+
+| Situation | Default |
+|---|---|
+| Deadline calculation uncertain | Assume shortest possible deadline — file immediately or pro forma |
+| Grounds partially supported by evidence | File on supported grounds only; flag unsupported for further documentation |
+| Legal interpretation unclear | State the most conservative interpretation; flag for professional review |
+| Payment postponement: unclear if automatic | Always request explicitly in the letter |
+| Hoorzitting offered | Always accept — right to be heard strengthens position |
+| Representative without machtiging | Do NOT file — obtain signed power of attorney first |
+| Ambtshalve vs bezwaar unclear | If within 6 weeks: file bezwaar (preserves appeal rights) |
+
+---
+
+## Section 9 — Official Source Verification Requirements
+
+Before any deadline, procedure, or legal reference is used:
+
+1. Verify objection procedures on `belastingdienst.nl/bezwaar`
+2. Verify statutory text on `wetten.overheid.nl` (Awb Chapter 6–7, AWR)
+3. Verify court procedures on `rechtspraak.nl`
+4. Record exact URL and retrieval date (YYYY-MM-DD)
+5. If source unavailable or conflicting: mark as **UNVERIFIED** and require professional confirmation
+
+---
+
+## Section 10 — Escalation Points
+
+Escalate to a qualified belastingadviseur or belastingadvocaat when:
+
+- Disputed amount exceeds EUR 25,000
+- Legal interpretation is contested or novel
+- Penalty involves opzet (intent) or grove schuld (gross negligence)
+- Beroep (court procedure) is being considered
+- Cross-border element affects the objection
+- Criminal tax fraud investigation (FIOD) is parallel
+- Multiple related assessments across years are disputed
+- Objection involves fiscal unity or group-level issues
+- Time pressure: less than 1 week remaining before deadline
+
+---
+
+**⚠️ DISCLAIMER: This skill provides workflow and drafting support only and does not constitute legal or tax advice. All bezwaar letters and tax correspondence must be reviewed and signed off by a qualified Dutch belastingadviseur or belastingadvocaat before submission. Deadlines are strict — missing the 6-week bezwaartermijn eliminates appeal rights.**
+
+---
+
+*OpenAccountants — open-source tax computation skills*
+*openaccountants.com*

--- a/skills/international/spain/es-autonomous-worker.md
+++ b/skills/international/spain/es-autonomous-worker.md
@@ -1,0 +1,397 @@
+---
+name: es-autonomous-worker
+description: >
+  Use this skill whenever asked about Spanish self-employed (autónomo) tax and social security obligations beyond IRPF computation. Trigger on phrases like "autonomo", "autónomo", "cuota de autonomos", "cuota seguridad social autonomo", "RETA", "tarifa plana", "alta autonomo", "baja autonomo", "cotizacion por ingresos reales", "obligaciones fiscales autonomo", "modelos autonomo", "Modelo 303", "Modelo 130", "Modelo 390", "Modelo 349", "calendario fiscal autonomo", "pluriactividad", "autonomo societario", "facturacion autonomo", "estimacion directa", "libro registro", "IGIC autonomo", "IPSI autonomo", "autonomo Canarias", "autonomo Ceuta Melilla", "cuanto paga un autonomo", or any question about the complete fiscal and social security picture for a self-employed worker in Spain. ALWAYS read this skill before advising on autónomo setup, ongoing obligations, or take-home pay calculations.
+version: 1.0
+jurisdiction: ES
+tax_year: 2025
+category: international
+depends_on:
+  - es-income-tax
+  - es-social-contributions
+---
+
+# Spain Autónomo (Self-Employed Worker) Complete Obligations Skill v1.0
+
+> **Based on work by [Nambu89 (Impuestify)](https://github.com/Nambu89/Impuestify)** and **[Pau March (larenta)](https://github.com/paumrch/larenta)**, licensed under MIT. Adapted for the OpenAccountants format.
+
+---
+
+## Section 1 -- Quick Reference
+
+| Field | Value |
+|---|---|
+| Country | Spain (Estado Español) |
+| Subject | Trabajador Autónomo (Self-Employed Worker / Sole Trader) |
+| Currency | EUR only |
+| Legal framework | Ley 20/2007 (Estatuto del Trabajo Autónomo); RDL 13/2022 (cotización por ingresos reales) |
+| Social Security regime | RETA (Régimen Especial de Trabajadores Autónomos) |
+| Tax regime | IRPF (estimación directa simplificada by default) |
+| Tax authority | AEAT (tax) + Tesorería General de la Seguridad Social (TGSS) (social security) |
+| Key filing forms | Modelo 036/037 (census), Modelo 130 (quarterly IRPF), Modelo 303 (quarterly IVA), Modelo 100 (annual IRPF) |
+
+---
+
+## Section 2 -- Cuota de Autónomos 2025: Cotización por Ingresos Reales
+
+Since January 2023, self-employed workers pay Social Security (cuota de autónomos) based on actual income (rendimientos netos). The system has 15 brackets deployed gradually until 2032.
+
+### The 15 Contribution Brackets (Tramos) -- 2025
+
+| Tramo | Net Monthly Income (EUR) | Minimum Contribution (EUR/month) |
+|---|---|---|
+| 1 | ≤ 670 | 200 |
+| 2 | 670.01 - 900 | 250 |
+| 3 | 900.01 - 1,166.70 | 267 |
+| 4 | 1,166.71 - 1,300 | 291 |
+| 5 | 1,300.01 - 1,500 | 294 |
+| 6 | 1,500.01 - 1,700 | 294 |
+| 7 | 1,700.01 - 1,850 | 310 |
+| 8 | 1,850.01 - 2,030 | 315 |
+| 9 | 2,030.01 - 2,330 | 320 |
+| 10 | 2,330.01 - 2,760 | 330 |
+| 11 | 2,760.01 - 3,190 | 350 |
+| 12 | 3,190.01 - 3,620 | 370 |
+| 13 | 3,620.01 - 4,050 | 390 |
+| 14 | 4,050.01 - 6,000 | 400 |
+| 15 | > 6,000 | 530 |
+
+**Contribution rate:** 31.4% of chosen base de cotización (the contribution amounts above are the minimums -- workers can choose higher bases within their bracket for better future pensions).
+
+### How to Calculate Net Monthly Income (Rendimiento Neto)
+
+For autónomos persona física in estimación directa:
+
+```
+1. Annual gross income (ingresos brutos)
+2. MINUS deductible expenses (gastos deducibles)
+3. MINUS 7% generic deduction (3% for autónomos societarios)
+4. DIVIDE by 12 = Monthly net income (rendimiento neto mensual)
+```
+
+### Key Rules
+
+- **6 changes per year:** You can change your contribution base up to 6 times annually to match income fluctuations
+- **Annual regularization:** After year-end, TGSS compares actual income vs. chosen base. Overpayments are refunded; underpayments are collected (second half of following year)
+- **Autónomos societarios minimum:** EUR 1,000/month base → EUR 314/month minimum contribution
+
+---
+
+## Section 3 -- Tarifa Plana (Flat Rate for New Autónomos)
+
+### Standard Tarifa Plana (DA 52ª LGSS, RDL 13/2022)
+
+| Period | Monthly Contribution |
+|---|---|
+| Months 1-12 | EUR 80 |
+| Months 13-24 (if income < SMI) | Reduced rate (tramo-dependent) |
+
+### Requirements
+
+- Not registered as autónomo in the previous 2 years
+- Not previously benefited from tarifa plana in the previous 3 years
+- No outstanding debts with Seguridad Social or Hacienda
+- NOT autónomo societario (company administrators excluded)
+- Must apply at the moment of registration (alta)
+
+### Extended Tarifa Plana (24 months at EUR 80)
+
+Available for:
+- Workers with disability ≥ 33%
+- Victims of gender violence
+- Victims of terrorism
+
+### Important Notes
+
+- Request is automatic when registering (mark the box in Modelo TA.0521)
+- Cannot be requested retroactively
+- Compatible with pluriactividad (working as both employed and self-employed)
+- After tarifa plana ends, the normal bracket system applies
+
+---
+
+## Section 4 -- Complete Fiscal Calendar for Autónomos
+
+### Quarterly Obligations
+
+| Quarter | Period | Deadline | Models to File |
+|---|---|---|---|
+| Q1 | Jan-Mar | 1-20 April | 130 (IRPF) + 303 (IVA) |
+| Q2 | Apr-Jun | 1-20 July | 130 + 303 |
+| Q3 | Jul-Sep | 1-20 October | 130 + 303 |
+| Q4 | Oct-Dec | 1-30 January | 130 + 303 |
+
+### Annual Obligations
+
+| Model | Description | Deadline |
+|---|---|---|
+| 100 | Declaración de la Renta (IRPF annual) | April-June (campaign dates vary) |
+| 390 | Annual IVA summary | 1-30 January |
+| 347 | Operations with third parties > EUR 3,005.06 | February |
+| 349 | Intra-EU operations (if applicable) | Monthly or quarterly |
+
+### Additional Models (if applicable)
+
+| Model | Who | When |
+|---|---|---|
+| 111 | If you have employees (retenciones nóminas) | Quarterly |
+| 115 | If you rent premises (retenciones alquileres) | Quarterly |
+| 131 | Instead of 130, if in estimación objetiva (módulos) | Quarterly |
+| 720 | Assets abroad > EUR 50,000 | March |
+
+---
+
+## Section 5 -- Indirect Tax by Territory
+
+### IVA (Common Territory + Baleares)
+
+| Item | Value |
+|---|---|
+| General rate | 21% |
+| Reduced rate | 10% (food, transport, hotels) |
+| Super-reduced rate | 4% (bread, milk, medicines, books) |
+| Filed via | Modelo 303 (quarterly) + Modelo 390 (annual summary) |
+
+### IGIC (Canarias)
+
+| Item | Value |
+|---|---|
+| General rate | 7% |
+| Reduced | 3% |
+| Zero rate | 0% (certain essential goods) |
+| Incrementado | 9.5%, 15% |
+| Filed via | Modelo 420 (quarterly) to Hacienda Canaria |
+
+### IPSI (Ceuta and Melilla)
+
+| Item | Value |
+|---|---|
+| General rate (services) | 4% |
+| Other rates | 0.5% - 10% depending on goods/services |
+| Filed via | Local IPSI models to Ciudad Autónoma |
+
+---
+
+## Section 6 -- Net Take-Home Calculation (Sueldo Neto Autónomo)
+
+### Monthly Calculation Formula
+
+```
+Facturación bruta (without IVA)
++ IVA/IGIC/IPSI repercutido (charged to client)
+= Total factura (amount on invoice)
+- Retención IRPF (15% or 7% withheld by client, if applicable)
+= Cobro efectivo (cash received)
+- Cuota autónomos (Social Security)
+- Gastos deducibles
+= Neto mensual aproximado
+
+IVA/IGIC/IPSI a pagar Hacienda = repercutido - soportado (on purchases)
+```
+
+### Annual Calculation Formula
+
+```
+Facturación bruta anual
+- Gastos deducibles anuales
+- Cuota autónomos anual
+- 5% gastos difícil justificación (max EUR 2,000, if simplificada)
+= Base imponible IRPF
+
+IRPF anual = Apply progressive brackets to base imponible
+Neto anual = Facturación bruta - IRPF - Cuota SS - Gastos
+```
+
+### Worked Example: IT Freelancer, Madrid, EUR 3,000/month billing
+
+```
+Monthly:
+  Facturación bruta:            EUR 3,000
+  + IVA 21%:                    EUR 630
+  = Total factura:              EUR 3,630
+  - Retención IRPF 15%:        EUR 450
+  = Cobro efectivo:             EUR 3,180
+  - Cuota autónomos (Tramo 9): EUR 320
+  - Gastos deducibles:          EUR 200
+  = Neto mensual estimado:      EUR 2,660
+
+Annual:
+  Facturación bruta:            EUR 36,000
+  - Gastos deducibles:          EUR 2,400
+  - Cuota autónomos:            EUR 3,840
+  - Gastos difícil justificación: EUR 1,488 (5% × 29,760, < 2,000)
+  = Base imponible:             EUR 28,272
+  IRPF estimado (escala 2025):  ~EUR 5,600
+  Neto anual:                   EUR 36,000 - 5,600 - 3,840 - 2,400 = EUR 24,160
+  Neto mensual real:            EUR 2,013
+  % neto sobre facturación:     ~67%
+```
+
+**Note:** The monthly "neto" from cash flow differs from the annual real neto because retenciones are prepayments that may result in refund or additional payment at year-end.
+
+---
+
+## Section 7 -- Territorial Regime Classification
+
+| Fiscal Residence | IRPF Scale | Indirect Tax | SS Bonification |
+|---|---|---|---|
+| Common territory (15 CCAA) | State + Regional (50/50) | IVA 21% | None |
+| Canarias | State + Regional | IGIC 7% | None |
+| Ceuta | State + Regional, 60% deduction cuota | IPSI 4% | 50% cuota SS (certain sectors) |
+| Melilla | State + Regional, 60% deduction cuota | IPSI 4% | 50% cuota SS (certain sectors) |
+| País Vasco (Álava/Bizkaia/Gipuzkoa) | Foral (own scale, 23%-49%) | IVA 21% | None |
+| Navarra | Foral (own scale, 13%-52.8%) | IVA 21% | None |
+
+### Ceuta/Melilla Sectors with 50% SS Bonification
+
+- Agriculture, fishing, aquaculture
+- Industry (except energy and water)
+- Commerce, tourism, hospitality
+- Other services (excluding air transport, building construction, financial/real estate activities)
+
+---
+
+## Section 8 -- Types of Autónomo
+
+### 8.1 Autónomo Persona Física (Standard)
+
+- Most common: freelancer or sole trader
+- Filed as individual IRPF taxpayer
+- Can choose estimación directa simplificada (default) or normal
+- Retención 15% (7% first 3 years) on professional invoices (Sección 2 IAE only)
+
+### 8.2 Autónomo Societario
+
+- Administrators/partners with ≥33% ownership who perform management
+- Must register in RETA
+- Minimum base: EUR 1,000/month (cuota mínima EUR 314/month)
+- Cannot access tarifa plana
+- Deduction for generic expenses: 3% (not 7%)
+- Their income comes as nómina from the company (rendimientos del trabajo), NOT business income
+
+### 8.3 Autónomo Colaborador (Family Member)
+
+- Spouse or family member (up to 2nd degree) working regularly in the business
+- Minimum base: SMI (EUR 1,000/month in 2025)
+- Bonificación: 50% during first 18 months, 25% next 6 months
+- Does NOT file their own Modelo 130/303 -- works under the main autónomo's business
+
+### 8.4 Autónomo Económicamente Dependiente (TRADE)
+
+- Derives ≥75% of income from a single client
+- Must formalize the relationship with a written contract
+- Specific protections under Estatuto del Trabajo Autónomo
+- Tax obligations are the same as standard autónomo
+
+---
+
+## Section 9 -- Registration Process (Alta de Autónomo)
+
+### Steps
+
+1. **Alta en Hacienda** (Modelo 036 or 037): Register for tax obligations, select IAE epígrafe, choose estimation regime
+2. **Alta en RETA** (Modelo TA.0521): Register with Social Security within 60 days before starting activity (or same day)
+3. **Licencia de actividad** (if applicable): Some activities require local permits
+4. **Libro registro**: Start maintaining income and expense records from day one
+
+### Key Decisions at Registration
+
+| Decision | Options | Default |
+|---|---|---|
+| Estimation regime | Directa simplificada / Directa normal / Objetiva (módulos) | Simplificada |
+| IAE epígrafe | Section 1 (business) or Section 2 (professional) | Determines if retención applies |
+| IVA regime | General / Simplified / Recargo equivalencia | General |
+| Tarifa plana | Apply or not | Apply if eligible |
+| Contribution base | Minimum of bracket or higher | Minimum |
+
+---
+
+## Section 10 -- Deductible Expenses for Autónomos
+
+### Fully Deductible (with proper invoice)
+
+| Expense | Notes |
+|---|---|
+| Cuota autónomos (RETA) | Monthly SS contribution |
+| Office rent (local de negocio) | Fully deductible with factura |
+| Professional services (gestoría, abogado) | Fully deductible |
+| Software and subscriptions | Business use |
+| Advertising and marketing | Fully deductible |
+| Professional training | Related to activity |
+| Professional insurance | Liability, etc. |
+| Bank fees (business account) | Fully deductible |
+| Payment processor fees (Stripe, PayPal) | Fully deductible |
+| Depreciation (amortización) | Per simplified table |
+| Business travel (transport) | Documented trips |
+| Travel meals (dietas) | Max EUR 26.67/day domestic, EUR 48.08/day international |
+
+### Partially Deductible (Special Rules)
+
+| Expense | Rule | Reference |
+|---|---|---|
+| Home office supplies (luz, gas, agua) | (office area / total area) × 30% of supply costs | LIRPF Art. 30.2.5.b |
+| Vehicle expenses | Business portion only (default: 50% IVA, IRPF needs logbook) | Art. 95 LIVA |
+| Mobile phone | Business portion only (default 0% if not documented) | |
+| Meals not during travel | NOT deductible | Client entertainment excluded |
+| Personal insurance | NOT deductible | |
+| IRPF payments (Modelo 130) | NOT deductible (prepayment of tax, not expense) | |
+
+### Gastos de Difícil Justificación (Simplificada only)
+
+- 5% of rendimiento neto previo, maximum EUR 2,000/year
+- Automatic reduction under estimación directa simplificada
+- Covers expenses that are difficult to document but clearly business-related
+
+---
+
+## Section 11 -- Obligación de Declarar (Filing Obligation)
+
+Not all autónomos are obligated to file the annual Renta if their income is very low:
+
+| Situation | Limit |
+|---|---|
+| Single payer, employment income only | EUR 22,000 |
+| Multiple payers (2nd+ pays > EUR 1,500) | EUR 15,876 |
+| Capital income | > EUR 1,600 |
+| Real estate income | > EUR 1,000 |
+| Any business/professional income | Always obligated to file |
+
+**Autónomos are ALWAYS obligated to file Modelo 100** regardless of income level (Art. 96 LIRPF exception for rendimientos de actividades económicas).
+
+---
+
+## Section 12 -- Conservative Defaults
+
+| Ambiguity | Default |
+|---|---|
+| Unknown estimation regime | Directa simplificada |
+| Unknown cuota autónomos | Calculate from bracket table using 60% of billing as proxy for net income |
+| Unknown tarifa plana eligibility | Not eligible (apply standard brackets) |
+| Unknown if new autónomo | NOT new (15% retención, not 7%) |
+| Unknown Sección IAE | Sección 2 (professional -- retención applies) |
+| Unknown business-use % | 0% for mixed-use items |
+| Unknown territory | Common territory with IVA 21% |
+| Unknown activity start date | Do not apply tarifa plana |
+
+---
+
+## PROHIBITIONS
+
+- NEVER tell someone they can avoid paying cuota de autónomos if they are actively self-employed
+- NEVER apply tarifa plana to autónomos societarios
+- NEVER deduct client entertainment meals from IRPF
+- NEVER apply the 7% generic deduction to autónomos persona física (it's 7% for them, 3% for societarios -- don't mix these up)
+- NEVER confuse retenciones (tax prepayments) with expenses -- they are NOT deductible business expenses
+- NEVER apply IVA to an autónomo in Canarias (they use IGIC) or Ceuta/Melilla (IPSI)
+- NEVER forget that Modelo 130 is cumulative year-to-date (not just the quarter's income)
+- NEVER apply the EUR 80 tarifa plana beyond month 12 without verifying income < SMI
+- NEVER present cuota estimates as exact -- actual regularization happens the following year
+- NEVER advise on baja (deregistration) without noting that this affects future tarifa plana eligibility
+
+---
+
+## Disclaimer
+
+This skill and its outputs are provided for informational and computational purposes only and do not constitute tax, legal, or financial advice. Open Accountants and its contributors accept no liability for any errors, omissions, or outcomes arising from the use of this skill. All outputs must be reviewed and signed off by a qualified professional (such as an asesor fiscal or equivalent licensed practitioner in your jurisdiction) before filing or acting upon.
+
+The most up-to-date, verified version of this skill is maintained at [openaccountants.com](https://openaccountants.com). Log in to access the latest version, request a professional review from a licensed accountant, and track updates as tax law changes.

--- a/skills/international/spain/es-corporate-tax.md
+++ b/skills/international/spain/es-corporate-tax.md
@@ -1,0 +1,308 @@
+---
+name: es-corporate-tax
+description: >
+  Use this skill whenever asked about Spanish corporate income tax (Impuesto sobre Sociedades, IS), Modelo 200, Modelo 202 (pagos fraccionados), corporate tax rates in Spain, SL tax obligations, company formation tax, deducciones empresariales, bases imponibles negativas (BINs), reserva de capitalizacion, reserva de nivelacion, or foral corporate tax. Trigger on phrases like "Impuesto de Sociedades", "Modelo 200", "Modelo 202", "IS Spain", "corporate tax Spain", "tipo gravamen sociedades", "SL taxes", "nueva creacion", "empresa reducida dimension", "microempresa fiscal", "BINs", "compensacion perdidas sociedad", "pago fraccionado empresa", "ZEC Canarias", "bonificacion Ceuta Melilla sociedades", "I+D deduccion sociedades", "donativos sociedad", "resultado contable", or any question about computing or filing corporate income tax in Spain. ALWAYS read this skill before touching any Spanish corporate tax work.
+version: 1.0
+jurisdiction: ES
+tax_year: 2025
+category: international
+depends_on:
+  - income-tax-workflow-base
+---
+
+# Spain Corporate Income Tax (Impuesto sobre Sociedades) Skill v1.0
+
+> **Based on work by [Nambu89 (Impuestify)](https://github.com/Nambu89/Impuestify)** and **[Pau March (larenta)](https://github.com/paumrch/larenta)**, licensed under MIT. Adapted for the OpenAccountants format.
+
+---
+
+## Section 1 -- Quick Reference
+
+| Field | Value |
+|---|---|
+| Country | Spain (Estado Español) |
+| Tax | Impuesto sobre Sociedades (IS) |
+| Currency | EUR only |
+| Fiscal year | Generally calendar year (can differ) |
+| Primary legislation | Ley 27/2014 (LIS); Ley 7/2024 (reform) |
+| Supporting legislation | RDL 4/2024 (microempresa); Art. 25-26 LIS (reserves/BINs) |
+| Tax authority | AEAT (common territory); Haciendas Forales (Basque/Navarra) |
+| Filing form | Modelo 200 (annual) |
+| Quarterly payments | Modelo 202 (pagos fraccionados) |
+| Filing deadline | 25 days after 6 months from fiscal year-end (July 25 for calendar year) |
+| Modelo 202 deadlines | 1-20 April, 1-20 October, 1-20 December |
+
+---
+
+## Section 2 -- Tax Rates (Tipos de Gravamen) 2025
+
+### Common Territory (Territorio Común) -- Ley 7/2024
+
+| Entity Type | INCN (Facturación) | Rate | Notes |
+|---|---|---|---|
+| Microempresa | < EUR 1,000,000 | 17% (first EUR 50,000) + 20% (rest) | Ley 7/2024 Disp. Final 8ª |
+| ERD (Empresa Reducida Dimensión) | EUR 1M - 10M | 24% | Transitional: drops 1pp/year to 20% by 2029 |
+| General | ≥ EUR 10,000,000 | 25% | Standard rate |
+| Nueva creación | Any (first 2 years with BI > 0) | 15% | First 2 fiscal years with positive base imponible |
+
+### ERD Transitional Calendar (Ley 7/2024)
+
+| Fiscal Year | ERD Rate |
+|---|---|
+| 2025 | 24% |
+| 2026 | 23% |
+| 2027 | 22% |
+| 2028 | 21% |
+| 2029+ | 20% |
+
+### Foral Territories
+
+| Territory | General Rate | Microempresa | Nueva Creación |
+|---|---|---|---|
+| Álava (NF 37/2013) | 24% | 20%/24% (EUR 50k tramo) | 19%/24% |
+| Bizkaia (NF 11/2013) | 24% | 20%/24% (EUR 50k tramo) | 19%/24% |
+| Gipuzkoa (NF 1/2025) | 19% | 15%/17% (EUR 50k tramo) | 15%/19% |
+| Navarra (LF 26/2016) | 28% | 23%/28% (EUR 50k tramo) | 15%/28% |
+
+### Special Regimes
+
+| Regime | Rate | Applicable |
+|---|---|---|
+| ZEC Canarias | 4% (up to employment-based ceiling) | Entities in Zona Especial Canaria |
+| Ceuta/Melilla | 25% with 50% bonificación on qualifying income | Income generated in Ceuta/Melilla |
+| Cooperativas fiscalmente protegidas | 20% | Ley 20/1990 |
+| Cooperativas especialmente protegidas | 20% + 50% bonificación cuota | Art. 34.2 Ley 20/1990 |
+
+---
+
+## Section 3 -- Liquidation Pipeline (Modelo 200)
+
+The IS computation follows this pipeline:
+
+```
+1. Resultado contable (accounting profit)
+   + Ajustes positivos (non-deductible expenses, amortization differences)
+   - Ajustes negativos (exempt income, timing differences)
+   - Reserva de capitalización (Art. 25 LIS)
+   = Base imponible previa
+   - Reserva de nivelación (Art. 105 LIS, ERD only)
+   - Compensación BINs (Art. 26 LIS)
+   - RIC Canarias (if applicable)
+   = Base imponible (floor: EUR 0)
+   × Tipo de gravamen (rate table above)
+   = Cuota íntegra
+   - Deducciones (I+D, IT, donativos, empleo, cine...)
+   - Bonificaciones (Ceuta/Melilla, cooperativas)
+   = Cuota líquida (with tributación mínima floor if applicable)
+   - Retenciones e ingresos a cuenta
+   - Pagos fraccionados (Modelo 202)
+   = Resultado liquidación (a ingresar / a devolver)
+```
+
+---
+
+## Section 4 -- Key Computations
+
+### 4.1 Reserva de Capitalización (Art. 25 LIS)
+
+Reduces base imponible for companies that increase their fondos propios (equity).
+
+| Fiscal Year | Reduction % | Limit (% of base previa) |
+|---|---|---|
+| Pre-2025 | 10% of equity increase | 10% |
+| 2025 (Ley 7/2024) | 20% base (up to 30% with workforce growth) | 20% |
+
+**2025 scale by workforce growth:**
+- 0% workforce increase: 20% reduction
+- 2%+ workforce increase: 23% reduction
+- 5%+ workforce increase: 26.5% reduction
+- 8%+ workforce increase: 30% reduction
+
+### 4.2 Compensación de Bases Imponibles Negativas (BINs) -- Art. 26 LIS
+
+Past losses (BINs) reduce current positive base imponible:
+
+| INCN (Annual Revenue) | BIN Compensation Limit |
+|---|---|
+| < EUR 20M | 100% (with EUR 1M free floor) |
+| EUR 20M - 60M | 70% of base imponible previa |
+| ≥ EUR 60M | 50% of base imponible previa |
+
+BINs never expire (no time limit since 2015 reform).
+
+### 4.3 Reserva de Nivelación (Art. 105 LIS) -- ERD Only
+
+Only for companies with INCN < EUR 10M:
+- Reduces base imponible by up to 10% (max EUR 1,000,000)
+- Must be added back within 5 years if not offset by future losses
+- Effectively allows "advance" loss compensation
+
+### 4.4 Deducciones en Cuota
+
+| Deduction | Rate | Limit (% of cuota) | Reference |
+|---|---|---|---|
+| I+D (Investigación y Desarrollo) | 25% of expenditure | 25% of cuota íntegra | Art. 35.1 LIS |
+| I+D (exceso sobre media 2 años) | 42% of excess | Included in 25% limit | Art. 35.1.b LIS |
+| I+D personal investigador | +17% of researcher costs | Included | Art. 35.1.b LIS |
+| I+D inmovilizado afecto | +8% of dedicated assets | Included | Art. 35.1.b LIS |
+| IT (Innovación Tecnológica) | 12% of expenditure | 25% of cuota íntegra | Art. 35.2 LIS |
+| Donativos mecenazgo | 40% (sociedades) | 10% of base imponible | Art. 20 Ley 49/2002 |
+| Empleo discapacitados 33-65% | EUR 9,000/employee | No limit | Art. 38 LIS |
+| Empleo discapacitados ≥65% | EUR 12,000/employee | No limit | Art. 38 LIS |
+| Producción cinematográfica española | 30%/25% (first EUR 1.5M/rest) | EUR 20M | Art. 36.1 LIS |
+| Producción cinematográfica extranjera | 30% | EUR 20M (EUR 40M CSI) | Art. 36.2 LIS |
+
+### 4.5 Bonificación Ceuta y Melilla (Art. 33.6 LIS)
+
+- 50% bonificación on the cuota íntegra proportional to income generated in Ceuta/Melilla
+- Proportion = rentas Ceuta-Melilla / resultado contable total
+- Combined with 25% rate = effective ~12.5% on Ceuta/Melilla income
+
+### 4.6 Tributación Mínima (Art. 30 bis LIS)
+
+Applies to entities with INCN ≥ EUR 20M or in consolidated group:
+
+| Situation | Minimum Rate (on base imponible) |
+|---|---|
+| General | 15% |
+| Nueva creación (first 2 years BI+) | 10% |
+| Banking/hydrocarbon entities | 18% |
+
+If cuota líquida (after deductions) < minimum, it is raised to the minimum.
+
+---
+
+## Section 5 -- Modelo 202: Pagos Fraccionados
+
+### Two Modalities
+
+| Modality | Calculation | When Used |
+|---|---|---|
+| Art. 40.2 | 18% × (cuota íntegra - deducciones - bonificaciones - retenciones) del último ejercicio | Default for most companies |
+| Art. 40.3 | 17% × base imponible del período (24% if INCN > EUR 10M) | Mandatory if INCN > EUR 6M; optional otherwise |
+
+### Calendar
+
+| Period | Deadline |
+|---|---|
+| 1P (Jan-Mar) | 1-20 April |
+| 2P (Jan-Sep) | 1-20 October |
+| 3P (Jan-Nov) | 1-20 December |
+
+### Pago Fraccionado Mínimo (DA 14ª LIS)
+
+For entities with INCN ≥ EUR 10M in modality Art. 40.3:
+- Minimum payment: 23% of (resultado contable positivo + ajustes positivos) for the period
+- Banking/hydrocarbon: 25%
+- If calculated payment < minimum, minimum applies
+
+---
+
+## Section 6 -- Non-Deductible Expenses (Gastos No Deducibles)
+
+| Expense | Art. LIS | Treatment |
+|---|---|---|
+| Resultado contable del propio IS | Art. 15.b | Ajuste positivo |
+| Multas y sanciones | Art. 15.c | Never deductible |
+| Donativos y liberalidades | Art. 15.e | Generally not deductible (exceptions for promotion) |
+| Retribución fondos propios | Art. 15.a | Dividends are not expense |
+| Pérdidas por deterioro de participaciones | Art. 15.k | Not deductible (since 2013) |
+| Gastos financieros > 30% EBITDA or EUR 1M | Art. 16 | Excess is non-deductible (carry forward) |
+| Atenciones a clientes > EUR 1/1000 INCN | Art. 15.e | Excess is non-deductible, max EUR 1% of INCN |
+
+---
+
+## Section 7 -- ZEC Canarias (Zona Especial Canaria)
+
+Special regime under Art. 43 Ley 19/1994:
+
+| Feature | Value |
+|---|---|
+| Rate | 4% on base imponible up to ceiling |
+| Ceiling by employees | 5 employees: EUR 1.8M; 6-10: EUR 2.7M; each +5: +EUR 1.8M |
+| Minimum employees | 5 (3 in remote areas) |
+| Excess above ceiling | 25% (general rate) |
+| Eligible activities | Industrial, commercial, services (with exclusions) |
+| Combining with RIC | Yes -- RIC further reduces base imponible |
+
+---
+
+## Section 8 -- Worked Example: Standard SL
+
+**Input:** SL Consultora Digital, Madrid. Calendar year 2025. INCN EUR 500,000. Resultado contable EUR 80,000. Gastos no deducibles EUR 3,000. Incremento fondos propios EUR 20,000. BINs pendientes EUR 15,000. No I+D. 1 employee with 33% disability.
+
+**Computation:**
+
+```
+1. Resultado contable:                        EUR 80,000
+2. + Ajustes positivos (gastos no deducibles): EUR 3,000
+3. - Ajustes negativos:                        EUR 0
+4. - Reserva capitalización (20% × 20,000):   EUR 4,000
+   = Base imponible previa:                    EUR 79,000
+5. - Compensación BINs (100%, free floor 1M):  EUR 15,000
+   = Base imponible:                           EUR 64,000
+6. Tipo gravamen: Microempresa (INCN < 1M)
+   - First EUR 50,000 × 17% =                 EUR 8,500
+   - Remaining EUR 14,000 × 20% =             EUR 2,800
+   = Cuota íntegra:                            EUR 11,300
+7. - Deducción empleo discapacidad (1 × 9,000): EUR 9,000
+   = Cuota líquida:                            EUR 2,300
+8. - Retenciones:                              EUR 0
+   - Pagos fraccionados:                       EUR 0
+   = Resultado liquidación:                    EUR 2,300 (a ingresar)
+
+Tipo efectivo: 2,300 / 80,000 = 2.88%
+```
+
+---
+
+## Section 9 -- Filing Obligations
+
+| Modelo | Who Must File | Deadline |
+|---|---|---|
+| 200 | All entities subject to IS | 25 July (calendar year) |
+| 202 | Entities with cuota líquida > 0 in prior year OR INCN > EUR 6M | April/October/December |
+| 220 | Consolidated groups | 25 July |
+| 232 | Related-party transactions > EUR 250K | November |
+
+### Exempt from filing Modelo 200:
+- Entities fully exempt (Art. 9.1 LIS): State, CCAA, local entities
+- Partially exempt entities with income exclusively from exempt sources, no withholdings, and no non-exempt income
+
+---
+
+## Section 10 -- Conservative Defaults
+
+| Ambiguity | Default |
+|---|---|
+| Unknown territory | Common territory (Madrid) |
+| Unknown INCN | General rate (25%) |
+| Unknown entity type | SL (standard) |
+| Unknown fiscal year | 2025 |
+| Unknown BINs | EUR 0 (no compensation) |
+| Amortización fiscal unknown | Same as contable (no adjustment) |
+| Unknown if nueva creación | NOT nueva creación (higher rate) |
+| ERD vs general unknown | General (higher rate) |
+
+---
+
+## PROHIBITIONS
+
+- NEVER apply microempresa rates to entities with INCN ≥ EUR 1,000,000
+- NEVER apply nueva creación rate beyond the first 2 fiscal years with positive base imponible
+- NEVER compensate BINs beyond the percentage limit for the entity's INCN bracket
+- NEVER exceed the 25% cuota íntegra limit for I+D/IT/donations combined
+- NEVER forget tributación mínima for entities with INCN ≥ EUR 20M or consolidated groups
+- NEVER apply ZEC 4% rate without verifying the employment ceiling
+- NEVER deduct multas, sanciones, or retribución de fondos propios
+- NEVER apply the Ley 7/2024 microempresa rates (17%/20%) to fiscal years before 2025
+- NEVER apply common territory IS rates to entities fiscally domiciled in foral territories
+- NEVER confuse IRPF (personal) with IS (corporate) -- completely different regimes
+
+---
+
+## Disclaimer
+
+This skill and its outputs are provided for informational and computational purposes only and do not constitute tax, legal, or financial advice. Open Accountants and its contributors accept no liability for any errors, omissions, or outcomes arising from the use of this skill. All outputs must be reviewed and signed off by a qualified professional (such as an asesor fiscal or equivalent licensed practitioner in your jurisdiction) before filing or acting upon.
+
+The most up-to-date, verified version of this skill is maintained at [openaccountants.com](https://openaccountants.com). Log in to access the latest version, request a professional review from a licensed accountant, and track updates as tax law changes.

--- a/skills/international/spain/es-irpf-deductions.md
+++ b/skills/international/spain/es-irpf-deductions.md
@@ -1,0 +1,414 @@
+---
+name: es-irpf-deductions
+description: >
+  Use this skill whenever asked about Spanish regional tax deductions (deducciones autonomicas), IRPF deductions by Comunidad Autonoma, or territory-specific tax benefits. Trigger on phrases like "deducciones autonomicas", "deduccion por vivienda", "deduccion por familia numerosa", "deduccion por nacimiento", "deduccion Madrid", "deduccion Cataluna", "deduccion Valencia", "deducciones por discapacidad", "deducciones por alquiler", "deducciones IRPF por comunidad", "casilla AEAT", "territory deductions Spain", "regional tax credits Spain", "Ceuta Melilla deduction", "foral deductions", "Pais Vasco IRPF", "Navarra IRPF", "deduccion por donativo", "deduccion por guarderia", "deduccion por maternidad autonomica", or any question about which IRPF deductions apply in a specific Spanish territory. ALWAYS read this skill before advising on territory-specific deductions.
+version: 1.0
+jurisdiction: ES
+tax_year: 2025
+category: international
+depends_on:
+  - es-income-tax
+---
+
+# Spain IRPF Regional Deductions (Deducciones Autonómicas) Skill v1.0
+
+> **Based on work by [Nambu89 (Impuestify)](https://github.com/Nambu89/Impuestify)** and **[Pau March (larenta)](https://github.com/paumrch/larenta)**, licensed under MIT. Adapted for the OpenAccountants format.
+
+---
+
+## Section 1 -- Quick Reference
+
+| Field | Value |
+|---|---|
+| Country | Spain (Estado Español) |
+| Tax | IRPF -- Deducciones Autonómicas (Cuota Autonómica) |
+| Currency | EUR only |
+| Tax year | Calendar year (año natural) |
+| Legislation | LIRPF Art. 77; Each Comunidad Autónoma's own tax law |
+| Authority | AEAT + Regional tax agencies (ATC, ATV, etc.) |
+| Total known deductions | ~339 in common territory + additional in foral territories |
+| Territories covered | 15 common territory CCAA + 4 foral (Álava, Bizkaia, Gipuzkoa, Navarra) + Ceuta + Melilla |
+| Skill version | 1.0 |
+
+---
+
+## Section 2 -- How Regional Deductions Work
+
+### The Dual Structure of Spanish IRPF
+
+Spanish IRPF is split 50/50 between the State (cuota estatal) and the Autonomous Community (cuota autonómica). The state portion is fixed nationwide; the regional portion is where each CCAA can:
+
+1. **Modify the regional tax brackets** (escala autonómica)
+2. **Create regional deductions** (deducciones autonómicas) that reduce the cuota autonómica
+
+Regional deductions apply AFTER computing the cuota íntegra autonómica. They reduce the tax owed to the regional government. They do NOT reduce the state portion.
+
+### Key Principles
+
+- Deductions are claimed on Modelo 100 (annual IRPF return), in the autonomous community section
+- Each deduction has a specific AEAT casilla (box number)
+- Most deductions have income limits (base imponible general + base imponible del ahorro)
+- Joint filing (tributación conjunta) may double some limits
+- Deductions cannot generate a negative cuota autonómica (floor = 0)
+
+---
+
+## Section 3 -- Deductions by Territory: Common Territory (Territorio Común)
+
+### 3.1 Andalucía (15 deductions)
+
+| Category | Deduction | Key Requirements |
+|---|---|---|
+| Familia | Por nacimiento o adopción de hijos | Recent birth/adoption |
+| Familia | Por adopción internacional | International adoption |
+| Familia | Familia monoparental | Single parent with dependents |
+| Discapacidad | Contribuyente con discapacidad | Taxpayer disability ≥33% |
+| Discapacidad | Cónyuge con discapacidad | Spouse disability ≥33% |
+| Vivienda | Inversión vivienda protegida / jóvenes | Protected housing or under 35 |
+| Vivienda | Alquiler vivienda habitual | Habitual residence rental |
+| Inversión | Adquisición acciones sociedades | Investment in new companies |
+| Donaciones | Donativos con finalidad ecológica | Ecological donations |
+| General | Deducción aplicable con carácter general | Income below threshold |
+| Salud | Gastos defensa jurídica laboral | Employment legal costs |
+
+### 3.2 Aragón (21 deductions)
+
+| Category | Deduction | Key Requirements |
+|---|---|---|
+| Familia | Nacimiento o adopción tercer hijo+ | 3rd or subsequent child |
+| Educación | Libros de texto y material escolar | School-age children |
+| Vivienda | Adquisición vivienda habitual víctimas terrorismo | Terrorism victims |
+| Inversión | Acciones entidades segmento empresas en expansión | Listed growth companies |
+| Inversión | Adquisición acciones/participaciones nuevas sociedades | New company investment |
+| Donaciones | Donaciones ecológicas e I+D | R&D and ecological |
+| Discapacidad | Gastos formación autonomía discapacitados | Disability training expenses |
+
+### 3.3 Asturias (Principado de Asturias) (27 deductions)
+
+| Category | Deduction | Key Requirements |
+|---|---|---|
+| Familia | Adopción internacional | International adoption |
+| Familia | Partos múltiples / adopción simultánea | Multiple births |
+| Familia | Familias numerosas | Large families |
+| Familia | Familias monoparentales | Single-parent families |
+| Educación | Libros de texto y material escolar | School-age children |
+| Educación | Gastos formación contribuyentes | Training expenses |
+| Vivienda | Inversión vivienda habitual protegida | Protected housing |
+| Vivienda | Arrendamiento vivienda habitual | Rent ≤ income limits |
+| Territorial | Trabajadores cuenta propia zonas rurales | Self-employed in rural areas |
+| Territorial | Gastos transporte público concejos despoblación | Public transport in depopulating areas |
+| Trabajo | Traslado domicilio fiscal a Asturias | Relocating to Asturias |
+
+### 3.4 Islas Baleares (Illes Balears) (25 deductions)
+
+| Category | Deduction | Key Requirements |
+|---|---|---|
+| Familia | Gastos adquisición libros texto | School books |
+| Familia | Gastos aprendizaje extraescolar idiomas | Language classes |
+| Vivienda | Arrendamiento vivienda habitual jóvenes/discapacitados | Under 36 or disabled, rental |
+| Donaciones | Donaciones investigación, desarrollo, innovación | R&D&I donations |
+| Donaciones | Donaciones patrimonio histórico | Heritage preservation |
+| Salud | Gastos ascendientes mayores 65 años | Elderly care expenses |
+
+### 3.5 Canarias (27 deductions)
+
+| Category | Deduction | Key Requirements |
+|---|---|---|
+| Donaciones | Donaciones finalidad ecológica | Ecological donations |
+| Donaciones | Donaciones rehabilitación patrimonio | Heritage rehabilitation |
+| Educación | Gastos estudios educación superior | University/higher education |
+| Territorial | Traslado residencia a otra isla | Inter-island relocation |
+| Vivienda | Inversión vivienda habitual | Habitual residence acquisition |
+| Familia | Nacimiento o adopción | Birth/adoption |
+| Familia | Gastos guardería | Nursery expenses |
+
+**Note:** Canarias also has specific indirect tax benefits (IGIC instead of IVA) and the RIC (Reserva para Inversiones en Canarias) which affects corporate tax. These are NOT IRPF deductions.
+
+### 3.6 Cantabria (18 deductions)
+
+| Category | Deduction | Key Requirements |
+|---|---|---|
+| Familia | Cuidado familiares dependientes | Dependent family care |
+| Familia | Gastos guardería menores 3 años | Nursery for children under 3 |
+| Vivienda | Arrendamiento vivienda habitual jóvenes | Rental for young people |
+| Vivienda | Obras mejora vivienda | Home improvement works |
+| Donaciones | Donativos fundaciones Cantabria | Donations to Cantabrian foundations |
+
+### 3.7 Castilla y León (22 deductions)
+
+| Category | Deduction | Key Requirements |
+|---|---|---|
+| Familia | Nacimiento o adopción | Birth/adoption |
+| Familia | Cuidado hijos menores | Childcare expenses |
+| Familia | Familias numerosas | Large families |
+| Actividad Económica | Fomento emprendimiento | Entrepreneurship promotion |
+| Vivienda | Adquisición vivienda jóvenes zonas rurales | Young people buying in rural areas |
+| Vivienda | Alquiler vivienda habitual jóvenes | Rental for young people |
+
+### 3.8 Castilla-La Mancha (25 deductions)
+
+| Category | Deduction | Key Requirements |
+|---|---|---|
+| Familia | Nacimiento o adopción | Birth/adoption |
+| Familia | Familia numerosa | Large family |
+| Discapacidad | Contribuyentes con discapacidad | Disability ≥33% |
+| Vivienda | Adquisición vivienda habitual jóvenes | Young people (<36) buying home |
+| Vivienda | Arrendamiento vivienda habitual jóvenes | Young people renting |
+| Donaciones | Donaciones finalidad medioambiental | Environmental donations |
+| Educación | Gastos educativos | Educational expenses |
+
+### 3.9 Cataluña (Catalunya) (10 deductions)
+
+| Category | Deduction | Key Requirements |
+|---|---|---|
+| Familia | Nacimiento o adopción hijo | Birth/adoption |
+| Donaciones | Donativos lengua catalana/occitana | Catalan/Occitan language promotion |
+| Donaciones | Donativos investigación científica | Scientific research donations |
+| Vivienda | Alquiler vivienda habitual | Habitual residence rental |
+| Educación | Intereses préstamos máster/doctorado | Loan interest for postgraduate studies |
+
+**Note:** Cataluña has fewer deductions but applies modified regional brackets that can result in a higher overall rate for high earners.
+
+### 3.10 Comunidad Valenciana (44 deductions -- most of any CCAA)
+
+| Category | Deduction | Key Requirements |
+|---|---|---|
+| Familia | Nacimiento, adopción, acogimiento | Birth/adoption/foster care |
+| Familia | Nacimiento o adopción múltiples | Multiple births |
+| Familia | Hijos con discapacidad | Children with disabilities |
+| Familia | Familia numerosa o monoparental | Large or single-parent family |
+| Familia | Custodia guarderías | Nursery custody expenses |
+| Familia | Conciliación trabajo-familia | Work-family balance |
+| Vivienda | Arrendamiento vivienda habitual | Habitual residence rental |
+| Vivienda | Adquisición vivienda habitual discapacitados | Home purchase by disabled |
+| Vivienda | Primera adquisición vivienda jóvenes ≤35 | First home under 35 |
+| Sostenibilidad | Instalaciones autoconsumo renovable | Renewable self-consumption |
+| Movilidad | Adquisición vehículos nuevos | New vehicle purchase |
+| Donaciones | Donativos medioambientales | Environmental donations |
+| Donaciones | Donaciones patrimonio cultural valenciano | Valencian cultural heritage |
+| Educación | Gastos educativos: libros, transporte, comedor | School expenses |
+
+### 3.11 Extremadura (13 deductions)
+
+| Category | Deduction | Key Requirements |
+|---|---|---|
+| Familia | Cuidado hijos menores 14 años | Childcare for children under 14 |
+| Vivienda | Adquisición vivienda habitual jóvenes | Young people buying home |
+| Vivienda | Alquiler vivienda habitual jóvenes | Young people renting |
+| Trabajo | Trabajo dependiente | Dependent employment income |
+| Donaciones | Donaciones entidades Extremadura | Regional donations |
+
+### 3.12 Galicia (21 deductions)
+
+| Category | Deduction | Key Requirements |
+|---|---|---|
+| Familia | Nacimiento o adopción | Birth/adoption |
+| Familia | Familia numerosa | Large family |
+| Familia | Cuidado hijos menores | Childcare |
+| Vivienda | Inversión vivienda habitual | Home purchase |
+| Vivienda | Alquiler vivienda habitual | Rental |
+| Educación | Gastos universitarios | University expenses |
+| Discapacidad | Contribuyentes con discapacidad ≥33% | Disability |
+| Donaciones | Donativos entidades gallegas | Galician donations |
+
+### 3.13 La Rioja (23 deductions)
+
+| Category | Deduction | Key Requirements |
+|---|---|---|
+| Familia | Nacimiento y adopción | Birth/adoption |
+| Vivienda | Inversión vivienda habitual jóvenes | Young people buying |
+| Vivienda | Alquiler vivienda habitual jóvenes | Young people renting |
+| Movilidad | Adquisición bicicletas pedaleo no asistido | Non-electric bicycle purchase |
+| Donaciones | Donativos culturales, medioambientales | Cultural/environmental donations |
+| Educación | Gastos escolarización | School expenses |
+
+### 3.14 Comunidad de Madrid (26 deductions)
+
+| Category | Deduction | Key Requirements |
+|---|---|---|
+| Familia | Nacimiento o adopción | EUR 600/child (EUR 600 additional if multiple) |
+| Familia | Adopción internacional | EUR 600/child |
+| Familia | Acogimiento familiar menores | EUR 600-900/minor |
+| Familia | Acogimiento no remunerado mayores 65/discapacitados | EUR 900/person |
+| Vivienda | Arrendamiento vivienda habitual | 30% rent, max EUR 1,000 (under 35) |
+| Actividad Económica | Fomento autoempleo jóvenes <35 | EUR 1,000 for new self-employed under 35 |
+| Territorial | Cambio residencia municipio despoblación | Relocation to depopulating area |
+| Donaciones | Donativos fundaciones culturales | 15% of donations |
+| Donaciones | Donativos medioambientales | 15% of donations |
+| Educación | Gastos educativos (escolaridad, idiomas, vestuario) | EUR 400-900/child depending on stage |
+
+**Madrid typical income limits for housing deductions:**
+- Base imponible general + ahorro < EUR 25,620 (individual) / EUR 36,200 (joint)
+
+### 3.15 Región de Murcia (22 deductions)
+
+| Category | Deduction | Key Requirements |
+|---|---|---|
+| Familia | Gastos guardería menores 3 años | Nursery for children under 3 |
+| Vivienda | Inversión vivienda habitual jóvenes | Young people buying home |
+| Vivienda | Arrendamiento vivienda habitual | Rental deduction |
+| Sostenibilidad | Instalaciones recursos energéticos renovables | Renewable energy installations |
+| Donaciones | Donativos medioambientales | Environmental donations |
+| Discapacidad | Contribuyentes con discapacidad | Disability ≥33% |
+
+---
+
+## Section 4 -- Foral Territories
+
+### 4.1 País Vasco (Álava, Bizkaia, Gipuzkoa)
+
+The three Basque provinces have their OWN IRPF system entirely separate from the common territory. They set their own:
+- Tax brackets (generally lower than common territory for low-to-mid incomes)
+- Deductions (different catalogue)
+- Minimum exemptions
+
+**Key differences from common territory:**
+- IRPF brackets: 7 progressive brackets from 23% to 49% (2025)
+- Mínimo personal exento: EUR 5,472
+- No split state/regional -- single scale
+- Own deductions catalogue not covered by AEAT XSD
+
+**Regime classifier:** If the taxpayer's fiscal residence is in País Vasco, use foral basque rules. Do NOT apply common territory deductions.
+
+### 4.2 Navarra (Comunidad Foral de Navarra)
+
+Navarra has its own complete IRPF system:
+- 11 progressive brackets from 13% to 52.8%
+- Mínimo personal: ~EUR 5,500
+- Own deductions set
+- Filed with Hacienda Foral de Navarra, NOT AEAT
+
+**Regime classifier:** If fiscal residence is Navarra, use foral navarra rules exclusively.
+
+### 4.3 Ceuta and Melilla
+
+Ceuta and Melilla are NOT autonomous communities but autonomous cities. They use the common territory IRPF scale but benefit from:
+- **60% deduction on cuota íntegra** (Art. 68.4 LIRPF) for income generated there
+- **50% bonificación on cuota autónomos** for specific sectors (Agriculture, Industry, Commerce, Tourism)
+- This effectively means total IRPF rates are ~40% of what common territory taxpayers pay
+
+---
+
+## Section 5 -- Deduction Categories Explained
+
+| Category | Count | Description |
+|---|---|---|
+| Familia | 74 | Birth, adoption, large families, childcare, single parents |
+| Vivienda | 74 | Home purchase, rental, renovation, protected housing |
+| General | 65 | Broad-application deductions, income-based |
+| Donaciones | 39 | Ecological, cultural, scientific, heritage donations |
+| Discapacidad | 27 | Taxpayer or family member disability ≥33% |
+| Educación | 20 | School materials, tuition, university, training |
+| Inversión | 18 | Startup investment, company shares |
+| Salud | 9 | Healthcare, elderly care, legal costs |
+| Sostenibilidad | 3 | Renewable energy, self-consumption installations |
+| Territorial | 3 | Rural depopulation incentives, island relocation |
+| Trabajo | 3 | Employment mobility, relocation |
+| Movilidad | 2 | Vehicle/bicycle purchase |
+| Actividad Económica | 2 | Self-employment, entrepreneurship |
+
+---
+
+## Section 6 -- How to Apply Regional Deductions (Computation)
+
+### Step-by-Step Process
+
+1. **Identify the taxpayer's Comunidad Autónoma** of fiscal residence (where they lived on 31 December of the tax year)
+2. **Compute the cuota íntegra autonómica** using that CCAA's regional brackets
+3. **Apply mínimo personal y familiar** at the regional rate to get cuota líquida autonómica
+4. **Sum all applicable regional deductions** for which the taxpayer qualifies
+5. **Cap:** Total deductions cannot exceed the cuota líquida autonómica (floor = 0)
+6. **Result:** Cuota diferencial autonómica = cuota líquida autonómica - deducciones autonómicas
+
+### Common Eligibility Requirements
+
+Most deductions require:
+- **Income limit:** Base imponible general + base imponible del ahorro below a threshold (varies by CCAA, typically EUR 25,000-30,000 individual, EUR 36,000-50,000 joint)
+- **Residency:** Fiscal residence in the CCAA during the full tax year
+- **Documentation:** Supporting invoices, certificates, or official documents
+- **Non-duplication:** Cannot apply overlapping state and regional deductions for the same expense
+
+---
+
+## Section 7 -- Conservative Defaults
+
+| Ambiguity | Default |
+|---|---|
+| Unknown Comunidad Autónoma | DO NOT apply any regional deductions; ask first |
+| Income limit unknown | Assume limit is exceeded (conservative = no deduction) |
+| Foral vs common territory unknown | Ask -- critical difference in entire tax computation |
+| Joint vs individual filing unknown | Assume individual (lower deduction limits) |
+| Child disability not documented | Do not apply disability deduction |
+| Duration of residency in CCAA unknown | Ask -- partial-year residency affects eligibility |
+
+---
+
+## Section 8 -- Worked Example: Madrid Taxpayer
+
+**Input:** María, 32, single, one child born 2025, rents apartment EUR 800/month. Base imponible EUR 22,000. Fiscal residence: Madrid.
+
+**Applicable Madrid deductions:**
+1. Por nacimiento de hijos: EUR 600
+2. Arrendamiento vivienda habitual (under 35): 30% × EUR 9,600 annual rent = EUR 2,880, capped at EUR 1,000
+3. Total deductions: EUR 600 + EUR 1,000 = EUR 1,600
+
+**Result:** María's cuota autonómica is reduced by EUR 1,600.
+
+---
+
+## Section 9 -- Casilla Reference (AEAT Modelo 100)
+
+Regional deductions are declared in casillas 0850-1200+ of the AEAT Modelo 100 form. Each CCAA has assigned casilla ranges. Key ranges:
+
+| CCAA | Casilla Range (approximate) |
+|---|---|
+| Andalucía | 0850-0870 |
+| Aragón | 0871-0900 |
+| Asturias | 0901-0930 |
+| Baleares | 0931-0960 |
+| Canarias | 0961-0990 |
+| Cantabria | 0991-1010 |
+| Castilla y León | 1011-1040 |
+| Castilla-La Mancha | 1041-1070 |
+| Cataluña | 1071-1090 |
+| Comunidad Valenciana | 1091-1140 |
+| Extremadura | 1141-1160 |
+| Galicia | 1161-1185 |
+| La Rioja | 1186-1210 |
+| Madrid | 1211-1240 |
+| Murcia | 1241-1270 |
+
+---
+
+## Section 10 -- Interaction with State Deductions
+
+Some deductions exist at BOTH state and regional level:
+- **Maternidad** (maternity): State deduction EUR 1,200/year + some CCAA add regional top-up
+- **Familia numerosa**: State deduction + some CCAA add extra
+- **Donativos**: State deduction (Ley 49/2002) + CCAA-specific donation deductions
+- **Vivienda habitual pre-2013**: State transitional deduction + CCAA may maintain their own
+
+**Rule:** State and regional deductions for the SAME concept may coexist (they reduce different portions of the tax). However, the same expense cannot generate deductions at BOTH levels if the law explicitly prohibits it.
+
+---
+
+## PROHIBITIONS
+
+- NEVER apply regional deductions without confirming the Comunidad Autónoma of fiscal residence
+- NEVER apply common territory deductions to a foral (País Vasco / Navarra) taxpayer
+- NEVER exceed the cuota líquida autonómica (deductions cannot create a refund from the regional portion alone)
+- NEVER assume income limits are met -- verify base imponible first
+- NEVER confuse the 60% Ceuta/Melilla deduction (state-level, Art. 68.4) with regional deductions
+- NEVER apply 2024 deduction amounts to 2025 filings without checking for updates (rates change annually)
+- NEVER claim a deduction without proper documentation (facturas, certificates, padron)
+- NEVER apply Madrid deductions to a taxpayer whose fiscal residence is in another CCAA
+
+---
+
+## Disclaimer
+
+This skill and its outputs are provided for informational and computational purposes only and do not constitute tax, legal, or financial advice. Open Accountants and its contributors accept no liability for any errors, omissions, or outcomes arising from the use of this skill. All outputs must be reviewed and signed off by a qualified professional (such as an asesor fiscal or equivalent licensed practitioner in your jurisdiction) before filing or acting upon.
+
+The deduction catalogue changes annually. CCAA legislatures modify amounts, add new deductions, and remove others each fiscal year. Always verify against the current year's published BOE/BOJA/DOGC/DOGV/etc.
+
+The most up-to-date, verified version of this skill is maintained at [openaccountants.com](https://openaccountants.com). Log in to access the latest version, request a professional review from a licensed accountant, and track updates as tax law changes.


### PR DESCRIPTION
## Summary

PR #22 added 23 community skills to `packages/` but the sync pipeline reads from `skills/international/`. This copies the same files to the correct location so the sync workflow picks them up.

No content changes — just placing files where the sync script expects them.

## Files added (27)
- `skills/international/japan/` — 3 new (etax-filing, bookkeeping, incorporation)
- `skills/international/israel/` — 7 new (freelancer ops, withholding, income tax, corporate, employee refund, crypto, customs)
- `skills/international/france/` — 6 new (personal income tax, capital gains, rental, crypto, business accounting, audit)
- `skills/international/netherlands/` — 4 new (corporate tax, payroll, deductions, objection)
- `skills/international/spain/` — 3 new (IRPF deductions, corporate tax, autonomous worker)
- `skills/cross-border/` — 4 new (incorporation, tax residency, forex, VAT/GST)


Made with [Cursor](https://cursor.com)