### PR TITLE
mcp: add `submit_feedback` tool (pre-filled GitHub issue URL)

### DIFF
--- a/mcp/README.md
+++ b/mcp/README.md
@@ -50,8 +50,9 @@ This server mirrors the hosted server at `https://www.openaccountants.com/api/mc
 | `get_skill` | Given a skill `slug`, returns the full markdown plus a provenance/attribution footer. |
 | `get_skill_sections` | Given a `slug`, returns the skill parsed into sections (`heading`, `content`, `level`) for step-by-step application. |
 | `search_skills` | Keyword search across skill markdown (`query`, optional `jurisdiction`). Returns the matched section heading and a snippet. |
+| `submit_feedback` | Build a pre-filled GitHub New Issue URL the user opens to submit feedback (skill problem, missing jurisdiction, bug, etc.). Takes `summary` plus optional `title`, `skill_slug`, `jurisdiction`, `rating`. Returns `github_url`, `title`, `body`, `labels`. No server-side auth — user submits under their own account. |
 
-All access is **read-only** and **path-sandboxed** to the `packages/` directory.
+Skill access is **read-only** and **path-sandboxed** to the `packages/` directory; `submit_feedback` does not call GitHub itself, it only constructs a URL.
 
 ### The `start` flow
 

--- a/mcp/openaccountants_mcp/server.py
+++ b/mcp/openaccountants_mcp/server.py
@@ -42,6 +42,7 @@ from datetime import datetime, timezone
 from functools import lru_cache
 from pathlib import Path
 from typing import Any
+from urllib.parse import urlencode
 
 import yaml
 from mcp.server.fastmcp import FastMCP
@@ -58,6 +59,14 @@ PACKAGES_DIR = REPO_ROOT / "packages"
 MAX_FILE_BYTES = 2 * 1024 * 1024  # 2 MB safety cap
 SEARCH_LIMIT = 25
 SOURCE_BASE = "https://openaccountants.com/skills"
+
+# Feedback flows construct a GitHub New Issue URL the user opens themselves.
+FEEDBACK_REPO = "openaccountants/openaccountants"
+FEEDBACK_NEW_ISSUE_URL = f"https://github.com/{FEEDBACK_REPO}/issues/new"
+# Practical browser/GitHub URL ceiling is ~8 KB; we cap the body at 6 KB so
+# title + labels + query overhead never push us past it.
+FEEDBACK_MAX_BODY_BYTES = 6000
+FEEDBACK_MAX_TITLE_CHARS = 120
 
 # ---------------------------------------------------------------------------
 # Path safety
@@ -318,7 +327,12 @@ mcp = FastMCP(
         "sources, awaiting credentialed sign-off) or accountant-verified (a "
         "named licensed practitioner has signed off).  Always advise the user "
         "to have output reviewed by a qualified professional before filing, "
-        "and cite the skill (and its verifier where accountant-verified)."
+        "and cite the skill (and its verifier where accountant-verified).\n\n"
+        "**Feedback**: when a user reports a problem with a skill, a missing "
+        "jurisdiction, or anything else worth capturing, call `submit_feedback` "
+        "— it returns a pre-filled GitHub New Issue URL the user opens to "
+        "submit under their own account.  The `skill-feedback` prompt drives "
+        "the structured interview for skill-specific feedback."
     ),
     host=_HTTP_HOST,
     port=_HTTP_PORT,
@@ -797,6 +811,117 @@ def start(intent: str | None = None, jurisdiction: str | None = None) -> dict[st
 
 
 # ---------------------------------------------------------------------------
+# Feedback — build a pre-filled GitHub New Issue URL the user submits themselves
+# ---------------------------------------------------------------------------
+
+
+def _truncate_utf8(text: str, max_bytes: int) -> tuple[str, bool]:
+    """Truncate *text* so its UTF-8 encoding fits in *max_bytes*."""
+    encoded = text.encode("utf-8")
+    if len(encoded) <= max_bytes:
+        return text, False
+    # Step back until we land on a valid character boundary.
+    cut = encoded[:max_bytes]
+    while True:
+        try:
+            return cut.decode("utf-8"), True
+        except UnicodeDecodeError:
+            cut = cut[:-1]
+
+
+def _build_feedback_body(
+    summary: str,
+    skill_slug: str | None,
+    jurisdiction: str | None,
+    rating: int | None,
+) -> tuple[str, bool]:
+    today = datetime.now(tz=timezone.utc).date().isoformat()
+    meta_lines = [f"**Submitted via:** OpenAccountants MCP `submit_feedback`",
+                  f"**Date:** {today}"]
+    if skill_slug:
+        meta_lines.append(f"**Skill:** `{skill_slug}`")
+    if jurisdiction:
+        meta_lines.append(f"**Jurisdiction:** `{jurisdiction.upper()}`")
+    if rating is not None:
+        meta_lines.append(f"**Rating:** {rating}/5")
+
+    body = f"{summary.strip()}\n\n---\n" + "\n".join(meta_lines) + "\n"
+    return _truncate_utf8(body, FEEDBACK_MAX_BODY_BYTES)
+
+
+@mcp.tool(annotations=_READONLY)
+def submit_feedback(
+    summary: str,
+    title: str | None = None,
+    skill_slug: str | None = None,
+    jurisdiction: str | None = None,
+    rating: int | None = None,
+) -> dict[str, Any]:
+    """Build a pre-filled GitHub New Issue URL the user opens to submit feedback.
+
+    The tool does not post to GitHub — it constructs the URL so the user
+    reviews + submits themselves under their own GitHub account (no
+    server-side credentials, no abuse vector, attribution preserved).
+
+    Use this whenever a user shares feedback worth capturing — bug reports,
+    skill inaccuracies, missing jurisdictions, suggested improvements. Pair
+    with the `skill-feedback` prompt for guided skill feedback.
+
+    Args:
+        summary:      The feedback narrative (markdown is fine). Required.
+        title:        Optional explicit issue title. Auto-generated if omitted.
+        skill_slug:   Optional slug when feedback targets a specific skill.
+                      When set, adds the `skill-feedback` label.
+        jurisdiction: Optional jurisdiction code (e.g. "MT", "US-CA").
+        rating:       Optional accuracy/quality rating 1-5.
+
+    Returns:
+        ``{"github_url", "title", "body", "labels", "next_action"}``.
+        Surface the URL to the user; they open it, review, sign in if
+        needed, and click *Submit new issue*.
+    """
+    s = (summary or "").strip()
+    if not s:
+        raise ValueError("summary is required")
+    if rating is not None and not (1 <= rating <= 5):
+        raise ValueError("rating must be between 1 and 5")
+
+    if title:
+        issue_title = title.strip()
+    elif skill_slug:
+        suffix = f" ({jurisdiction.upper()})" if jurisdiction else ""
+        issue_title = f"Skill feedback: {skill_slug}{suffix}"
+    else:
+        issue_title = "Feedback"
+    if len(issue_title) > FEEDBACK_MAX_TITLE_CHARS:
+        issue_title = issue_title[: FEEDBACK_MAX_TITLE_CHARS - 1].rstrip() + "…"
+
+    body, truncated = _build_feedback_body(s, skill_slug, jurisdiction, rating)
+    if truncated:
+        body += ("\n> _Body truncated to fit GitHub's URL length limit. "
+                 "Paste the rest as a follow-up comment after submitting._\n")
+
+    labels = ["feedback"]
+    if skill_slug:
+        labels.append("skill-feedback")
+
+    query = urlencode({"title": issue_title, "body": body, "labels": ",".join(labels)})
+    url = f"{FEEDBACK_NEW_ISSUE_URL}?{query}"
+
+    return {
+        "github_url": url,
+        "title": issue_title,
+        "body": body,
+        "labels": labels,
+        "next_action": (
+            "Share the github_url with the user. Opening it loads GitHub's "
+            "New Issue page with everything pre-filled — they review, sign "
+            "in if needed, and click 'Submit new issue'."
+        ),
+    }
+
+
+# ---------------------------------------------------------------------------
 # Prompts (mirror the hosted server)
 # ---------------------------------------------------------------------------
 
@@ -879,7 +1004,6 @@ Only include deductions explicitly listed in the skill. Never invent deductions 
     description="Collect structured feedback on a skill after the agent has used it.",
 )
 def skill_feedback(skill_slug: str, country: str) -> str:
-    today = datetime.now(tz=timezone.utc).date().isoformat()
     return f"""You just used the {skill_slug} skill for {country} to help a user with their taxes.
 
 Ask the user:
@@ -888,18 +1012,23 @@ Ask the user:
 3. "Were any transactions classified in a way that surprised you?"
 4. "Any other feedback on the skill?"
 
-Compile their responses into a structured feedback summary:
-- Skill: {skill_slug}
-- Country: {country}
-- Date: {today}
-- Accuracy rating: [1-5 based on response to Q1]
-- Missing items: [from Q2]
-- Classification issues: [from Q3]
-- Other: [from Q4]
+Compile their responses into a markdown summary like:
 
-Then call submit_skill_feedback with this summary (if the tool is available).
-If submit_skill_feedback is not available, display the summary and say:
-"Please share this feedback at github.com/openaccountants/openaccountants/issues so we can improve the skill."."""
+```
+**Accuracy:** <answer to Q1>
+**Missing items:** <answer to Q2>
+**Classification issues:** <answer to Q3>
+**Other:** <answer to Q4>
+```
+
+Then call `submit_feedback` with:
+- summary: the markdown above
+- skill_slug: "{skill_slug}"
+- jurisdiction: "{country}"
+- rating: 1-5 derived from the user's answer to Q1 (omit if unclear)
+
+`submit_feedback` returns a `github_url`. Share it with the user verbatim and tell them:
+"Open this link to submit the feedback — GitHub's New Issue page will be pre-filled. Sign in if needed, review, and click *Submit new issue*."."""
 
 
 @mcp.prompt(

--- a/mcp/smoke_test.py
+++ b/mcp/smoke_test.py
@@ -129,6 +129,54 @@ gib = S.start(intent="gibberish")
 check("unmatched intent → needs_clarification",
       gib["status"] == "needs_clarification", gib.get("status"))
 
+# --- submit_feedback ------------------------------------------------------
+print("\nsubmit_feedback (general):")
+fb = S.submit_feedback("Cyprus is missing from the catalogue.")
+check("returns github_url", "github_url" in fb and fb["github_url"].startswith(
+    "https://github.com/openaccountants/openaccountants/issues/new?"), fb.get("github_url"))
+check("title auto-generated", fb["title"] == "Feedback", fb.get("title"))
+check("labels = ['feedback']", fb["labels"] == ["feedback"], str(fb.get("labels")))
+check("body includes the summary", "Cyprus is missing" in fb["body"])
+check("body includes submitted-via footer", "submit_feedback" in fb["body"])
+
+print("submit_feedback (skill-specific, rated):")
+fb_skill = S.submit_feedback(
+    summary="Rates look right but home-office deduction is outdated.",
+    skill_slug="malta-income-tax",
+    jurisdiction="mt",
+    rating=4,
+)
+check("skill title auto", fb_skill["title"] == "Skill feedback: malta-income-tax (MT)",
+      fb_skill.get("title"))
+check("skill-feedback label added", "skill-feedback" in fb_skill["labels"],
+      str(fb_skill["labels"]))
+check("body mentions slug + jurisdiction + rating",
+      "malta-income-tax" in fb_skill["body"]
+      and "MT" in fb_skill["body"]
+      and "4/5" in fb_skill["body"])
+check("url contains url-encoded labels",
+      "labels=feedback%2Cskill-feedback" in fb_skill["github_url"],
+      fb_skill["github_url"])
+
+print("submit_feedback validation:")
+for label, fn in [
+    ("empty summary rejected", lambda: S.submit_feedback("")),
+    ("rating > 5 rejected", lambda: S.submit_feedback("ok", rating=6)),
+    ("rating < 1 rejected", lambda: S.submit_feedback("ok", rating=0)),
+]:
+    try:
+        fn()
+        check(label, False, "did NOT raise")
+    except Exception:
+        check(label, True)
+
+print("submit_feedback (long summary truncated):")
+long_fb = S.submit_feedback("x" * 8000)
+check("long body truncated under 6000 bytes",
+      len(long_fb["body"].encode("utf-8")) <= 6500,  # 6000 + truncation note
+      f"body bytes = {len(long_fb['body'].encode('utf-8'))}")
+check("truncation note present", "truncated" in long_fb["body"].lower())
+
 # --- search_skills --------------------------------------------------------
 print("\nsearch_skills('reverse charge', 'MT'):")
 sr = S.search_skills("reverse charge", "MT")
@@ -156,14 +204,18 @@ check("tax-return interpolates",
       "company taxpayer in Malta" in S.tax_return("Malta", entity_type="company"))
 check("compare-jurisdictions interpolates income",
       "Effective income tax rate at EUR 80000" in S.compare_jurisdictions("MT,UK", income="EUR 80000"))
-check("skill-feedback has slug + date",
-      "malta-income-tax" in S.skill_feedback("malta-income-tax", "MT"))
+sfb = S.skill_feedback("malta-income-tax", "MT")
+check("skill-feedback prompt embeds slug + jurisdiction",
+      "malta-income-tax" in sfb and "MT" in sfb)
+check("skill-feedback prompt points at submit_feedback tool",
+      "submit_feedback" in sfb)
 
 
 async def _registry() -> None:
     tools = {t.name for t in await S.mcp.list_tools()}
-    check("5 tools registered",
-          tools == {"list_skills", "get_skill", "get_skill_sections", "search_skills", "start"},
+    check("6 tools registered",
+          tools == {"list_skills", "get_skill", "get_skill_sections",
+                    "search_skills", "start", "submit_feedback"},
           str(tools))
     prompts = {p.name for p in await S.mcp.list_prompts()}
     check("6 prompts registered",


### PR DESCRIPTION
> **Stacked on #26.** Base is `feature/mcp-docker-and-start-tool` for a focused diff. When #26 merges, GitHub auto-retargets this PR to `main`.

## Summary

The existing `skill-feedback` prompt ends with a dead-end fallback ("please share at github.com/.../issues so we can improve the skill") — high friction, most users won't follow through. This PR replaces it with an actionable path:

- **New `submit_feedback` tool** — takes `summary` + optional `title`, `skill_slug`, `jurisdiction`, `rating`. URL-encodes the payload into GitHub's `?title=&body=&labels=` New Issue URL and hands the link back. The user opens it, GitHub's New Issue page is pre-filled, they sign in if needed and submit under their own account. No server-side token, no abuse vector, attribution preserved.
- **Auto-titling + auto-labels** — `Feedback` for general, `Skill feedback: {slug} ({JX})` for skill-specific. Always-on `feedback` label; adds `skill-feedback` label when a slug is provided.
- **Truncation** — body capped at 6 KB (GitHub URLs practically die past ~8 KB); a truncation note tells the user to paste the rest as a follow-up comment.
- **`skill-feedback` prompt rewired** to drive the 4-question interview *and then* call `submit_feedback`. The never-implemented `submit_skill_feedback` reference is gone.
- **FastMCP `instructions`** extended so models discover the tool without needing the prompt.
- **Smoke test** bumped to 6 tools, gains 14 checks for general feedback, skill feedback, input validation, and body truncation. Total checks: 52, all green locally.

## Test plan

- [ ] Run smoke test: `python mcp/smoke_test.py` (or via uv) — all 52 checks pass
- [ ] From an MCP client, call `submit_feedback(summary="Test", skill_slug="malta-income-tax", jurisdiction="MT", rating=4)`; open the returned `github_url`; confirm GitHub's New Issue page loads with title, labels (`feedback`, `skill-feedback`), and pre-filled body
- [ ] Call `submit_feedback(summary="Cyprus missing")`; open URL; confirm general feedback flow (only `feedback` label)
- [ ] Invoke the `skill-feedback` slash-prompt for `malta-income-tax` / `MT`; let the model run the interview; confirm it ends with a `submit_feedback` call rather than the old dead-end text
- [ ] Edge cases: empty summary → `ValueError`; rating outside 1–5 → `ValueError`; 8000-char summary → body truncated with note

🤖 Generated with [Claude Code](https://claude.com/claude-code)