### PR TITLE
ci: sync packages/ to openaccountants-mcp on main pushes

### DIFF
--- a/.github/workflows/sync-mcp.yml
+++ b/.github/workflows/sync-mcp.yml
@@ -1,0 +1,60 @@
+# Sync packages/ into openaccountants/openaccountants-mcp on every push to main.
+#
+# packages/ is the canonical skill catalogue and lives in this repo.  The MCP
+# server ships a vendored copy so `pip install openaccountants-mcp` works
+# without cloning anything else.  Humans do not edit packages/ in the MCP repo
+# directly — this workflow is the one and only writer there.
+#
+# Auth: the MCP_SYNC_DEPLOY_KEY secret holds an ed25519 deploy key with
+# write access on openaccountants/openaccountants-mcp (and nothing else).
+
+name: Sync packages to MCP repo
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'packages/**'
+      - '.github/workflows/sync-mcp.yml'
+  workflow_dispatch:
+
+concurrency:
+  group: sync-mcp
+  cancel-in-progress: false
+
+jobs:
+  sync:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout source (openaccountants)
+        uses: actions/checkout@v4
+        with:
+          path: source
+
+      - name: Checkout destination (openaccountants-mcp)
+        uses: actions/checkout@v4
+        with:
+          repository: openaccountants/openaccountants-mcp
+          ssh-key: ${{ secrets.MCP_SYNC_DEPLOY_KEY }}
+          path: dest
+          persist-credentials: true
+
+      - name: Mirror packages/ (rsync --delete)
+        run: |
+          rsync -a --delete source/packages/ dest/packages/
+
+      - name: Commit + push if changed
+        working-directory: dest
+        run: |
+          git config user.name "openaccountants-sync[bot]"
+          git config user.email "sync@openaccountants.invalid"
+          if [[ -z "$(git status --porcelain packages)" ]]; then
+            echo "No skill content changes since last sync. Nothing to push."
+            exit 0
+          fi
+          SHORT_SHA="${GITHUB_SHA::7}"
+          git add packages
+          git commit -m "Sync packages/ from openaccountants@${SHORT_SHA}"
+          git push origin HEAD:main


### PR DESCRIPTION
## Summary

- Adds `.github/workflows/sync-mcp.yml` — on every push to `main` (or via `workflow_dispatch`), `rsync --delete` of `packages/` into `openaccountants/openaccountants-mcp` and pushes a sync commit there.
- Auth: `MCP_SYNC_DEPLOY_KEY` secret (already set) — ed25519 deploy key with write access on `openaccountants-mcp` only.
- After this merges, `packages/` in the MCP repo becomes a **build artifact** — single writer is this workflow.

## Test plan

- [ ] Merge to main
- [ ] Confirm workflow run kicks off (push event with `packages/**` paths)
- [ ] Confirm a sync commit appears on `openaccountants-mcp/main` authored by `openaccountants-sync[bot]`
- [ ] Confirm the MCP repo's CI (smoke test) passes on the synced commit