### PR TITLE
Fix contact-email typo (787×), reconcile coverage numbers, add proof docs

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -12,7 +12,7 @@ OpenAccountants is dual-licensed (AGPL-3.0 + commercial). We need a clear **yes*
 
 - [ ] **I have read [CLA.md](https://github.com/openaccountants/openaccountants/blob/main/CLA.md) and agree to the Contributor License Agreement** for everything included in this pull request. *(Checking this box is your explicit opt-in.)*
 
-If you cannot agree, do not open this PR — contact **info@openaaccountants.com** to discuss alternatives (including a formal signed agreement).
+If you cannot agree, do not open this PR — contact **info@openaccountants.com** to discuss alternatives (including a formal signed agreement).
 
 ## Checklist
 

--- a/CLA.md
+++ b/CLA.md
@@ -47,7 +47,7 @@ Glimpse Ltd is under no obligation to accept, merge, or use your Contribution.
 
 You may instead include a clear statement in the PR description (for example: “I agree to the CLA at CLA.md”) if you cannot use the checkbox, but the checkbox is the default path maintainers will look for.
 
-If you prefer a formal signed agreement, contact **info@openaaccountants.com** and we will provide one.
+If you prefer a formal signed agreement, contact **info@openaccountants.com** and we will provide one.
 
 ---
 
@@ -64,7 +64,7 @@ This CLA is between the contributor and:
 **Glimpse Ltd**
 Malta
 
-Contact: info@openaaccountants.com
+Contact: info@openaccountants.com
 
 ---
 

--- a/COMMERCIAL_LICENSE.md
+++ b/COMMERCIAL_LICENSE.md
@@ -55,13 +55,13 @@ Commercial licenses are negotiated based on use case and scale. We aim to be fai
 - **Startups and small teams** — affordable flat fee
 - **Enterprise and large-scale SaaS** — usage-based or annual license
 
-Contact **info@openaaccountants.com** to discuss your use case.
+Contact **info@openaccountants.com** to discuss your use case.
 
 ---
 
 ## How to get a commercial license
 
-1. Email **info@openaaccountants.com** with:
+1. Email **info@openaccountants.com** with:
    - Your company name and country
    - A brief description of how you intend to use the skills
    - Approximate scale (number of users, API calls, etc.)
@@ -76,7 +76,7 @@ Commercial licenses are issued by:
 **Glimpse Ltd**
 Malta
 
-Contact: info@openaaccountants.com
+Contact: info@openaccountants.com
 
 ---
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -133,7 +133,7 @@ OpenAccountants is **dual-licensed** (AGPL-3.0 + commercial). The [Contributor L
 
 **GitHub pull requests:** we rely on an **explicit opt-in**. When you open a PR, you must **tick the CLA checkbox** in the [pull request template](.github/PULL_REQUEST_TEMPLATE.md) (and leave it checked on updates to the same PR). That single action is how you record agreement. Maintainers should not merge PRs where the contributor has not confirmed the CLA.
 
-**Website / other channels:** follow whatever acceptance flow that channel provides, or contact **info@openaaccountants.com** for a formal signed agreement.
+**Website / other channels:** follow whatever acceptance flow that channel provides, or contact **info@openaccountants.com** for a formal signed agreement.
 
 If anything in [CLA.md](CLA.md) is unclear, ask before contributing.
 

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 
 # OpenAccountants
 
-Open-source accounting skills for AI. **890+ skills across 134 countries + 51 US state packages + 13 Canadian province/territory packages.**
+Open-source accounting & tax skills for AI agents. **1,000+ skills across 192 jurisdictions** — 130+ countries plus every US state. Research-verified in this repo; [accountant-verified via the MCP connector](https://openaccountants.com/connect). Full breakdown: [docs/COVERAGE.md](docs/COVERAGE.md).
 
 **11 accounting domains:** tax, bookkeeping, e-invoicing, payroll, company formation, financial statements, transfer pricing, tax optimization, **crypto tax**, cross-border, plus industry verticals and platform integrations.
 
@@ -129,6 +129,16 @@ Check my invoice compliance for EU e-invoicing.
 
 The AI will ask a few questions, load the right skills, and produce a working paper for your accountant.
 
+**Cross-border and scenario questions work too** — describe the situation and the AI loads the right skills across jurisdictions:
+
+```
+US citizen moving to Malta — tax workflow and exit considerations
+Freelancer in Germany — VAT and income tax for the year
+Cross-border SaaS — VAT place-of-supply for EU B2B and B2C
+Crypto tax: Portugal vs Malta for a long-term holder
+Selling a UK company as a non-resident — CGT and treaty relief
+```
+
 ---
 
 ## Are you an accountant?
@@ -139,7 +149,7 @@ These skills need your eye. Most are **research-verified** — drafted from auth
 
 1. Find your country's folder under `packages/`
 2. Check the rates against your tax authority's website
-3. Email your corrections to **info@openaaccountants.com** — Word doc, Excel, PDF, tracked changes, whatever format works for you
+3. Email your corrections to **info@openaccountants.com** — Word doc, Excel, PDF, tracked changes, whatever format works for you
 
 We'll update the skill and credit you publicly as the verified reviewer at [openaccountants.com](https://openaccountants.com).
 

--- a/START-HERE.md
+++ b/START-HERE.md
@@ -113,7 +113,7 @@ See [QUALITY-TIERS.md](docs/QUALITY-TIERS.md) for the full definitions.
 
 - **Country not listed?** Check [`packages/`](packages/) — we have folders for 134 countries. If yours is missing, file an issue.
 - **Your scenario isn't in the table above?** Open an issue describing it and we'll add a row.
-- **Skill produced something wrong?** That's a contribution. Email info@openaaccountants.com or submit a PR. Your correction gets the skill upgraded and you get public credit.
+- **Skill produced something wrong?** That's a contribution. Email info@openaccountants.com or submit a PR. Your correction gets the skill upgraded and you get public credit.
 
 ---
 

--- a/docs/ACCURACY-METHODOLOGY.md
+++ b/docs/ACCURACY-METHODOLOGY.md
@@ -1,0 +1,47 @@
+# Accuracy methodology
+
+How OpenAccountants skills are built, verified, and corrected — and, just as importantly, what "verified" does **not** mean.
+
+## The problem we're solving
+
+General-purpose LLMs hallucinate tax law: they invent rates, misremember thresholds, cite forms that don't exist, and apply last year's rules to this year. OpenAccountants skills replace the model's guesswork with content drafted from authoritative sources and, where possible, signed off by a licensed practitioner.
+
+## Two verification tiers
+
+See [QUALITY-TIERS.md](QUALITY-TIERS.md) for the full definitions. In short:
+
+| Tier | Standard | Who |
+|---|---|---|
+| **Research-verified** (Tier 2) | Every rate, threshold, form, and deadline drafted from authoritative sources (tax-authority publications and primary legislation) | Drafted + cross-checked, awaiting credentialed sign-off |
+| **Accountant-verified** (Tier 1) | A licensed practitioner has reviewed the skill, tested it against representative data, and put their name + credential on it | Named CPA / CA / EA / Steuerberater / local equivalent |
+
+The honest headline is **"research-verified here, accountant-verified via MCP"** — never a blanket "verified by accountants." Most skills in this repo are Tier 2. See [COVERAGE.md](COVERAGE.md) for the exact split.
+
+## Sources
+
+Skills are drafted from, and cite, primary sources only:
+- Tax-authority publications (IRS, HMRC, CRA, ATO, etc.)
+- Primary legislation and statutory instruments
+- Official forms and their instructions
+
+Training-data recall and unsourced web results are **not** acceptable sources for a rate or threshold.
+
+## Conservative by design
+
+When the correct treatment is genuinely uncertain, skills are written to **assume the higher-tax / more-compliant position** and to flag the uncertainty rather than guess in the taxpayer's favour. Every skill surfaces **audit flash points** — the specific spots where a real practitioner should look before anything is filed.
+
+## The correction feedback loop
+
+Accuracy improves in the open. When a skill produces something wrong:
+1. Anyone can open an issue or PR with the correct figure and a source, or email a correction (see [CORRECTION-FEEDBACK-LOOP-SPEC.md](CORRECTION-FEEDBACK-LOOP-SPEC.md)).
+2. The fix is applied and the contributor gets public credit.
+3. With credentialed sign-off, the skill moves from research-verified to accountant-verified.
+
+## What "verified" does NOT mean
+
+- It is **not** tax advice and **not** a filed return — every output is a **working paper** for a human to check.
+- A research-verified skill has **not** been signed off by a credentialed practitioner.
+- Verification reflects the rules **as of the skill's stated date**; tax law changes — check the date.
+- Coverage of a jurisdiction does not imply coverage of every edge case within it.
+
+The product is designed around this honesty: the AI produces a working paper and routes you to a real accountant for sign-off via `request_accountant_review`.

--- a/docs/COVERAGE.md
+++ b/docs/COVERAGE.md
@@ -1,0 +1,43 @@
+# Coverage — single source of truth
+
+**This file is the canonical record of OpenAccountants coverage numbers.** Every other surface — GitHub README, repo About, the website, Smithery, MCP directories, release notes — should match the figures here. If they disagree, this file wins; fix the other surface.
+
+_Last updated: 2026-06-07 · source: production database (skills served via the MCP server)._
+
+## Headline (use these)
+
+| Claim | Number |
+|---|---|
+| Skills (published) | **1,098** |
+| Jurisdictions | **192** |
+| Rounded headline | **1,000+ skills across 192 jurisdictions** |
+
+> When a headline needs round numbers, use **"1,000+ skills"** and **"192 jurisdictions"** (or **"130+ countries plus every US state"**). Do not invent other figures.
+
+## Verification split
+
+OpenAccountants has two verification tiers (see [QUALITY-TIERS.md](QUALITY-TIERS.md)). The distinction matters and should never be collapsed into a blanket "accountant-verified":
+
+| Tier | What it means | Count | Where it lives |
+|---|---|---|---|
+| **Accountant-verified** (Tier 1) | A licensed practitioner has signed off; name + credential on every output | **85** | **MCP server only** (not in this repo) |
+| **Research-verified** (Tier 2) | Every rate/threshold/form drafted from authoritative sources, awaiting credentialed sign-off | **1,013** | **This repo** |
+
+**Correct headline phrasing:** _"Research-verified in this repo. Accountant-verified via the MCP connector."_
+
+## Jurisdiction breakdown
+
+| Level | Count |
+|---|---|
+| Country-level jurisdictions | **139** |
+| US state-level codes (50 states + DC + federal) | **53** |
+| **Total distinct jurisdictions** | **192** |
+
+Notes:
+- "130+ countries" is the safe rounded claim (139 country-level jurisdictions). **Do not say "every country"** — there are ~195 sovereign countries; we cover ~139.
+- Canada is served at the federal level (`CA`) via the MCP; this repo additionally breaks Canada into province/territory packages.
+- US is covered federally plus every state and DC.
+
+## How to update this file
+
+When skills are published or jurisdictions added, re-run the counts against the production database and update the tables above **and** the "Last updated" date. Then reconcile the README headline, repo About, and website to match.

--- a/docs/EXAMPLE-WORKING-PAPERS.md
+++ b/docs/EXAMPLE-WORKING-PAPERS.md
@@ -1,0 +1,55 @@
+# Example working papers
+
+What an OpenAccountants skill actually produces. The output is a **working paper** — a structured, sourced computation for a human to check — not a filed return and not tax advice.
+
+> ⚠️ The example below is **illustrative**, with round invented numbers, to show the *format*. It is not a real computation and the figures are not authoritative. Real output uses the live rates and thresholds in the skill, dated, with the verifier's name attached.
+
+## Anatomy of a working paper
+
+Every working paper has the same bones:
+
+1. **Inputs** — the facts the user provided, restated so they can confirm them
+2. **Computation** — each line derived from a specific rule in the skill, not from model recall
+3. **Audit flash points** — the spots a real practitioner must check before filing
+4. **Provenance footer** — skill, jurisdiction, date, and (for Tier 1) the named verifier
+5. **Handoff** — a route to a licensed accountant for sign-off
+
+## Illustrative example — UK sole trader (SA103)
+
+**Inputs (confirm these):**
+- Self-employment income: £50,000
+- Allowable expenses: £8,000
+- Tax year: 2025/26 · No other income
+
+**Computation (illustrative):**
+
+| Line | Amount |
+|---|---|
+| Turnover | £50,000 |
+| Less allowable expenses | (£8,000) |
+| **Net profit** | **£42,000** |
+| Personal allowance | (£12,570) |
+| Taxable profit | £29,430 |
+| Income tax (basic rate band) | _per skill's current rate table_ |
+| Class 4 NIC | _per skill's current thresholds_ |
+| **Estimated liability** | _computed from the above_ |
+
+**Audit flash points (the skill flags these):**
+- Is the trader registered for VAT? Turnover is near common thresholds — confirm.
+- Any disallowable items inside the £8,000 expenses (entertainment, private-use split)?
+- Payments on account for next year — has the user budgeted for them?
+- Student loan / High Income Child Benefit Charge interactions if other income exists.
+
+**Provenance footer:**
+> Computed with `uk-self-employment-sa103` · 2025/26 rules · research-verified.
+> _For accountant-verified output with a named UK CPA on the result, use the [MCP connector](https://openaccountants.com/connect)._
+
+**Handoff:** the AI then offers to route the working paper to a licensed accountant via `request_accountant_review`.
+
+## Generate a real one
+
+Don't copy figures from this page. To produce a real working paper:
+- **Upload** the relevant package from [`packages/`](../packages/) to your LLM and give it your facts, or
+- **Connect via [MCP](https://openaccountants.com/connect)** and ask your question — the AI loads the authoritative skill automatically and attaches a verifier's name where one exists.
+
+Always have a credentialed professional review before filing.

--- a/docs/VERIFIERS.md
+++ b/docs/VERIFIERS.md
@@ -1,0 +1,31 @@
+# Verifiers
+
+These are the licensed practitioners who have signed off on **accountant-verified (Tier 1)** skills. Tier 1 skills are served via the [MCP connector](https://openaccountants.com/connect) with the verifier's name and credential on every output.
+
+_Last updated: 2026-06-07. The authoritative, live list is the network directory at [openaccountants.com](https://openaccountants.com)._
+
+| Jurisdiction | Verifier | Credential |
+|---|---|---|
+| 🇧🇷 Brazil | Ariane Marrocos | CRC SP 312052/O-1 |
+| 🇮🇳 India | Mayur Deokar | 615638 |
+| 🇮🇩 Indonesia | Rilia Putri | 11.D43411 |
+| 🇰🇪 Kenya | Felistas Wanjiku Njihia | CPA |
+| 🇲🇹 Malta | Michael Cutajar | CPA (Malta) |
+| 🇳🇵 Nepal | Ashish Bista | ICAN 1765 |
+| 🇵🇹 Portugal | Mário Jorge da Costa Vale | CA 85883 |
+| 🇸🇦 Saudi Arabia | Mehran Habib | 13480 |
+| 🇿🇦 South Africa | Werner Britz | CA(SA) |
+| 🇬🇧 United Kingdom | James Power | — |
+| 🇺🇸 United States (federal + Illinois) | Amir Pelinkovic | 065.061971 |
+
+**11 credentialed practitioners across 13 jurisdiction assignments.** Most jurisdictions in this repo are still **research-verified** and awaiting a credentialed reviewer.
+
+## Become a verifier
+
+If you're a licensed CPA / CA / EA / Steuerberater (or local equivalent) and want to be the named verifier for your jurisdiction:
+
+- See the open [reviewer-wanted issues](https://github.com/openaccountants/openaccountants/issues)
+- Read [CONTRIBUTING.md](../CONTRIBUTING.md) and [QUALITY-TIERS.md](QUALITY-TIERS.md)
+- Apply at [openaccountants.com](https://openaccountants.com)
+
+Your sign-off moves a jurisdiction's skills from research-verified to accountant-verified, with your name on every answer the AI gives.

--- a/packages/_cross-border/cross-border-vat-gst.md
+++ b/packages/_cross-border/cross-border-vat-gst.md
@@ -317,7 +317,7 @@ If earning across multiple platforms (YouTube, Patreon, Substack, Gumroad), **ag
 
 *Data reflects 2024–2026 rules. VAT/GST thresholds, rates, and registration requirements change frequently. Verify all figures with official sources and a qualified indirect tax advisor.*
 *Original content: [Artin (@ar-gen-tin)](https://github.com/ar-gen-tin/panrise) — MIT License.*
-*OpenAccountants — open-source accounting skills for AI — info@openaaccountants.com*
+*OpenAccountants — open-source accounting skills for AI — info@openaccountants.com*
 
 ---
 

--- a/packages/_cross-border/forex-controls.md
+++ b/packages/_cross-border/forex-controls.md
@@ -317,7 +317,7 @@ When receiving a CRS inquiry letter from Chinese tax authorities:
 
 *Data reflects 2024–2026 rules. Forex regulations are enforced with increasing rigor worldwide. Verify current limits and procedures with your bank and a qualified advisor before large cross-border transfers.*
 *Original content: [Artin (@ar-gen-tin)](https://github.com/ar-gen-tin/panrise) — MIT License.*
-*OpenAccountants — open-source accounting skills for AI — info@openaaccountants.com*
+*OpenAccountants — open-source accounting skills for AI — info@openaccountants.com*
 
 ---
 

--- a/packages/_cross-border/international-incorporation.md
+++ b/packages/_cross-border/international-incorporation.md
@@ -303,7 +303,7 @@ Every LLC — even single-member — needs an operating agreement covering:
 
 *Data reflects 2024–2026 rules. For amounts >$100,000 USD or life-changing decisions, verify current rules with a qualified advisor in each relevant jurisdiction.*
 *Original content: [Artin (@ar-gen-tin)](https://github.com/ar-gen-tin/panrise) — MIT License.*
-*OpenAccountants — open-source accounting skills for AI — info@openaaccountants.com*
+*OpenAccountants — open-source accounting skills for AI — info@openaccountants.com*
 
 ---
 

--- a/packages/_cross-border/tax-residency-planning.md
+++ b/packages/_cross-border/tax-residency-planning.md
@@ -287,7 +287,7 @@ Five "flags" that do NOT need to be in the same country:
 
 *Data reflects 2024–2026 rules. Tax residency changes are high-stakes decisions — verify all rules with a qualified cross-border tax advisor before acting.*
 *Original content: [Artin (@ar-gen-tin)](https://github.com/ar-gen-tin/panrise) — MIT License.*
-*OpenAccountants — open-source accounting skills for AI — info@openaaccountants.com*
+*OpenAccountants — open-source accounting skills for AI — info@openaccountants.com*
 
 ---
 

--- a/packages/albania/README.md
+++ b/packages/albania/README.md
@@ -42,7 +42,7 @@ These Albania tax skills need your eye. Every rate, threshold, and form referenc
 
 1. Download the files in this folder
 2. Check the rates against your national tax authority's website
-3. Email your corrections to **info@openaaccountants.com** — Word doc, Excel, PDF, tracked changes, whatever works
+3. Email your corrections to **info@openaccountants.com** — Word doc, Excel, PDF, tracked changes, whatever works
 
 We'll update the skill and credit you publicly as the verified reviewer at [openaccountants.com](https://openaccountants.com).
 
@@ -54,4 +54,4 @@ Or if you're comfortable with GitHub: fork the repo, fix the source file under `
 
 *OpenAccountants — open-source accounting skills for AI*
 *134 countries + 51 US states — [openaccountants.com](https://openaccountants.com)*
-*info@openaaccountants.com*
+*info@openaccountants.com*

--- a/packages/algeria/README.md
+++ b/packages/algeria/README.md
@@ -42,7 +42,7 @@ These Algeria tax skills need your eye. Every rate, threshold, and form referenc
 
 1. Download the files in this folder
 2. Check the rates against your national tax authority's website
-3. Email your corrections to **info@openaaccountants.com** — Word doc, Excel, PDF, tracked changes, whatever works
+3. Email your corrections to **info@openaccountants.com** — Word doc, Excel, PDF, tracked changes, whatever works
 
 We'll update the skill and credit you publicly as the verified reviewer at [openaccountants.com](https://openaccountants.com).
 
@@ -54,4 +54,4 @@ Or if you're comfortable with GitHub: fork the repo, fix the source file under `
 
 *OpenAccountants — open-source accounting skills for AI*
 *134 countries + 51 US states — [openaccountants.com](https://openaccountants.com)*
-*info@openaaccountants.com*
+*info@openaccountants.com*

--- a/packages/andorra/README.md
+++ b/packages/andorra/README.md
@@ -42,7 +42,7 @@ These Andorra tax skills need your eye. Every rate, threshold, and form referenc
 
 1. Download the files in this folder
 2. Check the rates against your national tax authority's website
-3. Email your corrections to **info@openaaccountants.com** — Word doc, Excel, PDF, tracked changes, whatever works
+3. Email your corrections to **info@openaccountants.com** — Word doc, Excel, PDF, tracked changes, whatever works
 
 We'll update the skill and credit you publicly as the verified reviewer at [openaccountants.com](https://openaccountants.com).
 
@@ -54,4 +54,4 @@ Or if you're comfortable with GitHub: fork the repo, fix the source file under `
 
 *OpenAccountants — open-source accounting skills for AI*
 *134 countries + 51 US states — [openaccountants.com](https://openaccountants.com)*
-*info@openaaccountants.com*
+*info@openaccountants.com*

--- a/packages/argentina/README.md
+++ b/packages/argentina/README.md
@@ -53,7 +53,7 @@ These Argentina tax skills need your eye. Every rate, threshold, and form refere
 
 1. Download the files in this folder
 2. Check the rates against AFIP (Administración Federal de Ingresos Públicos)'s website
-3. Email your corrections to **info@openaaccountants.com** — Word doc, Excel, PDF, tracked changes, whatever works
+3. Email your corrections to **info@openaccountants.com** — Word doc, Excel, PDF, tracked changes, whatever works
 
 We'll update the skill and credit you publicly as the verified reviewer at [openaccountants.com](https://openaccountants.com).
 
@@ -65,4 +65,4 @@ Or if you're comfortable with GitHub: fork the repo, fix the source file under `
 
 *OpenAccountants — open-source accounting skills for AI*
 *134 countries + 51 US states — [openaccountants.com](https://openaccountants.com)*
-*info@openaaccountants.com*
+*info@openaccountants.com*

--- a/packages/armenia/README.md
+++ b/packages/armenia/README.md
@@ -42,7 +42,7 @@ These Armenia tax skills need your eye. Every rate, threshold, and form referenc
 
 1. Download the files in this folder
 2. Check the rates against your national tax authority's website
-3. Email your corrections to **info@openaaccountants.com** — Word doc, Excel, PDF, tracked changes, whatever works
+3. Email your corrections to **info@openaccountants.com** — Word doc, Excel, PDF, tracked changes, whatever works
 
 We'll update the skill and credit you publicly as the verified reviewer at [openaccountants.com](https://openaccountants.com).
 
@@ -54,4 +54,4 @@ Or if you're comfortable with GitHub: fork the repo, fix the source file under `
 
 *OpenAccountants — open-source accounting skills for AI*
 *134 countries + 51 US states — [openaccountants.com](https://openaccountants.com)*
-*info@openaaccountants.com*
+*info@openaccountants.com*

--- a/packages/australia/README.md
+++ b/packages/australia/README.md
@@ -70,7 +70,7 @@ These Australia tax skills need your eye. Every rate, threshold, and form refere
 
 1. Download the files in this folder
 2. Check the rates against Australian Taxation Office (ATO)'s website
-3. Email your corrections to **info@openaaccountants.com** — Word doc, Excel, PDF, tracked changes, whatever works
+3. Email your corrections to **info@openaccountants.com** — Word doc, Excel, PDF, tracked changes, whatever works
 
 We'll update the skill and credit you publicly as the verified reviewer at [openaccountants.com](https://openaccountants.com).
 
@@ -82,4 +82,4 @@ Or if you're comfortable with GitHub: fork the repo, fix the source file under `
 
 *OpenAccountants — open-source accounting skills for AI*
 *134 countries + 51 US states — [openaccountants.com](https://openaccountants.com)*
-*info@openaaccountants.com*
+*info@openaccountants.com*

--- a/packages/austria/README.md
+++ b/packages/austria/README.md
@@ -51,7 +51,7 @@ These Austria tax skills need your eye. Every rate, threshold, and form referenc
 
 1. Download the files in this folder
 2. Check the rates against Bundesministerium für Finanzen / FinanzOnline's website
-3. Email your corrections to **info@openaaccountants.com** — Word doc, Excel, PDF, tracked changes, whatever works
+3. Email your corrections to **info@openaccountants.com** — Word doc, Excel, PDF, tracked changes, whatever works
 
 We'll update the skill and credit you publicly as the verified reviewer at [openaccountants.com](https://openaccountants.com).
 
@@ -63,4 +63,4 @@ Or if you're comfortable with GitHub: fork the repo, fix the source file under `
 
 *OpenAccountants — open-source accounting skills for AI*
 *134 countries + 51 US states — [openaccountants.com](https://openaccountants.com)*
-*info@openaaccountants.com*
+*info@openaccountants.com*

--- a/packages/azerbaijan/README.md
+++ b/packages/azerbaijan/README.md
@@ -42,7 +42,7 @@ These Azerbaijan tax skills need your eye. Every rate, threshold, and form refer
 
 1. Download the files in this folder
 2. Check the rates against your national tax authority's website
-3. Email your corrections to **info@openaaccountants.com** — Word doc, Excel, PDF, tracked changes, whatever works
+3. Email your corrections to **info@openaccountants.com** — Word doc, Excel, PDF, tracked changes, whatever works
 
 We'll update the skill and credit you publicly as the verified reviewer at [openaccountants.com](https://openaccountants.com).
 
@@ -54,4 +54,4 @@ Or if you're comfortable with GitHub: fork the repo, fix the source file under `
 
 *OpenAccountants — open-source accounting skills for AI*
 *134 countries + 51 US states — [openaccountants.com](https://openaccountants.com)*
-*info@openaaccountants.com*
+*info@openaccountants.com*

--- a/packages/bahamas/README.md
+++ b/packages/bahamas/README.md
@@ -42,7 +42,7 @@ These Bahamas tax skills need your eye. Every rate, threshold, and form referenc
 
 1. Download the files in this folder
 2. Check the rates against your national tax authority's website
-3. Email your corrections to **info@openaaccountants.com** — Word doc, Excel, PDF, tracked changes, whatever works
+3. Email your corrections to **info@openaccountants.com** — Word doc, Excel, PDF, tracked changes, whatever works
 
 We'll update the skill and credit you publicly as the verified reviewer at [openaccountants.com](https://openaccountants.com).
 
@@ -54,4 +54,4 @@ Or if you're comfortable with GitHub: fork the repo, fix the source file under `
 
 *OpenAccountants — open-source accounting skills for AI*
 *134 countries + 51 US states — [openaccountants.com](https://openaccountants.com)*
-*info@openaaccountants.com*
+*info@openaccountants.com*

--- a/packages/bahrain/README.md
+++ b/packages/bahrain/README.md
@@ -42,7 +42,7 @@ These Bahrain tax skills need your eye. Every rate, threshold, and form referenc
 
 1. Download the files in this folder
 2. Check the rates against your national tax authority's website
-3. Email your corrections to **info@openaaccountants.com** — Word doc, Excel, PDF, tracked changes, whatever works
+3. Email your corrections to **info@openaccountants.com** — Word doc, Excel, PDF, tracked changes, whatever works
 
 We'll update the skill and credit you publicly as the verified reviewer at [openaccountants.com](https://openaccountants.com).
 
@@ -54,4 +54,4 @@ Or if you're comfortable with GitHub: fork the repo, fix the source file under `
 
 *OpenAccountants — open-source accounting skills for AI*
 *134 countries + 51 US states — [openaccountants.com](https://openaccountants.com)*
-*info@openaaccountants.com*
+*info@openaccountants.com*

--- a/packages/bangladesh/README.md
+++ b/packages/bangladesh/README.md
@@ -44,7 +44,7 @@ These Bangladesh tax skills need your eye. Every rate, threshold, and form refer
 
 1. Download the files in this folder
 2. Check the rates against your national tax authority's website
-3. Email your corrections to **info@openaaccountants.com** — Word doc, Excel, PDF, tracked changes, whatever works
+3. Email your corrections to **info@openaccountants.com** — Word doc, Excel, PDF, tracked changes, whatever works
 
 We'll update the skill and credit you publicly as the verified reviewer at [openaccountants.com](https://openaccountants.com).
 
@@ -56,4 +56,4 @@ Or if you're comfortable with GitHub: fork the repo, fix the source file under `
 
 *OpenAccountants — open-source accounting skills for AI*
 *134 countries + 51 US states — [openaccountants.com](https://openaccountants.com)*
-*info@openaaccountants.com*
+*info@openaccountants.com*

--- a/packages/barbados/README.md
+++ b/packages/barbados/README.md
@@ -42,7 +42,7 @@ These Barbados tax skills need your eye. Every rate, threshold, and form referen
 
 1. Download the files in this folder
 2. Check the rates against your national tax authority's website
-3. Email your corrections to **info@openaaccountants.com** — Word doc, Excel, PDF, tracked changes, whatever works
+3. Email your corrections to **info@openaccountants.com** — Word doc, Excel, PDF, tracked changes, whatever works
 
 We'll update the skill and credit you publicly as the verified reviewer at [openaccountants.com](https://openaccountants.com).
 
@@ -54,4 +54,4 @@ Or if you're comfortable with GitHub: fork the repo, fix the source file under `
 
 *OpenAccountants — open-source accounting skills for AI*
 *134 countries + 51 US states — [openaccountants.com](https://openaccountants.com)*
-*info@openaaccountants.com*
+*info@openaccountants.com*

--- a/packages/belarus/README.md
+++ b/packages/belarus/README.md
@@ -42,7 +42,7 @@ These Belarus tax skills need your eye. Every rate, threshold, and form referenc
 
 1. Download the files in this folder
 2. Check the rates against your national tax authority's website
-3. Email your corrections to **info@openaaccountants.com** — Word doc, Excel, PDF, tracked changes, whatever works
+3. Email your corrections to **info@openaccountants.com** — Word doc, Excel, PDF, tracked changes, whatever works
 
 We'll update the skill and credit you publicly as the verified reviewer at [openaccountants.com](https://openaccountants.com).
 
@@ -54,4 +54,4 @@ Or if you're comfortable with GitHub: fork the repo, fix the source file under `
 
 *OpenAccountants — open-source accounting skills for AI*
 *134 countries + 51 US states — [openaccountants.com](https://openaccountants.com)*
-*info@openaaccountants.com*
+*info@openaccountants.com*

--- a/packages/belgium/README.md
+++ b/packages/belgium/README.md
@@ -61,7 +61,7 @@ These Belgium tax skills need your eye. Every rate, threshold, and form referenc
 
 1. Download the files in this folder
 2. Check the rates against SPF Finances / FOD Financiën's website
-3. Email your corrections to **info@openaaccountants.com** — Word doc, Excel, PDF, tracked changes, whatever works
+3. Email your corrections to **info@openaccountants.com** — Word doc, Excel, PDF, tracked changes, whatever works
 
 We'll update the skill and credit you publicly as the verified reviewer at [openaccountants.com](https://openaccountants.com).
 
@@ -73,4 +73,4 @@ Or if you're comfortable with GitHub: fork the repo, fix the source file under `
 
 *OpenAccountants — open-source accounting skills for AI*
 *134 countries + 51 US states — [openaccountants.com](https://openaccountants.com)*
-*info@openaaccountants.com*
+*info@openaccountants.com*

--- a/packages/bermuda/README.md
+++ b/packages/bermuda/README.md
@@ -42,7 +42,7 @@ These Bermuda tax skills need your eye. Every rate, threshold, and form referenc
 
 1. Download the files in this folder
 2. Check the rates against your national tax authority's website
-3. Email your corrections to **info@openaaccountants.com** — Word doc, Excel, PDF, tracked changes, whatever works
+3. Email your corrections to **info@openaccountants.com** — Word doc, Excel, PDF, tracked changes, whatever works
 
 We'll update the skill and credit you publicly as the verified reviewer at [openaccountants.com](https://openaccountants.com).
 
@@ -54,4 +54,4 @@ Or if you're comfortable with GitHub: fork the repo, fix the source file under `
 
 *OpenAccountants — open-source accounting skills for AI*
 *134 countries + 51 US states — [openaccountants.com](https://openaccountants.com)*
-*info@openaaccountants.com*
+*info@openaccountants.com*

--- a/packages/bolivia/README.md
+++ b/packages/bolivia/README.md
@@ -42,7 +42,7 @@ These Bolivia tax skills need your eye. Every rate, threshold, and form referenc
 
 1. Download the files in this folder
 2. Check the rates against your national tax authority's website
-3. Email your corrections to **info@openaaccountants.com** — Word doc, Excel, PDF, tracked changes, whatever works
+3. Email your corrections to **info@openaccountants.com** — Word doc, Excel, PDF, tracked changes, whatever works
 
 We'll update the skill and credit you publicly as the verified reviewer at [openaccountants.com](https://openaccountants.com).
 
@@ -54,4 +54,4 @@ Or if you're comfortable with GitHub: fork the repo, fix the source file under `
 
 *OpenAccountants — open-source accounting skills for AI*
 *134 countries + 51 US states — [openaccountants.com](https://openaccountants.com)*
-*info@openaaccountants.com*
+*info@openaccountants.com*

--- a/packages/bosnia/README.md
+++ b/packages/bosnia/README.md
@@ -42,7 +42,7 @@ These Bosnia and Herzegovina tax skills need your eye. Every rate, threshold, an
 
 1. Download the files in this folder
 2. Check the rates against your national tax authority's website
-3. Email your corrections to **info@openaaccountants.com** — Word doc, Excel, PDF, tracked changes, whatever works
+3. Email your corrections to **info@openaccountants.com** — Word doc, Excel, PDF, tracked changes, whatever works
 
 We'll update the skill and credit you publicly as the verified reviewer at [openaccountants.com](https://openaccountants.com).
 
@@ -54,4 +54,4 @@ Or if you're comfortable with GitHub: fork the repo, fix the source file under `
 
 *OpenAccountants — open-source accounting skills for AI*
 *134 countries + 51 US states — [openaccountants.com](https://openaccountants.com)*
-*info@openaaccountants.com*
+*info@openaccountants.com*

--- a/packages/brazil/README.md
+++ b/packages/brazil/README.md
@@ -64,7 +64,7 @@ These Brazil tax skills need your eye. Every rate, threshold, and form reference
 
 1. Download the files in this folder
 2. Check the rates against Receita Federal do Brasil's website
-3. Email your corrections to **info@openaaccountants.com** — Word doc, Excel, PDF, tracked changes, whatever works
+3. Email your corrections to **info@openaccountants.com** — Word doc, Excel, PDF, tracked changes, whatever works
 
 We'll update the skill and credit you publicly as the verified reviewer at [openaccountants.com](https://openaccountants.com).
 
@@ -76,4 +76,4 @@ Or if you're comfortable with GitHub: fork the repo, fix the source file under `
 
 *OpenAccountants — open-source accounting skills for AI*
 *134 countries + 51 US states — [openaccountants.com](https://openaccountants.com)*
-*info@openaaccountants.com*
+*info@openaccountants.com*

--- a/packages/brunei/README.md
+++ b/packages/brunei/README.md
@@ -42,7 +42,7 @@ These Brunei tax skills need your eye. Every rate, threshold, and form reference
 
 1. Download the files in this folder
 2. Check the rates against your national tax authority's website
-3. Email your corrections to **info@openaaccountants.com** — Word doc, Excel, PDF, tracked changes, whatever works
+3. Email your corrections to **info@openaccountants.com** — Word doc, Excel, PDF, tracked changes, whatever works
 
 We'll update the skill and credit you publicly as the verified reviewer at [openaccountants.com](https://openaccountants.com).
 
@@ -54,4 +54,4 @@ Or if you're comfortable with GitHub: fork the repo, fix the source file under `
 
 *OpenAccountants — open-source accounting skills for AI*
 *134 countries + 51 US states — [openaccountants.com](https://openaccountants.com)*
-*info@openaaccountants.com*
+*info@openaccountants.com*

--- a/packages/bulgaria/README.md
+++ b/packages/bulgaria/README.md
@@ -43,7 +43,7 @@ These Bulgaria tax skills need your eye. Every rate, threshold, and form referen
 
 1. Download the files in this folder
 2. Check the rates against your national tax authority's website
-3. Email your corrections to **info@openaaccountants.com** — Word doc, Excel, PDF, tracked changes, whatever works
+3. Email your corrections to **info@openaccountants.com** — Word doc, Excel, PDF, tracked changes, whatever works
 
 We'll update the skill and credit you publicly as the verified reviewer at [openaccountants.com](https://openaccountants.com).
 
@@ -55,4 +55,4 @@ Or if you're comfortable with GitHub: fork the repo, fix the source file under `
 
 *OpenAccountants — open-source accounting skills for AI*
 *134 countries + 51 US states — [openaccountants.com](https://openaccountants.com)*
-*info@openaaccountants.com*
+*info@openaccountants.com*

--- a/packages/bvi/README.md
+++ b/packages/bvi/README.md
@@ -42,7 +42,7 @@ These BVI tax skills need your eye. Every rate, threshold, and form reference wa
 
 1. Download the files in this folder
 2. Check the rates against your national tax authority's website
-3. Email your corrections to **info@openaaccountants.com** — Word doc, Excel, PDF, tracked changes, whatever works
+3. Email your corrections to **info@openaccountants.com** — Word doc, Excel, PDF, tracked changes, whatever works
 
 We'll update the skill and credit you publicly as the verified reviewer at [openaccountants.com](https://openaccountants.com).
 
@@ -54,4 +54,4 @@ Or if you're comfortable with GitHub: fork the repo, fix the source file under `
 
 *OpenAccountants — open-source accounting skills for AI*
 *134 countries + 51 US states — [openaccountants.com](https://openaccountants.com)*
-*info@openaaccountants.com*
+*info@openaccountants.com*

--- a/packages/cambodia/README.md
+++ b/packages/cambodia/README.md
@@ -42,7 +42,7 @@ These Cambodia tax skills need your eye. Every rate, threshold, and form referen
 
 1. Download the files in this folder
 2. Check the rates against your national tax authority's website
-3. Email your corrections to **info@openaaccountants.com** — Word doc, Excel, PDF, tracked changes, whatever works
+3. Email your corrections to **info@openaccountants.com** — Word doc, Excel, PDF, tracked changes, whatever works
 
 We'll update the skill and credit you publicly as the verified reviewer at [openaccountants.com](https://openaccountants.com).
 
@@ -54,4 +54,4 @@ Or if you're comfortable with GitHub: fork the repo, fix the source file under `
 
 *OpenAccountants — open-source accounting skills for AI*
 *134 countries + 51 US states — [openaccountants.com](https://openaccountants.com)*
-*info@openaaccountants.com*
+*info@openaccountants.com*

--- a/packages/cameroon/README.md
+++ b/packages/cameroon/README.md
@@ -42,7 +42,7 @@ These Cameroon tax skills need your eye. Every rate, threshold, and form referen
 
 1. Download the files in this folder
 2. Check the rates against your national tax authority's website
-3. Email your corrections to **info@openaaccountants.com** — Word doc, Excel, PDF, tracked changes, whatever works
+3. Email your corrections to **info@openaccountants.com** — Word doc, Excel, PDF, tracked changes, whatever works
 
 We'll update the skill and credit you publicly as the verified reviewer at [openaccountants.com](https://openaccountants.com).
 
@@ -54,4 +54,4 @@ Or if you're comfortable with GitHub: fork the repo, fix the source file under `
 
 *OpenAccountants — open-source accounting skills for AI*
 *134 countries + 51 US states — [openaccountants.com](https://openaccountants.com)*
-*info@openaaccountants.com*
+*info@openaccountants.com*

--- a/packages/canada/README.md
+++ b/packages/canada/README.md
@@ -67,7 +67,7 @@ These Ontario tax skills need your eye. Every rate, threshold, and form referenc
 
 1. Download the files in this folder
 2. Check the rates against the CRA and your provincial/territorial finance department
-3. Email your corrections to **info@openaaccountants.com** — Word doc, Excel, PDF, tracked changes, whatever works
+3. Email your corrections to **info@openaccountants.com** — Word doc, Excel, PDF, tracked changes, whatever works
 
 We'll update the skill and credit you publicly as the verified reviewer at [openaccountants.com](https://openaccountants.com).
 
@@ -79,4 +79,4 @@ Or if you're comfortable with GitHub: fork the repo, fix the source under `skill
 
 *OpenAccountants — open-source accounting skills for AI*
 *134 countries + 51 US states + 13 Canadian provinces/territories — [openaccountants.com](https://openaccountants.com)*
-*info@openaaccountants.com*
+*info@openaccountants.com*

--- a/packages/cayman-islands/README.md
+++ b/packages/cayman-islands/README.md
@@ -42,7 +42,7 @@ These Cayman Islands tax skills need your eye. Every rate, threshold, and form r
 
 1. Download the files in this folder
 2. Check the rates against your national tax authority's website
-3. Email your corrections to **info@openaaccountants.com** — Word doc, Excel, PDF, tracked changes, whatever works
+3. Email your corrections to **info@openaccountants.com** — Word doc, Excel, PDF, tracked changes, whatever works
 
 We'll update the skill and credit you publicly as the verified reviewer at [openaccountants.com](https://openaccountants.com).
 
@@ -54,4 +54,4 @@ Or if you're comfortable with GitHub: fork the repo, fix the source file under `
 
 *OpenAccountants — open-source accounting skills for AI*
 *134 countries + 51 US states — [openaccountants.com](https://openaccountants.com)*
-*info@openaaccountants.com*
+*info@openaccountants.com*

--- a/packages/chile/README.md
+++ b/packages/chile/README.md
@@ -52,7 +52,7 @@ These Chile tax skills need your eye. Every rate, threshold, and form reference 
 
 1. Download the files in this folder
 2. Check the rates against Servicio de Impuestos Internos (SII)'s website
-3. Email your corrections to **info@openaaccountants.com** — Word doc, Excel, PDF, tracked changes, whatever works
+3. Email your corrections to **info@openaccountants.com** — Word doc, Excel, PDF, tracked changes, whatever works
 
 We'll update the skill and credit you publicly as the verified reviewer at [openaccountants.com](https://openaccountants.com).
 
@@ -64,4 +64,4 @@ Or if you're comfortable with GitHub: fork the repo, fix the source file under `
 
 *OpenAccountants — open-source accounting skills for AI*
 *134 countries + 51 US states — [openaccountants.com](https://openaccountants.com)*
-*info@openaaccountants.com*
+*info@openaccountants.com*

--- a/packages/china/README.md
+++ b/packages/china/README.md
@@ -50,7 +50,7 @@ These China tax skills need your eye. Every rate, threshold, and form reference 
 
 1. Download the files in this folder
 2. Check the rates against State Taxation Administration (国家税务总局)'s website
-3. Email your corrections to **info@openaaccountants.com** — Word doc, Excel, PDF, tracked changes, whatever works
+3. Email your corrections to **info@openaccountants.com** — Word doc, Excel, PDF, tracked changes, whatever works
 
 We'll update the skill and credit you publicly as the verified reviewer at [openaccountants.com](https://openaccountants.com).
 
@@ -62,4 +62,4 @@ Or if you're comfortable with GitHub: fork the repo, fix the source file under `
 
 *OpenAccountants — open-source accounting skills for AI*
 *134 countries + 51 US states — [openaccountants.com](https://openaccountants.com)*
-*info@openaaccountants.com*
+*info@openaccountants.com*

--- a/packages/colombia/README.md
+++ b/packages/colombia/README.md
@@ -51,7 +51,7 @@ These Colombia tax skills need your eye. Every rate, threshold, and form referen
 
 1. Download the files in this folder
 2. Check the rates against DIAN (Dirección de Impuestos y Aduanas Nacionales)'s website
-3. Email your corrections to **info@openaaccountants.com** — Word doc, Excel, PDF, tracked changes, whatever works
+3. Email your corrections to **info@openaccountants.com** — Word doc, Excel, PDF, tracked changes, whatever works
 
 We'll update the skill and credit you publicly as the verified reviewer at [openaccountants.com](https://openaccountants.com).
 
@@ -63,4 +63,4 @@ Or if you're comfortable with GitHub: fork the repo, fix the source file under `
 
 *OpenAccountants — open-source accounting skills for AI*
 *134 countries + 51 US states — [openaccountants.com](https://openaccountants.com)*
-*info@openaaccountants.com*
+*info@openaccountants.com*

--- a/packages/costa-rica/README.md
+++ b/packages/costa-rica/README.md
@@ -42,7 +42,7 @@ These Costa Rica tax skills need your eye. Every rate, threshold, and form refer
 
 1. Download the files in this folder
 2. Check the rates against your national tax authority's website
-3. Email your corrections to **info@openaaccountants.com** — Word doc, Excel, PDF, tracked changes, whatever works
+3. Email your corrections to **info@openaccountants.com** — Word doc, Excel, PDF, tracked changes, whatever works
 
 We'll update the skill and credit you publicly as the verified reviewer at [openaccountants.com](https://openaccountants.com).
 
@@ -54,4 +54,4 @@ Or if you're comfortable with GitHub: fork the repo, fix the source file under `
 
 *OpenAccountants — open-source accounting skills for AI*
 *134 countries + 51 US states — [openaccountants.com](https://openaccountants.com)*
-*info@openaaccountants.com*
+*info@openaccountants.com*

--- a/packages/croatia/README.md
+++ b/packages/croatia/README.md
@@ -43,7 +43,7 @@ These Croatia tax skills need your eye. Every rate, threshold, and form referenc
 
 1. Download the files in this folder
 2. Check the rates against your national tax authority's website
-3. Email your corrections to **info@openaaccountants.com** — Word doc, Excel, PDF, tracked changes, whatever works
+3. Email your corrections to **info@openaccountants.com** — Word doc, Excel, PDF, tracked changes, whatever works
 
 We'll update the skill and credit you publicly as the verified reviewer at [openaccountants.com](https://openaccountants.com).
 
@@ -55,4 +55,4 @@ Or if you're comfortable with GitHub: fork the repo, fix the source file under `
 
 *OpenAccountants — open-source accounting skills for AI*
 *134 countries + 51 US states — [openaccountants.com](https://openaccountants.com)*
-*info@openaaccountants.com*
+*info@openaccountants.com*

--- a/packages/cyprus/README.md
+++ b/packages/cyprus/README.md
@@ -43,7 +43,7 @@ These Cyprus tax skills need your eye. Every rate, threshold, and form reference
 
 1. Download the files in this folder
 2. Check the rates against your national tax authority's website
-3. Email your corrections to **info@openaaccountants.com** — Word doc, Excel, PDF, tracked changes, whatever works
+3. Email your corrections to **info@openaccountants.com** — Word doc, Excel, PDF, tracked changes, whatever works
 
 We'll update the skill and credit you publicly as the verified reviewer at [openaccountants.com](https://openaccountants.com).
 
@@ -55,4 +55,4 @@ Or if you're comfortable with GitHub: fork the repo, fix the source file under `
 
 *OpenAccountants — open-source accounting skills for AI*
 *134 countries + 51 US states — [openaccountants.com](https://openaccountants.com)*
-*info@openaaccountants.com*
+*info@openaccountants.com*

--- a/packages/czech-republic/README.md
+++ b/packages/czech-republic/README.md
@@ -52,7 +52,7 @@ These Czech Republic tax skills need your eye. Every rate, threshold, and form r
 
 1. Download the files in this folder
 2. Check the rates against Finanční správa České republiky's website
-3. Email your corrections to **info@openaaccountants.com** — Word doc, Excel, PDF, tracked changes, whatever works
+3. Email your corrections to **info@openaccountants.com** — Word doc, Excel, PDF, tracked changes, whatever works
 
 We'll update the skill and credit you publicly as the verified reviewer at [openaccountants.com](https://openaccountants.com).
 
@@ -64,4 +64,4 @@ Or if you're comfortable with GitHub: fork the repo, fix the source file under `
 
 *OpenAccountants — open-source accounting skills for AI*
 *134 countries + 51 US states — [openaccountants.com](https://openaccountants.com)*
-*info@openaaccountants.com*
+*info@openaccountants.com*

--- a/packages/denmark/README.md
+++ b/packages/denmark/README.md
@@ -51,7 +51,7 @@ These Denmark tax skills need your eye. Every rate, threshold, and form referenc
 
 1. Download the files in this folder
 2. Check the rates against Skattestyrelsen's website
-3. Email your corrections to **info@openaaccountants.com** — Word doc, Excel, PDF, tracked changes, whatever works
+3. Email your corrections to **info@openaccountants.com** — Word doc, Excel, PDF, tracked changes, whatever works
 
 We'll update the skill and credit you publicly as the verified reviewer at [openaccountants.com](https://openaccountants.com).
 
@@ -63,4 +63,4 @@ Or if you're comfortable with GitHub: fork the repo, fix the source file under `
 
 *OpenAccountants — open-source accounting skills for AI*
 *134 countries + 51 US states — [openaccountants.com](https://openaccountants.com)*
-*info@openaaccountants.com*
+*info@openaccountants.com*

--- a/packages/dominican-republic/README.md
+++ b/packages/dominican-republic/README.md
@@ -42,7 +42,7 @@ These Dominican Republic tax skills need your eye. Every rate, threshold, and fo
 
 1. Download the files in this folder
 2. Check the rates against your national tax authority's website
-3. Email your corrections to **info@openaaccountants.com** — Word doc, Excel, PDF, tracked changes, whatever works
+3. Email your corrections to **info@openaccountants.com** — Word doc, Excel, PDF, tracked changes, whatever works
 
 We'll update the skill and credit you publicly as the verified reviewer at [openaccountants.com](https://openaccountants.com).
 
@@ -54,4 +54,4 @@ Or if you're comfortable with GitHub: fork the repo, fix the source file under `
 
 *OpenAccountants — open-source accounting skills for AI*
 *134 countries + 51 US states — [openaccountants.com](https://openaccountants.com)*
-*info@openaaccountants.com*
+*info@openaccountants.com*

--- a/packages/ecuador/README.md
+++ b/packages/ecuador/README.md
@@ -42,7 +42,7 @@ These Ecuador tax skills need your eye. Every rate, threshold, and form referenc
 
 1. Download the files in this folder
 2. Check the rates against your national tax authority's website
-3. Email your corrections to **info@openaaccountants.com** — Word doc, Excel, PDF, tracked changes, whatever works
+3. Email your corrections to **info@openaccountants.com** — Word doc, Excel, PDF, tracked changes, whatever works
 
 We'll update the skill and credit you publicly as the verified reviewer at [openaccountants.com](https://openaccountants.com).
 
@@ -54,4 +54,4 @@ Or if you're comfortable with GitHub: fork the repo, fix the source file under `
 
 *OpenAccountants — open-source accounting skills for AI*
 *134 countries + 51 US states — [openaccountants.com](https://openaccountants.com)*
-*info@openaaccountants.com*
+*info@openaccountants.com*

--- a/packages/egypt/README.md
+++ b/packages/egypt/README.md
@@ -42,7 +42,7 @@ These Egypt tax skills need your eye. Every rate, threshold, and form reference 
 
 1. Download the files in this folder
 2. Check the rates against your national tax authority's website
-3. Email your corrections to **info@openaaccountants.com** — Word doc, Excel, PDF, tracked changes, whatever works
+3. Email your corrections to **info@openaccountants.com** — Word doc, Excel, PDF, tracked changes, whatever works
 
 We'll update the skill and credit you publicly as the verified reviewer at [openaccountants.com](https://openaccountants.com).
 
@@ -54,4 +54,4 @@ Or if you're comfortable with GitHub: fork the repo, fix the source file under `
 
 *OpenAccountants — open-source accounting skills for AI*
 *134 countries + 51 US states — [openaccountants.com](https://openaccountants.com)*
-*info@openaaccountants.com*
+*info@openaccountants.com*

--- a/packages/el-salvador/README.md
+++ b/packages/el-salvador/README.md
@@ -42,7 +42,7 @@ These El Salvador tax skills need your eye. Every rate, threshold, and form refe
 
 1. Download the files in this folder
 2. Check the rates against your national tax authority's website
-3. Email your corrections to **info@openaaccountants.com** — Word doc, Excel, PDF, tracked changes, whatever works
+3. Email your corrections to **info@openaccountants.com** — Word doc, Excel, PDF, tracked changes, whatever works
 
 We'll update the skill and credit you publicly as the verified reviewer at [openaccountants.com](https://openaccountants.com).
 
@@ -54,4 +54,4 @@ Or if you're comfortable with GitHub: fork the repo, fix the source file under `
 
 *OpenAccountants — open-source accounting skills for AI*
 *134 countries + 51 US states — [openaccountants.com](https://openaccountants.com)*
-*info@openaaccountants.com*
+*info@openaccountants.com*

--- a/packages/estonia/README.md
+++ b/packages/estonia/README.md
@@ -43,7 +43,7 @@ These Estonia tax skills need your eye. Every rate, threshold, and form referenc
 
 1. Download the files in this folder
 2. Check the rates against your national tax authority's website
-3. Email your corrections to **info@openaaccountants.com** — Word doc, Excel, PDF, tracked changes, whatever works
+3. Email your corrections to **info@openaccountants.com** — Word doc, Excel, PDF, tracked changes, whatever works
 
 We'll update the skill and credit you publicly as the verified reviewer at [openaccountants.com](https://openaccountants.com).
 
@@ -55,4 +55,4 @@ Or if you're comfortable with GitHub: fork the repo, fix the source file under `
 
 *OpenAccountants — open-source accounting skills for AI*
 *134 countries + 51 US states — [openaccountants.com](https://openaccountants.com)*
-*info@openaaccountants.com*
+*info@openaccountants.com*

--- a/packages/ethiopia/README.md
+++ b/packages/ethiopia/README.md
@@ -42,7 +42,7 @@ These Ethiopia tax skills need your eye. Every rate, threshold, and form referen
 
 1. Download the files in this folder
 2. Check the rates against your national tax authority's website
-3. Email your corrections to **info@openaaccountants.com** — Word doc, Excel, PDF, tracked changes, whatever works
+3. Email your corrections to **info@openaccountants.com** — Word doc, Excel, PDF, tracked changes, whatever works
 
 We'll update the skill and credit you publicly as the verified reviewer at [openaccountants.com](https://openaccountants.com).
 
@@ -54,4 +54,4 @@ Or if you're comfortable with GitHub: fork the repo, fix the source file under `
 
 *OpenAccountants — open-source accounting skills for AI*
 *134 countries + 51 US states — [openaccountants.com](https://openaccountants.com)*
-*info@openaaccountants.com*
+*info@openaccountants.com*

--- a/packages/fiji/README.md
+++ b/packages/fiji/README.md
@@ -42,7 +42,7 @@ These Fiji tax skills need your eye. Every rate, threshold, and form reference w
 
 1. Download the files in this folder
 2. Check the rates against your national tax authority's website
-3. Email your corrections to **info@openaaccountants.com** — Word doc, Excel, PDF, tracked changes, whatever works
+3. Email your corrections to **info@openaccountants.com** — Word doc, Excel, PDF, tracked changes, whatever works
 
 We'll update the skill and credit you publicly as the verified reviewer at [openaccountants.com](https://openaccountants.com).
 
@@ -54,4 +54,4 @@ Or if you're comfortable with GitHub: fork the repo, fix the source file under `
 
 *OpenAccountants — open-source accounting skills for AI*
 *134 countries + 51 US states — [openaccountants.com](https://openaccountants.com)*
-*info@openaaccountants.com*
+*info@openaccountants.com*

--- a/packages/finland/README.md
+++ b/packages/finland/README.md
@@ -52,7 +52,7 @@ These Finland tax skills need your eye. Every rate, threshold, and form referenc
 
 1. Download the files in this folder
 2. Check the rates against Verohallinto's website
-3. Email your corrections to **info@openaaccountants.com** — Word doc, Excel, PDF, tracked changes, whatever works
+3. Email your corrections to **info@openaccountants.com** — Word doc, Excel, PDF, tracked changes, whatever works
 
 We'll update the skill and credit you publicly as the verified reviewer at [openaccountants.com](https://openaccountants.com).
 
@@ -64,4 +64,4 @@ Or if you're comfortable with GitHub: fork the repo, fix the source file under `
 
 *OpenAccountants — open-source accounting skills for AI*
 *134 countries + 51 US states — [openaccountants.com](https://openaccountants.com)*
-*info@openaaccountants.com*
+*info@openaccountants.com*

--- a/packages/france/README.md
+++ b/packages/france/README.md
@@ -75,7 +75,7 @@ These France tax skills need your eye. Every rate, threshold, and form reference
 
 1. Download the files in this folder
 2. Check the rates against Direction générale des Finances publiques (DGFiP)'s website
-3. Email your corrections to **info@openaaccountants.com** — Word doc, Excel, PDF, tracked changes, whatever works
+3. Email your corrections to **info@openaccountants.com** — Word doc, Excel, PDF, tracked changes, whatever works
 
 We'll update the skill and credit you publicly as the verified reviewer at [openaccountants.com](https://openaccountants.com).
 
@@ -87,4 +87,4 @@ Or if you're comfortable with GitHub: fork the repo, fix the source file under `
 
 *OpenAccountants — open-source accounting skills for AI*
 *134 countries + 51 US states — [openaccountants.com](https://openaccountants.com)*
-*info@openaaccountants.com*
+*info@openaccountants.com*

--- a/packages/georgia/README.md
+++ b/packages/georgia/README.md
@@ -42,7 +42,7 @@ These Georgia tax skills need your eye. Every rate, threshold, and form referenc
 
 1. Download the files in this folder
 2. Check the rates against your national tax authority's website
-3. Email your corrections to **info@openaaccountants.com** — Word doc, Excel, PDF, tracked changes, whatever works
+3. Email your corrections to **info@openaccountants.com** — Word doc, Excel, PDF, tracked changes, whatever works
 
 We'll update the skill and credit you publicly as the verified reviewer at [openaccountants.com](https://openaccountants.com).
 
@@ -54,4 +54,4 @@ Or if you're comfortable with GitHub: fork the repo, fix the source file under `
 
 *OpenAccountants — open-source accounting skills for AI*
 *134 countries + 51 US states — [openaccountants.com](https://openaccountants.com)*
-*info@openaaccountants.com*
+*info@openaccountants.com*

--- a/packages/germany/README.md
+++ b/packages/germany/README.md
@@ -73,7 +73,7 @@ These Germany tax skills need your eye. Every rate, threshold, and form referenc
 
 1. Download the files in this folder
 2. Check the rates against Finanzamt / Bundeszentralamt für Steuern's website
-3. Email your corrections to **info@openaaccountants.com** — Word doc, Excel, PDF, tracked changes, whatever works
+3. Email your corrections to **info@openaccountants.com** — Word doc, Excel, PDF, tracked changes, whatever works
 
 We'll update the skill and credit you publicly as the verified reviewer at [openaccountants.com](https://openaccountants.com).
 
@@ -85,4 +85,4 @@ Or if you're comfortable with GitHub: fork the repo, fix the source file under `
 
 *OpenAccountants — open-source accounting skills for AI*
 *134 countries + 51 US states — [openaccountants.com](https://openaccountants.com)*
-*info@openaaccountants.com*
+*info@openaccountants.com*

--- a/packages/ghana/README.md
+++ b/packages/ghana/README.md
@@ -44,7 +44,7 @@ These Ghana tax skills need your eye. Every rate, threshold, and form reference 
 
 1. Download the files in this folder
 2. Check the rates against your national tax authority's website
-3. Email your corrections to **info@openaaccountants.com** — Word doc, Excel, PDF, tracked changes, whatever works
+3. Email your corrections to **info@openaccountants.com** — Word doc, Excel, PDF, tracked changes, whatever works
 
 We'll update the skill and credit you publicly as the verified reviewer at [openaccountants.com](https://openaccountants.com).
 
@@ -56,4 +56,4 @@ Or if you're comfortable with GitHub: fork the repo, fix the source file under `
 
 *OpenAccountants — open-source accounting skills for AI*
 *134 countries + 51 US states — [openaccountants.com](https://openaccountants.com)*
-*info@openaaccountants.com*
+*info@openaccountants.com*

--- a/packages/greece/README.md
+++ b/packages/greece/README.md
@@ -53,7 +53,7 @@ These Greece tax skills need your eye. Every rate, threshold, and form reference
 
 1. Download the files in this folder
 2. Check the rates against AADE (Ανεξάρτητη Αρχή Δημοσίων Εσόδων)'s website
-3. Email your corrections to **info@openaaccountants.com** — Word doc, Excel, PDF, tracked changes, whatever works
+3. Email your corrections to **info@openaccountants.com** — Word doc, Excel, PDF, tracked changes, whatever works
 
 We'll update the skill and credit you publicly as the verified reviewer at [openaccountants.com](https://openaccountants.com).
 
@@ -65,4 +65,4 @@ Or if you're comfortable with GitHub: fork the repo, fix the source file under `
 
 *OpenAccountants — open-source accounting skills for AI*
 *134 countries + 51 US states — [openaccountants.com](https://openaccountants.com)*
-*info@openaaccountants.com*
+*info@openaccountants.com*

--- a/packages/guatemala/README.md
+++ b/packages/guatemala/README.md
@@ -42,7 +42,7 @@ These Guatemala tax skills need your eye. Every rate, threshold, and form refere
 
 1. Download the files in this folder
 2. Check the rates against your national tax authority's website
-3. Email your corrections to **info@openaaccountants.com** — Word doc, Excel, PDF, tracked changes, whatever works
+3. Email your corrections to **info@openaccountants.com** — Word doc, Excel, PDF, tracked changes, whatever works
 
 We'll update the skill and credit you publicly as the verified reviewer at [openaccountants.com](https://openaccountants.com).
 
@@ -54,4 +54,4 @@ Or if you're comfortable with GitHub: fork the repo, fix the source file under `
 
 *OpenAccountants — open-source accounting skills for AI*
 *134 countries + 51 US states — [openaccountants.com](https://openaccountants.com)*
-*info@openaaccountants.com*
+*info@openaccountants.com*

--- a/packages/honduras/README.md
+++ b/packages/honduras/README.md
@@ -42,7 +42,7 @@ These Honduras tax skills need your eye. Every rate, threshold, and form referen
 
 1. Download the files in this folder
 2. Check the rates against your national tax authority's website
-3. Email your corrections to **info@openaaccountants.com** — Word doc, Excel, PDF, tracked changes, whatever works
+3. Email your corrections to **info@openaccountants.com** — Word doc, Excel, PDF, tracked changes, whatever works
 
 We'll update the skill and credit you publicly as the verified reviewer at [openaccountants.com](https://openaccountants.com).
 
@@ -54,4 +54,4 @@ Or if you're comfortable with GitHub: fork the repo, fix the source file under `
 
 *OpenAccountants — open-source accounting skills for AI*
 *134 countries + 51 US states — [openaccountants.com](https://openaccountants.com)*
-*info@openaaccountants.com*
+*info@openaccountants.com*

--- a/packages/hong-kong/README.md
+++ b/packages/hong-kong/README.md
@@ -50,7 +50,7 @@ These Hong Kong tax skills need your eye. Every rate, threshold, and form refere
 
 1. Download the files in this folder
 2. Check the rates against Inland Revenue Department (IRD)'s website
-3. Email your corrections to **info@openaaccountants.com** — Word doc, Excel, PDF, tracked changes, whatever works
+3. Email your corrections to **info@openaccountants.com** — Word doc, Excel, PDF, tracked changes, whatever works
 
 We'll update the skill and credit you publicly as the verified reviewer at [openaccountants.com](https://openaccountants.com).
 
@@ -62,4 +62,4 @@ Or if you're comfortable with GitHub: fork the repo, fix the source file under `
 
 *OpenAccountants — open-source accounting skills for AI*
 *134 countries + 51 US states — [openaccountants.com](https://openaccountants.com)*
-*info@openaaccountants.com*
+*info@openaccountants.com*

--- a/packages/hungary/README.md
+++ b/packages/hungary/README.md
@@ -53,7 +53,7 @@ These Hungary tax skills need your eye. Every rate, threshold, and form referenc
 
 1. Download the files in this folder
 2. Check the rates against Nemzeti Adó- és Vámhivatal (NAV)'s website
-3. Email your corrections to **info@openaaccountants.com** — Word doc, Excel, PDF, tracked changes, whatever works
+3. Email your corrections to **info@openaccountants.com** — Word doc, Excel, PDF, tracked changes, whatever works
 
 We'll update the skill and credit you publicly as the verified reviewer at [openaccountants.com](https://openaccountants.com).
 
@@ -65,4 +65,4 @@ Or if you're comfortable with GitHub: fork the repo, fix the source file under `
 
 *OpenAccountants — open-source accounting skills for AI*
 *134 countries + 51 US states — [openaccountants.com](https://openaccountants.com)*
-*info@openaaccountants.com*
+*info@openaccountants.com*

--- a/packages/iceland/README.md
+++ b/packages/iceland/README.md
@@ -42,7 +42,7 @@ These Iceland tax skills need your eye. Every rate, threshold, and form referenc
 
 1. Download the files in this folder
 2. Check the rates against your national tax authority's website
-3. Email your corrections to **info@openaaccountants.com** — Word doc, Excel, PDF, tracked changes, whatever works
+3. Email your corrections to **info@openaccountants.com** — Word doc, Excel, PDF, tracked changes, whatever works
 
 We'll update the skill and credit you publicly as the verified reviewer at [openaccountants.com](https://openaccountants.com).
 
@@ -54,4 +54,4 @@ Or if you're comfortable with GitHub: fork the repo, fix the source file under `
 
 *OpenAccountants — open-source accounting skills for AI*
 *134 countries + 51 US states — [openaccountants.com](https://openaccountants.com)*
-*info@openaaccountants.com*
+*info@openaccountants.com*

--- a/packages/india/README.md
+++ b/packages/india/README.md
@@ -69,7 +69,7 @@ These India tax skills need your eye. Every rate, threshold, and form reference 
 
 1. Download the files in this folder
 2. Check the rates against Income Tax Department / CBDT / GSTN's website
-3. Email your corrections to **info@openaaccountants.com** — Word doc, Excel, PDF, tracked changes, whatever works
+3. Email your corrections to **info@openaccountants.com** — Word doc, Excel, PDF, tracked changes, whatever works
 
 We'll update the skill and credit you publicly as the verified reviewer at [openaccountants.com](https://openaccountants.com).
 
@@ -81,4 +81,4 @@ Or if you're comfortable with GitHub: fork the repo, fix the source file under `
 
 *OpenAccountants — open-source accounting skills for AI*
 *134 countries + 51 US states — [openaccountants.com](https://openaccountants.com)*
-*info@openaaccountants.com*
+*info@openaccountants.com*

--- a/packages/indonesia/README.md
+++ b/packages/indonesia/README.md
@@ -51,7 +51,7 @@ These Indonesia tax skills need your eye. Every rate, threshold, and form refere
 
 1. Download the files in this folder
 2. Check the rates against Direktorat Jenderal Pajak (DJP)'s website
-3. Email your corrections to **info@openaaccountants.com** — Word doc, Excel, PDF, tracked changes, whatever works
+3. Email your corrections to **info@openaccountants.com** — Word doc, Excel, PDF, tracked changes, whatever works
 
 We'll update the skill and credit you publicly as the verified reviewer at [openaccountants.com](https://openaccountants.com).
 
@@ -63,4 +63,4 @@ Or if you're comfortable with GitHub: fork the repo, fix the source file under `
 
 *OpenAccountants — open-source accounting skills for AI*
 *134 countries + 51 US states — [openaccountants.com](https://openaccountants.com)*
-*info@openaaccountants.com*
+*info@openaccountants.com*

--- a/packages/iran/README.md
+++ b/packages/iran/README.md
@@ -42,7 +42,7 @@ These Iran tax skills need your eye. Every rate, threshold, and form reference w
 
 1. Download the files in this folder
 2. Check the rates against your national tax authority's website
-3. Email your corrections to **info@openaaccountants.com** — Word doc, Excel, PDF, tracked changes, whatever works
+3. Email your corrections to **info@openaccountants.com** — Word doc, Excel, PDF, tracked changes, whatever works
 
 We'll update the skill and credit you publicly as the verified reviewer at [openaccountants.com](https://openaccountants.com).
 
@@ -54,4 +54,4 @@ Or if you're comfortable with GitHub: fork the repo, fix the source file under `
 
 *OpenAccountants — open-source accounting skills for AI*
 *134 countries + 51 US states — [openaccountants.com](https://openaccountants.com)*
-*info@openaaccountants.com*
+*info@openaccountants.com*

--- a/packages/iraq/README.md
+++ b/packages/iraq/README.md
@@ -42,7 +42,7 @@ These Iraq tax skills need your eye. Every rate, threshold, and form reference w
 
 1. Download the files in this folder
 2. Check the rates against your national tax authority's website
-3. Email your corrections to **info@openaaccountants.com** — Word doc, Excel, PDF, tracked changes, whatever works
+3. Email your corrections to **info@openaccountants.com** — Word doc, Excel, PDF, tracked changes, whatever works
 
 We'll update the skill and credit you publicly as the verified reviewer at [openaccountants.com](https://openaccountants.com).
 
@@ -54,4 +54,4 @@ Or if you're comfortable with GitHub: fork the repo, fix the source file under `
 
 *OpenAccountants — open-source accounting skills for AI*
 *134 countries + 51 US states — [openaccountants.com](https://openaccountants.com)*
-*info@openaaccountants.com*
+*info@openaccountants.com*

--- a/packages/ireland/README.md
+++ b/packages/ireland/README.md
@@ -53,7 +53,7 @@ These Ireland tax skills need your eye. Every rate, threshold, and form referenc
 
 1. Download the files in this folder
 2. Check the rates against Revenue Commissioners's website
-3. Email your corrections to **info@openaaccountants.com** — Word doc, Excel, PDF, tracked changes, whatever works
+3. Email your corrections to **info@openaccountants.com** — Word doc, Excel, PDF, tracked changes, whatever works
 
 We'll update the skill and credit you publicly as the verified reviewer at [openaccountants.com](https://openaccountants.com).
 
@@ -65,4 +65,4 @@ Or if you're comfortable with GitHub: fork the repo, fix the source file under `
 
 *OpenAccountants — open-source accounting skills for AI*
 *134 countries + 51 US states — [openaccountants.com](https://openaccountants.com)*
-*info@openaaccountants.com*
+*info@openaccountants.com*

--- a/packages/isle-of-man/README.md
+++ b/packages/isle-of-man/README.md
@@ -42,7 +42,7 @@ These Isle of Man tax skills need your eye. Every rate, threshold, and form refe
 
 1. Download the files in this folder
 2. Check the rates against your national tax authority's website
-3. Email your corrections to **info@openaaccountants.com** — Word doc, Excel, PDF, tracked changes, whatever works
+3. Email your corrections to **info@openaccountants.com** — Word doc, Excel, PDF, tracked changes, whatever works
 
 We'll update the skill and credit you publicly as the verified reviewer at [openaccountants.com](https://openaccountants.com).
 
@@ -54,4 +54,4 @@ Or if you're comfortable with GitHub: fork the repo, fix the source file under `
 
 *OpenAccountants — open-source accounting skills for AI*
 *134 countries + 51 US states — [openaccountants.com](https://openaccountants.com)*
-*info@openaaccountants.com*
+*info@openaccountants.com*

--- a/packages/israel/README.md
+++ b/packages/israel/README.md
@@ -57,7 +57,7 @@ These Israel tax skills need your eye. Every rate, threshold, and form reference
 
 1. Download the files in this folder
 2. Check the rates against Israel Tax Authority (רשות המסים)'s website
-3. Email your corrections to **info@openaaccountants.com** — Word doc, Excel, PDF, tracked changes, whatever works
+3. Email your corrections to **info@openaccountants.com** — Word doc, Excel, PDF, tracked changes, whatever works
 
 We'll update the skill and credit you publicly as the verified reviewer at [openaccountants.com](https://openaccountants.com).
 
@@ -69,4 +69,4 @@ Or if you're comfortable with GitHub: fork the repo, fix the source file under `
 
 *OpenAccountants — open-source accounting skills for AI*
 *134 countries + 51 US states — [openaccountants.com](https://openaccountants.com)*
-*info@openaaccountants.com*
+*info@openaccountants.com*

--- a/packages/italy/README.md
+++ b/packages/italy/README.md
@@ -69,7 +69,7 @@ These Italy tax skills need your eye. Every rate, threshold, and form reference 
 
 1. Download the files in this folder
 2. Check the rates against Agenzia delle Entrate's website
-3. Email your corrections to **info@openaaccountants.com** — Word doc, Excel, PDF, tracked changes, whatever works
+3. Email your corrections to **info@openaccountants.com** — Word doc, Excel, PDF, tracked changes, whatever works
 
 We'll update the skill and credit you publicly as the verified reviewer at [openaccountants.com](https://openaccountants.com).
 
@@ -81,4 +81,4 @@ Or if you're comfortable with GitHub: fork the repo, fix the source file under `
 
 *OpenAccountants — open-source accounting skills for AI*
 *134 countries + 51 US states — [openaccountants.com](https://openaccountants.com)*
-*info@openaaccountants.com*
+*info@openaccountants.com*

--- a/packages/ivory-coast/README.md
+++ b/packages/ivory-coast/README.md
@@ -42,7 +42,7 @@ These Ivory Coast tax skills need your eye. Every rate, threshold, and form refe
 
 1. Download the files in this folder
 2. Check the rates against your national tax authority's website
-3. Email your corrections to **info@openaaccountants.com** — Word doc, Excel, PDF, tracked changes, whatever works
+3. Email your corrections to **info@openaccountants.com** — Word doc, Excel, PDF, tracked changes, whatever works
 
 We'll update the skill and credit you publicly as the verified reviewer at [openaccountants.com](https://openaccountants.com).
 
@@ -54,4 +54,4 @@ Or if you're comfortable with GitHub: fork the repo, fix the source file under `
 
 *OpenAccountants — open-source accounting skills for AI*
 *134 countries + 51 US states — [openaccountants.com](https://openaccountants.com)*
-*info@openaaccountants.com*
+*info@openaccountants.com*

--- a/packages/jamaica/README.md
+++ b/packages/jamaica/README.md
@@ -42,7 +42,7 @@ These Jamaica tax skills need your eye. Every rate, threshold, and form referenc
 
 1. Download the files in this folder
 2. Check the rates against your national tax authority's website
-3. Email your corrections to **info@openaaccountants.com** — Word doc, Excel, PDF, tracked changes, whatever works
+3. Email your corrections to **info@openaccountants.com** — Word doc, Excel, PDF, tracked changes, whatever works
 
 We'll update the skill and credit you publicly as the verified reviewer at [openaccountants.com](https://openaccountants.com).
 
@@ -54,4 +54,4 @@ Or if you're comfortable with GitHub: fork the repo, fix the source file under `
 
 *OpenAccountants — open-source accounting skills for AI*
 *134 countries + 51 US states — [openaccountants.com](https://openaccountants.com)*
-*info@openaaccountants.com*
+*info@openaccountants.com*

--- a/packages/japan/README.md
+++ b/packages/japan/README.md
@@ -70,7 +70,7 @@ These Japan tax skills need your eye. Every rate, threshold, and form reference 
 
 1. Download the files in this folder
 2. Check the rates against National Tax Agency (国税庁)'s website
-3. Email your corrections to **info@openaaccountants.com** — Word doc, Excel, PDF, tracked changes, whatever works
+3. Email your corrections to **info@openaccountants.com** — Word doc, Excel, PDF, tracked changes, whatever works
 
 We'll update the skill and credit you publicly as the verified reviewer at [openaccountants.com](https://openaccountants.com).
 
@@ -82,4 +82,4 @@ Or if you're comfortable with GitHub: fork the repo, fix the source file under `
 
 *OpenAccountants — open-source accounting skills for AI*
 *134 countries + 51 US states — [openaccountants.com](https://openaccountants.com)*
-*info@openaaccountants.com*
+*info@openaccountants.com*

--- a/packages/jordan/README.md
+++ b/packages/jordan/README.md
@@ -42,7 +42,7 @@ These Jordan tax skills need your eye. Every rate, threshold, and form reference
 
 1. Download the files in this folder
 2. Check the rates against your national tax authority's website
-3. Email your corrections to **info@openaaccountants.com** — Word doc, Excel, PDF, tracked changes, whatever works
+3. Email your corrections to **info@openaccountants.com** — Word doc, Excel, PDF, tracked changes, whatever works
 
 We'll update the skill and credit you publicly as the verified reviewer at [openaccountants.com](https://openaccountants.com).
 
@@ -54,4 +54,4 @@ Or if you're comfortable with GitHub: fork the repo, fix the source file under `
 
 *OpenAccountants — open-source accounting skills for AI*
 *134 countries + 51 US states — [openaccountants.com](https://openaccountants.com)*
-*info@openaaccountants.com*
+*info@openaccountants.com*

--- a/packages/kazakhstan/README.md
+++ b/packages/kazakhstan/README.md
@@ -42,7 +42,7 @@ These Kazakhstan tax skills need your eye. Every rate, threshold, and form refer
 
 1. Download the files in this folder
 2. Check the rates against your national tax authority's website
-3. Email your corrections to **info@openaaccountants.com** — Word doc, Excel, PDF, tracked changes, whatever works
+3. Email your corrections to **info@openaccountants.com** — Word doc, Excel, PDF, tracked changes, whatever works
 
 We'll update the skill and credit you publicly as the verified reviewer at [openaccountants.com](https://openaccountants.com).
 
@@ -54,4 +54,4 @@ Or if you're comfortable with GitHub: fork the repo, fix the source file under `
 
 *OpenAccountants — open-source accounting skills for AI*
 *134 countries + 51 US states — [openaccountants.com](https://openaccountants.com)*
-*info@openaaccountants.com*
+*info@openaccountants.com*

--- a/packages/kenya/README.md
+++ b/packages/kenya/README.md
@@ -50,7 +50,7 @@ These Kenya tax skills need your eye. Every rate, threshold, and form reference 
 
 1. Download the files in this folder
 2. Check the rates against Kenya Revenue Authority (KRA)'s website
-3. Email your corrections to **info@openaaccountants.com** — Word doc, Excel, PDF, tracked changes, whatever works
+3. Email your corrections to **info@openaccountants.com** — Word doc, Excel, PDF, tracked changes, whatever works
 
 We'll update the skill and credit you publicly as the verified reviewer at [openaccountants.com](https://openaccountants.com).
 
@@ -62,4 +62,4 @@ Or if you're comfortable with GitHub: fork the repo, fix the source file under `
 
 *OpenAccountants — open-source accounting skills for AI*
 *134 countries + 51 US states — [openaccountants.com](https://openaccountants.com)*
-*info@openaaccountants.com*
+*info@openaccountants.com*

--- a/packages/kosovo/README.md
+++ b/packages/kosovo/README.md
@@ -42,7 +42,7 @@ These Kosovo tax skills need your eye. Every rate, threshold, and form reference
 
 1. Download the files in this folder
 2. Check the rates against your national tax authority's website
-3. Email your corrections to **info@openaaccountants.com** — Word doc, Excel, PDF, tracked changes, whatever works
+3. Email your corrections to **info@openaccountants.com** — Word doc, Excel, PDF, tracked changes, whatever works
 
 We'll update the skill and credit you publicly as the verified reviewer at [openaccountants.com](https://openaccountants.com).
 
@@ -54,4 +54,4 @@ Or if you're comfortable with GitHub: fork the repo, fix the source file under `
 
 *OpenAccountants — open-source accounting skills for AI*
 *134 countries + 51 US states — [openaccountants.com](https://openaccountants.com)*
-*info@openaaccountants.com*
+*info@openaccountants.com*

--- a/packages/kuwait/README.md
+++ b/packages/kuwait/README.md
@@ -42,7 +42,7 @@ These Kuwait tax skills need your eye. Every rate, threshold, and form reference
 
 1. Download the files in this folder
 2. Check the rates against your national tax authority's website
-3. Email your corrections to **info@openaaccountants.com** — Word doc, Excel, PDF, tracked changes, whatever works
+3. Email your corrections to **info@openaccountants.com** — Word doc, Excel, PDF, tracked changes, whatever works
 
 We'll update the skill and credit you publicly as the verified reviewer at [openaccountants.com](https://openaccountants.com).
 
@@ -54,4 +54,4 @@ Or if you're comfortable with GitHub: fork the repo, fix the source file under `
 
 *OpenAccountants — open-source accounting skills for AI*
 *134 countries + 51 US states — [openaccountants.com](https://openaccountants.com)*
-*info@openaaccountants.com*
+*info@openaccountants.com*

--- a/packages/laos/README.md
+++ b/packages/laos/README.md
@@ -42,7 +42,7 @@ These Laos tax skills need your eye. Every rate, threshold, and form reference w
 
 1. Download the files in this folder
 2. Check the rates against your national tax authority's website
-3. Email your corrections to **info@openaaccountants.com** — Word doc, Excel, PDF, tracked changes, whatever works
+3. Email your corrections to **info@openaccountants.com** — Word doc, Excel, PDF, tracked changes, whatever works
 
 We'll update the skill and credit you publicly as the verified reviewer at [openaccountants.com](https://openaccountants.com).
 
@@ -54,4 +54,4 @@ Or if you're comfortable with GitHub: fork the repo, fix the source file under `
 
 *OpenAccountants — open-source accounting skills for AI*
 *134 countries + 51 US states — [openaccountants.com](https://openaccountants.com)*
-*info@openaaccountants.com*
+*info@openaccountants.com*

--- a/packages/latvia/README.md
+++ b/packages/latvia/README.md
@@ -43,7 +43,7 @@ These Latvia tax skills need your eye. Every rate, threshold, and form reference
 
 1. Download the files in this folder
 2. Check the rates against your national tax authority's website
-3. Email your corrections to **info@openaaccountants.com** — Word doc, Excel, PDF, tracked changes, whatever works
+3. Email your corrections to **info@openaccountants.com** — Word doc, Excel, PDF, tracked changes, whatever works
 
 We'll update the skill and credit you publicly as the verified reviewer at [openaccountants.com](https://openaccountants.com).
 
@@ -55,4 +55,4 @@ Or if you're comfortable with GitHub: fork the repo, fix the source file under `
 
 *OpenAccountants — open-source accounting skills for AI*
 *134 countries + 51 US states — [openaccountants.com](https://openaccountants.com)*
-*info@openaaccountants.com*
+*info@openaccountants.com*

--- a/packages/lebanon/README.md
+++ b/packages/lebanon/README.md
@@ -42,7 +42,7 @@ These Lebanon tax skills need your eye. Every rate, threshold, and form referenc
 
 1. Download the files in this folder
 2. Check the rates against your national tax authority's website
-3. Email your corrections to **info@openaaccountants.com** — Word doc, Excel, PDF, tracked changes, whatever works
+3. Email your corrections to **info@openaccountants.com** — Word doc, Excel, PDF, tracked changes, whatever works
 
 We'll update the skill and credit you publicly as the verified reviewer at [openaccountants.com](https://openaccountants.com).
 
@@ -54,4 +54,4 @@ Or if you're comfortable with GitHub: fork the repo, fix the source file under `
 
 *OpenAccountants — open-source accounting skills for AI*
 *134 countries + 51 US states — [openaccountants.com](https://openaccountants.com)*
-*info@openaaccountants.com*
+*info@openaccountants.com*

--- a/packages/liechtenstein/README.md
+++ b/packages/liechtenstein/README.md
@@ -42,7 +42,7 @@ These Liechtenstein tax skills need your eye. Every rate, threshold, and form re
 
 1. Download the files in this folder
 2. Check the rates against your national tax authority's website
-3. Email your corrections to **info@openaaccountants.com** — Word doc, Excel, PDF, tracked changes, whatever works
+3. Email your corrections to **info@openaccountants.com** — Word doc, Excel, PDF, tracked changes, whatever works
 
 We'll update the skill and credit you publicly as the verified reviewer at [openaccountants.com](https://openaccountants.com).
 
@@ -54,4 +54,4 @@ Or if you're comfortable with GitHub: fork the repo, fix the source file under `
 
 *OpenAccountants — open-source accounting skills for AI*
 *134 countries + 51 US states — [openaccountants.com](https://openaccountants.com)*
-*info@openaaccountants.com*
+*info@openaccountants.com*

--- a/packages/lithuania/README.md
+++ b/packages/lithuania/README.md
@@ -45,7 +45,7 @@ These Lithuania tax skills need your eye. Every rate, threshold, and form refere
 
 1. Download the files in this folder
 2. Check the rates against your national tax authority's website
-3. Email your corrections to **info@openaaccountants.com** — Word doc, Excel, PDF, tracked changes, whatever works
+3. Email your corrections to **info@openaccountants.com** — Word doc, Excel, PDF, tracked changes, whatever works
 
 We'll update the skill and credit you publicly as the verified reviewer at [openaccountants.com](https://openaccountants.com).
 
@@ -57,4 +57,4 @@ Or if you're comfortable with GitHub: fork the repo, fix the source file under `
 
 *OpenAccountants — open-source accounting skills for AI*
 *134 countries + 51 US states — [openaccountants.com](https://openaccountants.com)*
-*info@openaaccountants.com*
+*info@openaccountants.com*

--- a/packages/luxembourg/README.md
+++ b/packages/luxembourg/README.md
@@ -43,7 +43,7 @@ These Luxembourg tax skills need your eye. Every rate, threshold, and form refer
 
 1. Download the files in this folder
 2. Check the rates against your national tax authority's website
-3. Email your corrections to **info@openaaccountants.com** — Word doc, Excel, PDF, tracked changes, whatever works
+3. Email your corrections to **info@openaccountants.com** — Word doc, Excel, PDF, tracked changes, whatever works
 
 We'll update the skill and credit you publicly as the verified reviewer at [openaccountants.com](https://openaccountants.com).
 
@@ -55,4 +55,4 @@ Or if you're comfortable with GitHub: fork the repo, fix the source file under `
 
 *OpenAccountants — open-source accounting skills for AI*
 *134 countries + 51 US states — [openaccountants.com](https://openaccountants.com)*
-*info@openaaccountants.com*
+*info@openaccountants.com*

--- a/packages/malaysia/README.md
+++ b/packages/malaysia/README.md
@@ -53,7 +53,7 @@ These Malaysia tax skills need your eye. Every rate, threshold, and form referen
 
 1. Download the files in this folder
 2. Check the rates against Inland Revenue Board of Malaysia (LHDN)'s website
-3. Email your corrections to **info@openaaccountants.com** — Word doc, Excel, PDF, tracked changes, whatever works
+3. Email your corrections to **info@openaccountants.com** — Word doc, Excel, PDF, tracked changes, whatever works
 
 We'll update the skill and credit you publicly as the verified reviewer at [openaccountants.com](https://openaccountants.com).
 
@@ -65,4 +65,4 @@ Or if you're comfortable with GitHub: fork the repo, fix the source file under `
 
 *OpenAccountants — open-source accounting skills for AI*
 *134 countries + 51 US states — [openaccountants.com](https://openaccountants.com)*
-*info@openaaccountants.com*
+*info@openaccountants.com*

--- a/packages/maldives/README.md
+++ b/packages/maldives/README.md
@@ -42,7 +42,7 @@ These Maldives tax skills need your eye. Every rate, threshold, and form referen
 
 1. Download the files in this folder
 2. Check the rates against your national tax authority's website
-3. Email your corrections to **info@openaaccountants.com** — Word doc, Excel, PDF, tracked changes, whatever works
+3. Email your corrections to **info@openaccountants.com** — Word doc, Excel, PDF, tracked changes, whatever works
 
 We'll update the skill and credit you publicly as the verified reviewer at [openaccountants.com](https://openaccountants.com).
 
@@ -54,4 +54,4 @@ Or if you're comfortable with GitHub: fork the repo, fix the source file under `
 
 *OpenAccountants — open-source accounting skills for AI*
 *134 countries + 51 US states — [openaccountants.com](https://openaccountants.com)*
-*info@openaaccountants.com*
+*info@openaccountants.com*

--- a/packages/malta/README.md
+++ b/packages/malta/README.md
@@ -68,7 +68,7 @@ These Malta tax skills need your eye. Every rate, threshold, and form reference 
 
 1. Download the files in this folder
 2. Check the rates against Commissioner for Revenue (CFR)'s website
-3. Email your corrections to **info@openaaccountants.com** — Word doc, Excel, PDF, tracked changes, whatever works
+3. Email your corrections to **info@openaccountants.com** — Word doc, Excel, PDF, tracked changes, whatever works
 
 We'll update the skill and credit you publicly as the verified reviewer at [openaccountants.com](https://openaccountants.com).
 
@@ -80,4 +80,4 @@ Or if you're comfortable with GitHub: fork the repo, fix the source file under `
 
 *OpenAccountants — open-source accounting skills for AI*
 *134 countries + 51 US states — [openaccountants.com](https://openaccountants.com)*
-*info@openaaccountants.com*
+*info@openaccountants.com*

--- a/packages/mauritius/README.md
+++ b/packages/mauritius/README.md
@@ -42,7 +42,7 @@ These Mauritius tax skills need your eye. Every rate, threshold, and form refere
 
 1. Download the files in this folder
 2. Check the rates against your national tax authority's website
-3. Email your corrections to **info@openaaccountants.com** — Word doc, Excel, PDF, tracked changes, whatever works
+3. Email your corrections to **info@openaccountants.com** — Word doc, Excel, PDF, tracked changes, whatever works
 
 We'll update the skill and credit you publicly as the verified reviewer at [openaccountants.com](https://openaccountants.com).
 
@@ -54,4 +54,4 @@ Or if you're comfortable with GitHub: fork the repo, fix the source file under `
 
 *OpenAccountants — open-source accounting skills for AI*
 *134 countries + 51 US states — [openaccountants.com](https://openaccountants.com)*
-*info@openaaccountants.com*
+*info@openaccountants.com*

--- a/packages/mexico/README.md
+++ b/packages/mexico/README.md
@@ -62,7 +62,7 @@ These Mexico tax skills need your eye. Every rate, threshold, and form reference
 
 1. Download the files in this folder
 2. Check the rates against Servicio de Administración Tributaria (SAT)'s website
-3. Email your corrections to **info@openaaccountants.com** — Word doc, Excel, PDF, tracked changes, whatever works
+3. Email your corrections to **info@openaccountants.com** — Word doc, Excel, PDF, tracked changes, whatever works
 
 We'll update the skill and credit you publicly as the verified reviewer at [openaccountants.com](https://openaccountants.com).
 
@@ -74,4 +74,4 @@ Or if you're comfortable with GitHub: fork the repo, fix the source file under `
 
 *OpenAccountants — open-source accounting skills for AI*
 *134 countries + 51 US states — [openaccountants.com](https://openaccountants.com)*
-*info@openaaccountants.com*
+*info@openaccountants.com*

--- a/packages/moldova/README.md
+++ b/packages/moldova/README.md
@@ -42,7 +42,7 @@ These Moldova tax skills need your eye. Every rate, threshold, and form referenc
 
 1. Download the files in this folder
 2. Check the rates against your national tax authority's website
-3. Email your corrections to **info@openaaccountants.com** — Word doc, Excel, PDF, tracked changes, whatever works
+3. Email your corrections to **info@openaccountants.com** — Word doc, Excel, PDF, tracked changes, whatever works
 
 We'll update the skill and credit you publicly as the verified reviewer at [openaccountants.com](https://openaccountants.com).
 
@@ -54,4 +54,4 @@ Or if you're comfortable with GitHub: fork the repo, fix the source file under `
 
 *OpenAccountants — open-source accounting skills for AI*
 *134 countries + 51 US states — [openaccountants.com](https://openaccountants.com)*
-*info@openaaccountants.com*
+*info@openaccountants.com*

--- a/packages/monaco/README.md
+++ b/packages/monaco/README.md
@@ -42,7 +42,7 @@ These Monaco tax skills need your eye. Every rate, threshold, and form reference
 
 1. Download the files in this folder
 2. Check the rates against your national tax authority's website
-3. Email your corrections to **info@openaaccountants.com** — Word doc, Excel, PDF, tracked changes, whatever works
+3. Email your corrections to **info@openaccountants.com** — Word doc, Excel, PDF, tracked changes, whatever works
 
 We'll update the skill and credit you publicly as the verified reviewer at [openaccountants.com](https://openaccountants.com).
 
@@ -54,4 +54,4 @@ Or if you're comfortable with GitHub: fork the repo, fix the source file under `
 
 *OpenAccountants — open-source accounting skills for AI*
 *134 countries + 51 US states — [openaccountants.com](https://openaccountants.com)*
-*info@openaaccountants.com*
+*info@openaccountants.com*

--- a/packages/mongolia/README.md
+++ b/packages/mongolia/README.md
@@ -42,7 +42,7 @@ These Mongolia tax skills need your eye. Every rate, threshold, and form referen
 
 1. Download the files in this folder
 2. Check the rates against your national tax authority's website
-3. Email your corrections to **info@openaaccountants.com** — Word doc, Excel, PDF, tracked changes, whatever works
+3. Email your corrections to **info@openaccountants.com** — Word doc, Excel, PDF, tracked changes, whatever works
 
 We'll update the skill and credit you publicly as the verified reviewer at [openaccountants.com](https://openaccountants.com).
 
@@ -54,4 +54,4 @@ Or if you're comfortable with GitHub: fork the repo, fix the source file under `
 
 *OpenAccountants — open-source accounting skills for AI*
 *134 countries + 51 US states — [openaccountants.com](https://openaccountants.com)*
-*info@openaaccountants.com*
+*info@openaccountants.com*

--- a/packages/montenegro/README.md
+++ b/packages/montenegro/README.md
@@ -42,7 +42,7 @@ These Montenegro tax skills need your eye. Every rate, threshold, and form refer
 
 1. Download the files in this folder
 2. Check the rates against your national tax authority's website
-3. Email your corrections to **info@openaaccountants.com** — Word doc, Excel, PDF, tracked changes, whatever works
+3. Email your corrections to **info@openaccountants.com** — Word doc, Excel, PDF, tracked changes, whatever works
 
 We'll update the skill and credit you publicly as the verified reviewer at [openaccountants.com](https://openaccountants.com).
 
@@ -54,4 +54,4 @@ Or if you're comfortable with GitHub: fork the repo, fix the source file under `
 
 *OpenAccountants — open-source accounting skills for AI*
 *134 countries + 51 US states — [openaccountants.com](https://openaccountants.com)*
-*info@openaaccountants.com*
+*info@openaccountants.com*

--- a/packages/morocco/README.md
+++ b/packages/morocco/README.md
@@ -42,7 +42,7 @@ These Morocco tax skills need your eye. Every rate, threshold, and form referenc
 
 1. Download the files in this folder
 2. Check the rates against your national tax authority's website
-3. Email your corrections to **info@openaaccountants.com** — Word doc, Excel, PDF, tracked changes, whatever works
+3. Email your corrections to **info@openaccountants.com** — Word doc, Excel, PDF, tracked changes, whatever works
 
 We'll update the skill and credit you publicly as the verified reviewer at [openaccountants.com](https://openaccountants.com).
 
@@ -54,4 +54,4 @@ Or if you're comfortable with GitHub: fork the repo, fix the source file under `
 
 *OpenAccountants — open-source accounting skills for AI*
 *134 countries + 51 US states — [openaccountants.com](https://openaccountants.com)*
-*info@openaaccountants.com*
+*info@openaccountants.com*

--- a/packages/mozambique/README.md
+++ b/packages/mozambique/README.md
@@ -42,7 +42,7 @@ These Mozambique tax skills need your eye. Every rate, threshold, and form refer
 
 1. Download the files in this folder
 2. Check the rates against your national tax authority's website
-3. Email your corrections to **info@openaaccountants.com** — Word doc, Excel, PDF, tracked changes, whatever works
+3. Email your corrections to **info@openaccountants.com** — Word doc, Excel, PDF, tracked changes, whatever works
 
 We'll update the skill and credit you publicly as the verified reviewer at [openaccountants.com](https://openaccountants.com).
 
@@ -54,4 +54,4 @@ Or if you're comfortable with GitHub: fork the repo, fix the source file under `
 
 *OpenAccountants — open-source accounting skills for AI*
 *134 countries + 51 US states — [openaccountants.com](https://openaccountants.com)*
-*info@openaaccountants.com*
+*info@openaccountants.com*

--- a/packages/myanmar/README.md
+++ b/packages/myanmar/README.md
@@ -42,7 +42,7 @@ These Myanmar tax skills need your eye. Every rate, threshold, and form referenc
 
 1. Download the files in this folder
 2. Check the rates against your national tax authority's website
-3. Email your corrections to **info@openaaccountants.com** — Word doc, Excel, PDF, tracked changes, whatever works
+3. Email your corrections to **info@openaccountants.com** — Word doc, Excel, PDF, tracked changes, whatever works
 
 We'll update the skill and credit you publicly as the verified reviewer at [openaccountants.com](https://openaccountants.com).
 
@@ -54,4 +54,4 @@ Or if you're comfortable with GitHub: fork the repo, fix the source file under `
 
 *OpenAccountants — open-source accounting skills for AI*
 *134 countries + 51 US states — [openaccountants.com](https://openaccountants.com)*
-*info@openaaccountants.com*
+*info@openaccountants.com*

--- a/packages/nepal/README.md
+++ b/packages/nepal/README.md
@@ -42,7 +42,7 @@ These Nepal tax skills need your eye. Every rate, threshold, and form reference 
 
 1. Download the files in this folder
 2. Check the rates against your national tax authority's website
-3. Email your corrections to **info@openaaccountants.com** — Word doc, Excel, PDF, tracked changes, whatever works
+3. Email your corrections to **info@openaccountants.com** — Word doc, Excel, PDF, tracked changes, whatever works
 
 We'll update the skill and credit you publicly as the verified reviewer at [openaccountants.com](https://openaccountants.com).
 
@@ -54,4 +54,4 @@ Or if you're comfortable with GitHub: fork the repo, fix the source file under `
 
 *OpenAccountants — open-source accounting skills for AI*
 *134 countries + 51 US states — [openaccountants.com](https://openaccountants.com)*
-*info@openaaccountants.com*
+*info@openaccountants.com*

--- a/packages/netherlands/README.md
+++ b/packages/netherlands/README.md
@@ -71,7 +71,7 @@ These Netherlands tax skills need your eye. Every rate, threshold, and form refe
 
 1. Download the files in this folder
 2. Check the rates against Belastingdienst's website
-3. Email your corrections to **info@openaaccountants.com** — Word doc, Excel, PDF, tracked changes, whatever works
+3. Email your corrections to **info@openaccountants.com** — Word doc, Excel, PDF, tracked changes, whatever works
 
 We'll update the skill and credit you publicly as the verified reviewer at [openaccountants.com](https://openaccountants.com).
 
@@ -83,4 +83,4 @@ Or if you're comfortable with GitHub: fork the repo, fix the source file under `
 
 *OpenAccountants — open-source accounting skills for AI*
 *134 countries + 51 US states — [openaccountants.com](https://openaccountants.com)*
-*info@openaaccountants.com*
+*info@openaccountants.com*

--- a/packages/new-zealand/README.md
+++ b/packages/new-zealand/README.md
@@ -55,7 +55,7 @@ These New Zealand tax skills need your eye. Every rate, threshold, and form refe
 
 1. Download the files in this folder
 2. Check the rates against Inland Revenue (IRD)'s website
-3. Email your corrections to **info@openaaccountants.com** — Word doc, Excel, PDF, tracked changes, whatever works
+3. Email your corrections to **info@openaccountants.com** — Word doc, Excel, PDF, tracked changes, whatever works
 
 We'll update the skill and credit you publicly as the verified reviewer at [openaccountants.com](https://openaccountants.com).
 
@@ -67,4 +67,4 @@ Or if you're comfortable with GitHub: fork the repo, fix the source file under `
 
 *OpenAccountants — open-source accounting skills for AI*
 *134 countries + 51 US states — [openaccountants.com](https://openaccountants.com)*
-*info@openaaccountants.com*
+*info@openaccountants.com*

--- a/packages/nicaragua/README.md
+++ b/packages/nicaragua/README.md
@@ -42,7 +42,7 @@ These Nicaragua tax skills need your eye. Every rate, threshold, and form refere
 
 1. Download the files in this folder
 2. Check the rates against your national tax authority's website
-3. Email your corrections to **info@openaaccountants.com** — Word doc, Excel, PDF, tracked changes, whatever works
+3. Email your corrections to **info@openaccountants.com** — Word doc, Excel, PDF, tracked changes, whatever works
 
 We'll update the skill and credit you publicly as the verified reviewer at [openaccountants.com](https://openaccountants.com).
 
@@ -54,4 +54,4 @@ Or if you're comfortable with GitHub: fork the repo, fix the source file under `
 
 *OpenAccountants — open-source accounting skills for AI*
 *134 countries + 51 US states — [openaccountants.com](https://openaccountants.com)*
-*info@openaaccountants.com*
+*info@openaccountants.com*

--- a/packages/nigeria/README.md
+++ b/packages/nigeria/README.md
@@ -51,7 +51,7 @@ These Nigeria tax skills need your eye. Every rate, threshold, and form referenc
 
 1. Download the files in this folder
 2. Check the rates against Federal Inland Revenue Service (FIRS)'s website
-3. Email your corrections to **info@openaaccountants.com** — Word doc, Excel, PDF, tracked changes, whatever works
+3. Email your corrections to **info@openaccountants.com** — Word doc, Excel, PDF, tracked changes, whatever works
 
 We'll update the skill and credit you publicly as the verified reviewer at [openaccountants.com](https://openaccountants.com).
 
@@ -63,4 +63,4 @@ Or if you're comfortable with GitHub: fork the repo, fix the source file under `
 
 *OpenAccountants — open-source accounting skills for AI*
 *134 countries + 51 US states — [openaccountants.com](https://openaccountants.com)*
-*info@openaaccountants.com*
+*info@openaccountants.com*

--- a/packages/north-macedonia/README.md
+++ b/packages/north-macedonia/README.md
@@ -42,7 +42,7 @@ These North Macedonia tax skills need your eye. Every rate, threshold, and form 
 
 1. Download the files in this folder
 2. Check the rates against your national tax authority's website
-3. Email your corrections to **info@openaaccountants.com** — Word doc, Excel, PDF, tracked changes, whatever works
+3. Email your corrections to **info@openaccountants.com** — Word doc, Excel, PDF, tracked changes, whatever works
 
 We'll update the skill and credit you publicly as the verified reviewer at [openaccountants.com](https://openaccountants.com).
 
@@ -54,4 +54,4 @@ Or if you're comfortable with GitHub: fork the repo, fix the source file under `
 
 *OpenAccountants — open-source accounting skills for AI*
 *134 countries + 51 US states — [openaccountants.com](https://openaccountants.com)*
-*info@openaaccountants.com*
+*info@openaccountants.com*

--- a/packages/norway/README.md
+++ b/packages/norway/README.md
@@ -50,7 +50,7 @@ These Norway tax skills need your eye. Every rate, threshold, and form reference
 
 1. Download the files in this folder
 2. Check the rates against Skatteetaten's website
-3. Email your corrections to **info@openaaccountants.com** — Word doc, Excel, PDF, tracked changes, whatever works
+3. Email your corrections to **info@openaccountants.com** — Word doc, Excel, PDF, tracked changes, whatever works
 
 We'll update the skill and credit you publicly as the verified reviewer at [openaccountants.com](https://openaccountants.com).
 
@@ -62,4 +62,4 @@ Or if you're comfortable with GitHub: fork the repo, fix the source file under `
 
 *OpenAccountants — open-source accounting skills for AI*
 *134 countries + 51 US states — [openaccountants.com](https://openaccountants.com)*
-*info@openaaccountants.com*
+*info@openaccountants.com*

--- a/packages/oman/README.md
+++ b/packages/oman/README.md
@@ -42,7 +42,7 @@ These Oman tax skills need your eye. Every rate, threshold, and form reference w
 
 1. Download the files in this folder
 2. Check the rates against your national tax authority's website
-3. Email your corrections to **info@openaaccountants.com** — Word doc, Excel, PDF, tracked changes, whatever works
+3. Email your corrections to **info@openaccountants.com** — Word doc, Excel, PDF, tracked changes, whatever works
 
 We'll update the skill and credit you publicly as the verified reviewer at [openaccountants.com](https://openaccountants.com).
 
@@ -54,4 +54,4 @@ Or if you're comfortable with GitHub: fork the repo, fix the source file under `
 
 *OpenAccountants — open-source accounting skills for AI*
 *134 countries + 51 US states — [openaccountants.com](https://openaccountants.com)*
-*info@openaaccountants.com*
+*info@openaccountants.com*

--- a/packages/pakistan/README.md
+++ b/packages/pakistan/README.md
@@ -42,7 +42,7 @@ These Pakistan tax skills need your eye. Every rate, threshold, and form referen
 
 1. Download the files in this folder
 2. Check the rates against your national tax authority's website
-3. Email your corrections to **info@openaaccountants.com** — Word doc, Excel, PDF, tracked changes, whatever works
+3. Email your corrections to **info@openaccountants.com** — Word doc, Excel, PDF, tracked changes, whatever works
 
 We'll update the skill and credit you publicly as the verified reviewer at [openaccountants.com](https://openaccountants.com).
 
@@ -54,4 +54,4 @@ Or if you're comfortable with GitHub: fork the repo, fix the source file under `
 
 *OpenAccountants — open-source accounting skills for AI*
 *134 countries + 51 US states — [openaccountants.com](https://openaccountants.com)*
-*info@openaaccountants.com*
+*info@openaccountants.com*

--- a/packages/panama/README.md
+++ b/packages/panama/README.md
@@ -42,7 +42,7 @@ These Panama tax skills need your eye. Every rate, threshold, and form reference
 
 1. Download the files in this folder
 2. Check the rates against your national tax authority's website
-3. Email your corrections to **info@openaaccountants.com** — Word doc, Excel, PDF, tracked changes, whatever works
+3. Email your corrections to **info@openaccountants.com** — Word doc, Excel, PDF, tracked changes, whatever works
 
 We'll update the skill and credit you publicly as the verified reviewer at [openaccountants.com](https://openaccountants.com).
 
@@ -54,4 +54,4 @@ Or if you're comfortable with GitHub: fork the repo, fix the source file under `
 
 *OpenAccountants — open-source accounting skills for AI*
 *134 countries + 51 US states — [openaccountants.com](https://openaccountants.com)*
-*info@openaaccountants.com*
+*info@openaccountants.com*

--- a/packages/papua-new-guinea/README.md
+++ b/packages/papua-new-guinea/README.md
@@ -42,7 +42,7 @@ These Papua New Guinea tax skills need your eye. Every rate, threshold, and form
 
 1. Download the files in this folder
 2. Check the rates against your national tax authority's website
-3. Email your corrections to **info@openaaccountants.com** — Word doc, Excel, PDF, tracked changes, whatever works
+3. Email your corrections to **info@openaccountants.com** — Word doc, Excel, PDF, tracked changes, whatever works
 
 We'll update the skill and credit you publicly as the verified reviewer at [openaccountants.com](https://openaccountants.com).
 
@@ -54,4 +54,4 @@ Or if you're comfortable with GitHub: fork the repo, fix the source file under `
 
 *OpenAccountants — open-source accounting skills for AI*
 *134 countries + 51 US states — [openaccountants.com](https://openaccountants.com)*
-*info@openaaccountants.com*
+*info@openaccountants.com*

--- a/packages/paraguay/README.md
+++ b/packages/paraguay/README.md
@@ -42,7 +42,7 @@ These Paraguay tax skills need your eye. Every rate, threshold, and form referen
 
 1. Download the files in this folder
 2. Check the rates against your national tax authority's website
-3. Email your corrections to **info@openaaccountants.com** — Word doc, Excel, PDF, tracked changes, whatever works
+3. Email your corrections to **info@openaccountants.com** — Word doc, Excel, PDF, tracked changes, whatever works
 
 We'll update the skill and credit you publicly as the verified reviewer at [openaccountants.com](https://openaccountants.com).
 
@@ -54,4 +54,4 @@ Or if you're comfortable with GitHub: fork the repo, fix the source file under `
 
 *OpenAccountants — open-source accounting skills for AI*
 *134 countries + 51 US states — [openaccountants.com](https://openaccountants.com)*
-*info@openaaccountants.com*
+*info@openaccountants.com*

--- a/packages/peru/README.md
+++ b/packages/peru/README.md
@@ -42,7 +42,7 @@ These Peru tax skills need your eye. Every rate, threshold, and form reference w
 
 1. Download the files in this folder
 2. Check the rates against your national tax authority's website
-3. Email your corrections to **info@openaaccountants.com** — Word doc, Excel, PDF, tracked changes, whatever works
+3. Email your corrections to **info@openaccountants.com** — Word doc, Excel, PDF, tracked changes, whatever works
 
 We'll update the skill and credit you publicly as the verified reviewer at [openaccountants.com](https://openaccountants.com).
 
@@ -54,4 +54,4 @@ Or if you're comfortable with GitHub: fork the repo, fix the source file under `
 
 *OpenAccountants — open-source accounting skills for AI*
 *134 countries + 51 US states — [openaccountants.com](https://openaccountants.com)*
-*info@openaaccountants.com*
+*info@openaccountants.com*

--- a/packages/philippines/README.md
+++ b/packages/philippines/README.md
@@ -51,7 +51,7 @@ These Philippines tax skills need your eye. Every rate, threshold, and form refe
 
 1. Download the files in this folder
 2. Check the rates against Bureau of Internal Revenue (BIR)'s website
-3. Email your corrections to **info@openaaccountants.com** — Word doc, Excel, PDF, tracked changes, whatever works
+3. Email your corrections to **info@openaccountants.com** — Word doc, Excel, PDF, tracked changes, whatever works
 
 We'll update the skill and credit you publicly as the verified reviewer at [openaccountants.com](https://openaccountants.com).
 
@@ -63,4 +63,4 @@ Or if you're comfortable with GitHub: fork the repo, fix the source file under `
 
 *OpenAccountants — open-source accounting skills for AI*
 *134 countries + 51 US states — [openaccountants.com](https://openaccountants.com)*
-*info@openaaccountants.com*
+*info@openaccountants.com*

--- a/packages/poland/README.md
+++ b/packages/poland/README.md
@@ -54,7 +54,7 @@ These Poland tax skills need your eye. Every rate, threshold, and form reference
 
 1. Download the files in this folder
 2. Check the rates against Krajowa Administracja Skarbowa (KAS)'s website
-3. Email your corrections to **info@openaaccountants.com** — Word doc, Excel, PDF, tracked changes, whatever works
+3. Email your corrections to **info@openaccountants.com** — Word doc, Excel, PDF, tracked changes, whatever works
 
 We'll update the skill and credit you publicly as the verified reviewer at [openaccountants.com](https://openaccountants.com).
 
@@ -66,4 +66,4 @@ Or if you're comfortable with GitHub: fork the repo, fix the source file under `
 
 *OpenAccountants — open-source accounting skills for AI*
 *134 countries + 51 US states — [openaccountants.com](https://openaccountants.com)*
-*info@openaaccountants.com*
+*info@openaccountants.com*

--- a/packages/portugal/README.md
+++ b/packages/portugal/README.md
@@ -64,7 +64,7 @@ These Portugal tax skills need your eye. Every rate, threshold, and form referen
 
 1. Download the files in this folder
 2. Check the rates against Autoridade Tributária e Aduaneira (AT)'s website
-3. Email your corrections to **info@openaaccountants.com** — Word doc, Excel, PDF, tracked changes, whatever works
+3. Email your corrections to **info@openaccountants.com** — Word doc, Excel, PDF, tracked changes, whatever works
 
 We'll update the skill and credit you publicly as the verified reviewer at [openaccountants.com](https://openaccountants.com).
 
@@ -76,4 +76,4 @@ Or if you're comfortable with GitHub: fork the repo, fix the source file under `
 
 *OpenAccountants — open-source accounting skills for AI*
 *134 countries + 51 US states — [openaccountants.com](https://openaccountants.com)*
-*info@openaaccountants.com*
+*info@openaccountants.com*

--- a/packages/qatar/README.md
+++ b/packages/qatar/README.md
@@ -42,7 +42,7 @@ These Qatar tax skills need your eye. Every rate, threshold, and form reference 
 
 1. Download the files in this folder
 2. Check the rates against your national tax authority's website
-3. Email your corrections to **info@openaaccountants.com** — Word doc, Excel, PDF, tracked changes, whatever works
+3. Email your corrections to **info@openaccountants.com** — Word doc, Excel, PDF, tracked changes, whatever works
 
 We'll update the skill and credit you publicly as the verified reviewer at [openaccountants.com](https://openaccountants.com).
 
@@ -54,4 +54,4 @@ Or if you're comfortable with GitHub: fork the repo, fix the source file under `
 
 *OpenAccountants — open-source accounting skills for AI*
 *134 countries + 51 US states — [openaccountants.com](https://openaccountants.com)*
-*info@openaaccountants.com*
+*info@openaccountants.com*

--- a/packages/romania/README.md
+++ b/packages/romania/README.md
@@ -54,7 +54,7 @@ These Romania tax skills need your eye. Every rate, threshold, and form referenc
 
 1. Download the files in this folder
 2. Check the rates against ANAF (Agenția Națională de Administrare Fiscală)'s website
-3. Email your corrections to **info@openaaccountants.com** — Word doc, Excel, PDF, tracked changes, whatever works
+3. Email your corrections to **info@openaccountants.com** — Word doc, Excel, PDF, tracked changes, whatever works
 
 We'll update the skill and credit you publicly as the verified reviewer at [openaccountants.com](https://openaccountants.com).
 
@@ -66,4 +66,4 @@ Or if you're comfortable with GitHub: fork the repo, fix the source file under `
 
 *OpenAccountants — open-source accounting skills for AI*
 *134 countries + 51 US states — [openaccountants.com](https://openaccountants.com)*
-*info@openaaccountants.com*
+*info@openaccountants.com*

--- a/packages/russia/README.md
+++ b/packages/russia/README.md
@@ -48,7 +48,7 @@ These Russia tax skills need your eye. Every rate, threshold, and form reference
 
 1. Download the files in this folder
 2. Check the rates against Federal Tax Service (ФНС России)'s website
-3. Email your corrections to **info@openaaccountants.com** — Word doc, Excel, PDF, tracked changes, whatever works
+3. Email your corrections to **info@openaccountants.com** — Word doc, Excel, PDF, tracked changes, whatever works
 
 We'll update the skill and credit you publicly as the verified reviewer at [openaccountants.com](https://openaccountants.com).
 
@@ -60,4 +60,4 @@ Or if you're comfortable with GitHub: fork the repo, fix the source file under `
 
 *OpenAccountants — open-source accounting skills for AI*
 *134 countries + 51 US states — [openaccountants.com](https://openaccountants.com)*
-*info@openaaccountants.com*
+*info@openaccountants.com*

--- a/packages/rwanda/README.md
+++ b/packages/rwanda/README.md
@@ -42,7 +42,7 @@ These Rwanda tax skills need your eye. Every rate, threshold, and form reference
 
 1. Download the files in this folder
 2. Check the rates against your national tax authority's website
-3. Email your corrections to **info@openaaccountants.com** — Word doc, Excel, PDF, tracked changes, whatever works
+3. Email your corrections to **info@openaccountants.com** — Word doc, Excel, PDF, tracked changes, whatever works
 
 We'll update the skill and credit you publicly as the verified reviewer at [openaccountants.com](https://openaccountants.com).
 
@@ -54,4 +54,4 @@ Or if you're comfortable with GitHub: fork the repo, fix the source file under `
 
 *OpenAccountants — open-source accounting skills for AI*
 *134 countries + 51 US states — [openaccountants.com](https://openaccountants.com)*
-*info@openaaccountants.com*
+*info@openaccountants.com*

--- a/packages/saudi-arabia/README.md
+++ b/packages/saudi-arabia/README.md
@@ -51,7 +51,7 @@ These Saudi Arabia tax skills need your eye. Every rate, threshold, and form ref
 
 1. Download the files in this folder
 2. Check the rates against Zakat, Tax and Customs Authority (ZATCA)'s website
-3. Email your corrections to **info@openaaccountants.com** — Word doc, Excel, PDF, tracked changes, whatever works
+3. Email your corrections to **info@openaccountants.com** — Word doc, Excel, PDF, tracked changes, whatever works
 
 We'll update the skill and credit you publicly as the verified reviewer at [openaccountants.com](https://openaccountants.com).
 
@@ -63,4 +63,4 @@ Or if you're comfortable with GitHub: fork the repo, fix the source file under `
 
 *OpenAccountants — open-source accounting skills for AI*
 *134 countries + 51 US states — [openaccountants.com](https://openaccountants.com)*
-*info@openaaccountants.com*
+*info@openaccountants.com*

--- a/packages/senegal/README.md
+++ b/packages/senegal/README.md
@@ -42,7 +42,7 @@ These Senegal tax skills need your eye. Every rate, threshold, and form referenc
 
 1. Download the files in this folder
 2. Check the rates against your national tax authority's website
-3. Email your corrections to **info@openaaccountants.com** — Word doc, Excel, PDF, tracked changes, whatever works
+3. Email your corrections to **info@openaccountants.com** — Word doc, Excel, PDF, tracked changes, whatever works
 
 We'll update the skill and credit you publicly as the verified reviewer at [openaccountants.com](https://openaccountants.com).
 
@@ -54,4 +54,4 @@ Or if you're comfortable with GitHub: fork the repo, fix the source file under `
 
 *OpenAccountants — open-source accounting skills for AI*
 *134 countries + 51 US states — [openaccountants.com](https://openaccountants.com)*
-*info@openaaccountants.com*
+*info@openaccountants.com*

--- a/packages/serbia/README.md
+++ b/packages/serbia/README.md
@@ -42,7 +42,7 @@ These Serbia tax skills need your eye. Every rate, threshold, and form reference
 
 1. Download the files in this folder
 2. Check the rates against your national tax authority's website
-3. Email your corrections to **info@openaaccountants.com** — Word doc, Excel, PDF, tracked changes, whatever works
+3. Email your corrections to **info@openaccountants.com** — Word doc, Excel, PDF, tracked changes, whatever works
 
 We'll update the skill and credit you publicly as the verified reviewer at [openaccountants.com](https://openaccountants.com).
 
@@ -54,4 +54,4 @@ Or if you're comfortable with GitHub: fork the repo, fix the source file under `
 
 *OpenAccountants — open-source accounting skills for AI*
 *134 countries + 51 US states — [openaccountants.com](https://openaccountants.com)*
-*info@openaaccountants.com*
+*info@openaccountants.com*

--- a/packages/singapore/README.md
+++ b/packages/singapore/README.md
@@ -57,7 +57,7 @@ These Singapore tax skills need your eye. Every rate, threshold, and form refere
 
 1. Download the files in this folder
 2. Check the rates against Inland Revenue Authority of Singapore (IRAS)'s website
-3. Email your corrections to **info@openaaccountants.com** — Word doc, Excel, PDF, tracked changes, whatever works
+3. Email your corrections to **info@openaccountants.com** — Word doc, Excel, PDF, tracked changes, whatever works
 
 We'll update the skill and credit you publicly as the verified reviewer at [openaccountants.com](https://openaccountants.com).
 
@@ -69,4 +69,4 @@ Or if you're comfortable with GitHub: fork the repo, fix the source file under `
 
 *OpenAccountants — open-source accounting skills for AI*
 *134 countries + 51 US states — [openaccountants.com](https://openaccountants.com)*
-*info@openaaccountants.com*
+*info@openaccountants.com*

--- a/packages/slovakia/README.md
+++ b/packages/slovakia/README.md
@@ -45,7 +45,7 @@ These Slovakia tax skills need your eye. Every rate, threshold, and form referen
 
 1. Download the files in this folder
 2. Check the rates against your national tax authority's website
-3. Email your corrections to **info@openaaccountants.com** — Word doc, Excel, PDF, tracked changes, whatever works
+3. Email your corrections to **info@openaccountants.com** — Word doc, Excel, PDF, tracked changes, whatever works
 
 We'll update the skill and credit you publicly as the verified reviewer at [openaccountants.com](https://openaccountants.com).
 
@@ -57,4 +57,4 @@ Or if you're comfortable with GitHub: fork the repo, fix the source file under `
 
 *OpenAccountants — open-source accounting skills for AI*
 *134 countries + 51 US states — [openaccountants.com](https://openaccountants.com)*
-*info@openaaccountants.com*
+*info@openaccountants.com*

--- a/packages/slovenia/README.md
+++ b/packages/slovenia/README.md
@@ -43,7 +43,7 @@ These Slovenia tax skills need your eye. Every rate, threshold, and form referen
 
 1. Download the files in this folder
 2. Check the rates against your national tax authority's website
-3. Email your corrections to **info@openaaccountants.com** — Word doc, Excel, PDF, tracked changes, whatever works
+3. Email your corrections to **info@openaccountants.com** — Word doc, Excel, PDF, tracked changes, whatever works
 
 We'll update the skill and credit you publicly as the verified reviewer at [openaccountants.com](https://openaccountants.com).
 
@@ -55,4 +55,4 @@ Or if you're comfortable with GitHub: fork the repo, fix the source file under `
 
 *OpenAccountants — open-source accounting skills for AI*
 *134 countries + 51 US states — [openaccountants.com](https://openaccountants.com)*
-*info@openaaccountants.com*
+*info@openaccountants.com*

--- a/packages/south-africa/README.md
+++ b/packages/south-africa/README.md
@@ -53,7 +53,7 @@ These South Africa tax skills need your eye. Every rate, threshold, and form ref
 
 1. Download the files in this folder
 2. Check the rates against South African Revenue Service (SARS)'s website
-3. Email your corrections to **info@openaaccountants.com** — Word doc, Excel, PDF, tracked changes, whatever works
+3. Email your corrections to **info@openaccountants.com** — Word doc, Excel, PDF, tracked changes, whatever works
 
 We'll update the skill and credit you publicly as the verified reviewer at [openaccountants.com](https://openaccountants.com).
 
@@ -65,4 +65,4 @@ Or if you're comfortable with GitHub: fork the repo, fix the source file under `
 
 *OpenAccountants — open-source accounting skills for AI*
 *134 countries + 51 US states — [openaccountants.com](https://openaccountants.com)*
-*info@openaaccountants.com*
+*info@openaccountants.com*

--- a/packages/south-korea/README.md
+++ b/packages/south-korea/README.md
@@ -53,7 +53,7 @@ These South Korea tax skills need your eye. Every rate, threshold, and form refe
 
 1. Download the files in this folder
 2. Check the rates against National Tax Service (국세청)'s website
-3. Email your corrections to **info@openaaccountants.com** — Word doc, Excel, PDF, tracked changes, whatever works
+3. Email your corrections to **info@openaccountants.com** — Word doc, Excel, PDF, tracked changes, whatever works
 
 We'll update the skill and credit you publicly as the verified reviewer at [openaccountants.com](https://openaccountants.com).
 
@@ -65,4 +65,4 @@ Or if you're comfortable with GitHub: fork the repo, fix the source file under `
 
 *OpenAccountants — open-source accounting skills for AI*
 *134 countries + 51 US states — [openaccountants.com](https://openaccountants.com)*
-*info@openaaccountants.com*
+*info@openaccountants.com*

--- a/packages/spain/README.md
+++ b/packages/spain/README.md
@@ -75,7 +75,7 @@ These Spain tax skills need your eye. Every rate, threshold, and form reference 
 
 1. Download the files in this folder
 2. Check the rates against Agencia Tributaria (AEAT)'s website
-3. Email your corrections to **info@openaaccountants.com** — Word doc, Excel, PDF, tracked changes, whatever works
+3. Email your corrections to **info@openaccountants.com** — Word doc, Excel, PDF, tracked changes, whatever works
 
 We'll update the skill and credit you publicly as the verified reviewer at [openaccountants.com](https://openaccountants.com).
 
@@ -87,4 +87,4 @@ Or if you're comfortable with GitHub: fork the repo, fix the source file under `
 
 *OpenAccountants — open-source accounting skills for AI*
 *134 countries + 51 US states — [openaccountants.com](https://openaccountants.com)*
-*info@openaaccountants.com*
+*info@openaccountants.com*

--- a/packages/sri-lanka/README.md
+++ b/packages/sri-lanka/README.md
@@ -42,7 +42,7 @@ These Sri Lanka tax skills need your eye. Every rate, threshold, and form refere
 
 1. Download the files in this folder
 2. Check the rates against your national tax authority's website
-3. Email your corrections to **info@openaaccountants.com** — Word doc, Excel, PDF, tracked changes, whatever works
+3. Email your corrections to **info@openaccountants.com** — Word doc, Excel, PDF, tracked changes, whatever works
 
 We'll update the skill and credit you publicly as the verified reviewer at [openaccountants.com](https://openaccountants.com).
 
@@ -54,4 +54,4 @@ Or if you're comfortable with GitHub: fork the repo, fix the source file under `
 
 *OpenAccountants — open-source accounting skills for AI*
 *134 countries + 51 US states — [openaccountants.com](https://openaccountants.com)*
-*info@openaaccountants.com*
+*info@openaccountants.com*

--- a/packages/sweden/README.md
+++ b/packages/sweden/README.md
@@ -58,7 +58,7 @@ These Sweden tax skills need your eye. Every rate, threshold, and form reference
 
 1. Download the files in this folder
 2. Check the rates against Skatteverket's website
-3. Email your corrections to **info@openaaccountants.com** — Word doc, Excel, PDF, tracked changes, whatever works
+3. Email your corrections to **info@openaccountants.com** — Word doc, Excel, PDF, tracked changes, whatever works
 
 We'll update the skill and credit you publicly as the verified reviewer at [openaccountants.com](https://openaccountants.com).
 
@@ -70,4 +70,4 @@ Or if you're comfortable with GitHub: fork the repo, fix the source file under `
 
 *OpenAccountants — open-source accounting skills for AI*
 *134 countries + 51 US states — [openaccountants.com](https://openaccountants.com)*
-*info@openaaccountants.com*
+*info@openaccountants.com*

--- a/packages/switzerland/README.md
+++ b/packages/switzerland/README.md
@@ -53,7 +53,7 @@ These Switzerland tax skills need your eye. Every rate, threshold, and form refe
 
 1. Download the files in this folder
 2. Check the rates against Eidgenössische Steuerverwaltung (ESTV) / AFC's website
-3. Email your corrections to **info@openaaccountants.com** — Word doc, Excel, PDF, tracked changes, whatever works
+3. Email your corrections to **info@openaccountants.com** — Word doc, Excel, PDF, tracked changes, whatever works
 
 We'll update the skill and credit you publicly as the verified reviewer at [openaccountants.com](https://openaccountants.com).
 
@@ -65,4 +65,4 @@ Or if you're comfortable with GitHub: fork the repo, fix the source file under `
 
 *OpenAccountants — open-source accounting skills for AI*
 *134 countries + 51 US states — [openaccountants.com](https://openaccountants.com)*
-*info@openaaccountants.com*
+*info@openaccountants.com*

--- a/packages/taiwan/README.md
+++ b/packages/taiwan/README.md
@@ -50,7 +50,7 @@ These Taiwan tax skills need your eye. Every rate, threshold, and form reference
 
 1. Download the files in this folder
 2. Check the rates against National Taxation Bureau (國稅局)'s website
-3. Email your corrections to **info@openaaccountants.com** — Word doc, Excel, PDF, tracked changes, whatever works
+3. Email your corrections to **info@openaccountants.com** — Word doc, Excel, PDF, tracked changes, whatever works
 
 We'll update the skill and credit you publicly as the verified reviewer at [openaccountants.com](https://openaccountants.com).
 
@@ -62,4 +62,4 @@ Or if you're comfortable with GitHub: fork the repo, fix the source file under `
 
 *OpenAccountants — open-source accounting skills for AI*
 *134 countries + 51 US states — [openaccountants.com](https://openaccountants.com)*
-*info@openaaccountants.com*
+*info@openaccountants.com*

--- a/packages/tanzania/README.md
+++ b/packages/tanzania/README.md
@@ -42,7 +42,7 @@ These Tanzania tax skills need your eye. Every rate, threshold, and form referen
 
 1. Download the files in this folder
 2. Check the rates against your national tax authority's website
-3. Email your corrections to **info@openaaccountants.com** — Word doc, Excel, PDF, tracked changes, whatever works
+3. Email your corrections to **info@openaccountants.com** — Word doc, Excel, PDF, tracked changes, whatever works
 
 We'll update the skill and credit you publicly as the verified reviewer at [openaccountants.com](https://openaccountants.com).
 
@@ -54,4 +54,4 @@ Or if you're comfortable with GitHub: fork the repo, fix the source file under `
 
 *OpenAccountants — open-source accounting skills for AI*
 *134 countries + 51 US states — [openaccountants.com](https://openaccountants.com)*
-*info@openaaccountants.com*
+*info@openaccountants.com*

--- a/packages/thailand/README.md
+++ b/packages/thailand/README.md
@@ -50,7 +50,7 @@ These Thailand tax skills need your eye. Every rate, threshold, and form referen
 
 1. Download the files in this folder
 2. Check the rates against Revenue Department (กรมสรรพากร)'s website
-3. Email your corrections to **info@openaaccountants.com** — Word doc, Excel, PDF, tracked changes, whatever works
+3. Email your corrections to **info@openaccountants.com** — Word doc, Excel, PDF, tracked changes, whatever works
 
 We'll update the skill and credit you publicly as the verified reviewer at [openaccountants.com](https://openaccountants.com).
 
@@ -62,4 +62,4 @@ Or if you're comfortable with GitHub: fork the repo, fix the source file under `
 
 *OpenAccountants — open-source accounting skills for AI*
 *134 countries + 51 US states — [openaccountants.com](https://openaccountants.com)*
-*info@openaaccountants.com*
+*info@openaccountants.com*

--- a/packages/trinidad-and-tobago/README.md
+++ b/packages/trinidad-and-tobago/README.md
@@ -42,7 +42,7 @@ These Trinidad and Tobago tax skills need your eye. Every rate, threshold, and f
 
 1. Download the files in this folder
 2. Check the rates against your national tax authority's website
-3. Email your corrections to **info@openaaccountants.com** — Word doc, Excel, PDF, tracked changes, whatever works
+3. Email your corrections to **info@openaccountants.com** — Word doc, Excel, PDF, tracked changes, whatever works
 
 We'll update the skill and credit you publicly as the verified reviewer at [openaccountants.com](https://openaccountants.com).
 
@@ -54,4 +54,4 @@ Or if you're comfortable with GitHub: fork the repo, fix the source file under `
 
 *OpenAccountants — open-source accounting skills for AI*
 *134 countries + 51 US states — [openaccountants.com](https://openaccountants.com)*
-*info@openaaccountants.com*
+*info@openaccountants.com*

--- a/packages/tunisia/README.md
+++ b/packages/tunisia/README.md
@@ -42,7 +42,7 @@ These Tunisia tax skills need your eye. Every rate, threshold, and form referenc
 
 1. Download the files in this folder
 2. Check the rates against your national tax authority's website
-3. Email your corrections to **info@openaaccountants.com** — Word doc, Excel, PDF, tracked changes, whatever works
+3. Email your corrections to **info@openaccountants.com** — Word doc, Excel, PDF, tracked changes, whatever works
 
 We'll update the skill and credit you publicly as the verified reviewer at [openaccountants.com](https://openaccountants.com).
 
@@ -54,4 +54,4 @@ Or if you're comfortable with GitHub: fork the repo, fix the source file under `
 
 *OpenAccountants — open-source accounting skills for AI*
 *134 countries + 51 US states — [openaccountants.com](https://openaccountants.com)*
-*info@openaaccountants.com*
+*info@openaccountants.com*

--- a/packages/turkey/README.md
+++ b/packages/turkey/README.md
@@ -50,7 +50,7 @@ These Turkey tax skills need your eye. Every rate, threshold, and form reference
 
 1. Download the files in this folder
 2. Check the rates against Gelir İdaresi Başkanlığı (GİB)'s website
-3. Email your corrections to **info@openaaccountants.com** — Word doc, Excel, PDF, tracked changes, whatever works
+3. Email your corrections to **info@openaccountants.com** — Word doc, Excel, PDF, tracked changes, whatever works
 
 We'll update the skill and credit you publicly as the verified reviewer at [openaccountants.com](https://openaccountants.com).
 
@@ -62,4 +62,4 @@ Or if you're comfortable with GitHub: fork the repo, fix the source file under `
 
 *OpenAccountants — open-source accounting skills for AI*
 *134 countries + 51 US states — [openaccountants.com](https://openaccountants.com)*
-*info@openaaccountants.com*
+*info@openaccountants.com*

--- a/packages/uae/README.md
+++ b/packages/uae/README.md
@@ -49,7 +49,7 @@ These UAE tax skills need your eye. Every rate, threshold, and form reference wa
 
 1. Download the files in this folder
 2. Check the rates against Federal Tax Authority (FTA)'s website
-3. Email your corrections to **info@openaaccountants.com** — Word doc, Excel, PDF, tracked changes, whatever works
+3. Email your corrections to **info@openaccountants.com** — Word doc, Excel, PDF, tracked changes, whatever works
 
 We'll update the skill and credit you publicly as the verified reviewer at [openaccountants.com](https://openaccountants.com).
 
@@ -61,4 +61,4 @@ Or if you're comfortable with GitHub: fork the repo, fix the source file under `
 
 *OpenAccountants — open-source accounting skills for AI*
 *134 countries + 51 US states — [openaccountants.com](https://openaccountants.com)*
-*info@openaaccountants.com*
+*info@openaccountants.com*

--- a/packages/uganda/README.md
+++ b/packages/uganda/README.md
@@ -42,7 +42,7 @@ These Uganda tax skills need your eye. Every rate, threshold, and form reference
 
 1. Download the files in this folder
 2. Check the rates against your national tax authority's website
-3. Email your corrections to **info@openaaccountants.com** — Word doc, Excel, PDF, tracked changes, whatever works
+3. Email your corrections to **info@openaccountants.com** — Word doc, Excel, PDF, tracked changes, whatever works
 
 We'll update the skill and credit you publicly as the verified reviewer at [openaccountants.com](https://openaccountants.com).
 
@@ -54,4 +54,4 @@ Or if you're comfortable with GitHub: fork the repo, fix the source file under `
 
 *OpenAccountants — open-source accounting skills for AI*
 *134 countries + 51 US states — [openaccountants.com](https://openaccountants.com)*
-*info@openaaccountants.com*
+*info@openaccountants.com*

--- a/packages/uk/README.md
+++ b/packages/uk/README.md
@@ -72,7 +72,7 @@ These United Kingdom tax skills need your eye. Every rate, threshold, and form r
 
 1. Download the files in this folder
 2. Check the rates against HM Revenue & Customs (HMRC)'s website
-3. Email your corrections to **info@openaaccountants.com** — Word doc, Excel, PDF, tracked changes, whatever works
+3. Email your corrections to **info@openaccountants.com** — Word doc, Excel, PDF, tracked changes, whatever works
 
 We'll update the skill and credit you publicly as the verified reviewer at [openaccountants.com](https://openaccountants.com).
 
@@ -84,4 +84,4 @@ Or if you're comfortable with GitHub: fork the repo, fix the source file under `
 
 *OpenAccountants — open-source accounting skills for AI*
 *134 countries + 51 US states — [openaccountants.com](https://openaccountants.com)*
-*info@openaaccountants.com*
+*info@openaccountants.com*

--- a/packages/ukraine/README.md
+++ b/packages/ukraine/README.md
@@ -42,7 +42,7 @@ These Ukraine tax skills need your eye. Every rate, threshold, and form referenc
 
 1. Download the files in this folder
 2. Check the rates against your national tax authority's website
-3. Email your corrections to **info@openaaccountants.com** — Word doc, Excel, PDF, tracked changes, whatever works
+3. Email your corrections to **info@openaccountants.com** — Word doc, Excel, PDF, tracked changes, whatever works
 
 We'll update the skill and credit you publicly as the verified reviewer at [openaccountants.com](https://openaccountants.com).
 
@@ -54,4 +54,4 @@ Or if you're comfortable with GitHub: fork the repo, fix the source file under `
 
 *OpenAccountants — open-source accounting skills for AI*
 *134 countries + 51 US states — [openaccountants.com](https://openaccountants.com)*
-*info@openaaccountants.com*
+*info@openaccountants.com*

--- a/packages/uruguay/README.md
+++ b/packages/uruguay/README.md
@@ -42,7 +42,7 @@ These Uruguay tax skills need your eye. Every rate, threshold, and form referenc
 
 1. Download the files in this folder
 2. Check the rates against your national tax authority's website
-3. Email your corrections to **info@openaaccountants.com** — Word doc, Excel, PDF, tracked changes, whatever works
+3. Email your corrections to **info@openaccountants.com** — Word doc, Excel, PDF, tracked changes, whatever works
 
 We'll update the skill and credit you publicly as the verified reviewer at [openaccountants.com](https://openaccountants.com).
 
@@ -54,4 +54,4 @@ Or if you're comfortable with GitHub: fork the repo, fix the source file under `
 
 *OpenAccountants — open-source accounting skills for AI*
 *134 countries + 51 US states — [openaccountants.com](https://openaccountants.com)*
-*info@openaaccountants.com*
+*info@openaccountants.com*

--- a/packages/us-ak/README.md
+++ b/packages/us-ak/README.md
@@ -53,7 +53,7 @@ These Alaska tax skills need your eye. Every rate, threshold, and form reference
 
 1. Download the files in this folder
 2. Check the rates against your state tax authority's website and the IRS
-3. Email your corrections to **info@openaaccountants.com** — Word doc, Excel, PDF, tracked changes, whatever works
+3. Email your corrections to **info@openaccountants.com** — Word doc, Excel, PDF, tracked changes, whatever works
 
 We'll update the skill and credit you publicly as the verified reviewer at [openaccountants.com](https://openaccountants.com).
 
@@ -65,4 +65,4 @@ Or if you're comfortable with GitHub: fork the repo, fix the source under `skill
 
 *OpenAccountants — open-source accounting skills for AI*
 *134 countries + 51 US states — [openaccountants.com](https://openaccountants.com)*
-*info@openaaccountants.com*
+*info@openaccountants.com*

--- a/packages/us-al/README.md
+++ b/packages/us-al/README.md
@@ -55,7 +55,7 @@ These Alabama tax skills need your eye. Every rate, threshold, and form referenc
 
 1. Download the files in this folder
 2. Check the rates against your state tax authority's website and the IRS
-3. Email your corrections to **info@openaaccountants.com** — Word doc, Excel, PDF, tracked changes, whatever works
+3. Email your corrections to **info@openaccountants.com** — Word doc, Excel, PDF, tracked changes, whatever works
 
 We'll update the skill and credit you publicly as the verified reviewer at [openaccountants.com](https://openaccountants.com).
 
@@ -67,4 +67,4 @@ Or if you're comfortable with GitHub: fork the repo, fix the source under `skill
 
 *OpenAccountants — open-source accounting skills for AI*
 *134 countries + 51 US states — [openaccountants.com](https://openaccountants.com)*
-*info@openaaccountants.com*
+*info@openaccountants.com*

--- a/packages/us-ar/README.md
+++ b/packages/us-ar/README.md
@@ -55,7 +55,7 @@ These Arkansas tax skills need your eye. Every rate, threshold, and form referen
 
 1. Download the files in this folder
 2. Check the rates against your state tax authority's website and the IRS
-3. Email your corrections to **info@openaaccountants.com** — Word doc, Excel, PDF, tracked changes, whatever works
+3. Email your corrections to **info@openaccountants.com** — Word doc, Excel, PDF, tracked changes, whatever works
 
 We'll update the skill and credit you publicly as the verified reviewer at [openaccountants.com](https://openaccountants.com).
 
@@ -67,4 +67,4 @@ Or if you're comfortable with GitHub: fork the repo, fix the source under `skill
 
 *OpenAccountants — open-source accounting skills for AI*
 *134 countries + 51 US states — [openaccountants.com](https://openaccountants.com)*
-*info@openaaccountants.com*
+*info@openaccountants.com*

--- a/packages/us-az/README.md
+++ b/packages/us-az/README.md
@@ -55,7 +55,7 @@ These Arizona tax skills need your eye. Every rate, threshold, and form referenc
 
 1. Download the files in this folder
 2. Check the rates against your state tax authority's website and the IRS
-3. Email your corrections to **info@openaaccountants.com** — Word doc, Excel, PDF, tracked changes, whatever works
+3. Email your corrections to **info@openaccountants.com** — Word doc, Excel, PDF, tracked changes, whatever works
 
 We'll update the skill and credit you publicly as the verified reviewer at [openaccountants.com](https://openaccountants.com).
 
@@ -67,4 +67,4 @@ Or if you're comfortable with GitHub: fork the repo, fix the source under `skill
 
 *OpenAccountants — open-source accounting skills for AI*
 *134 countries + 51 US states — [openaccountants.com](https://openaccountants.com)*
-*info@openaaccountants.com*
+*info@openaccountants.com*

--- a/packages/us-ca/README.md
+++ b/packages/us-ca/README.md
@@ -60,7 +60,7 @@ These California tax skills need your eye. Every rate, threshold, and form refer
 
 1. Download the files in this folder
 2. Check the rates against your state tax authority's website and the IRS
-3. Email your corrections to **info@openaaccountants.com** — Word doc, Excel, PDF, tracked changes, whatever works
+3. Email your corrections to **info@openaccountants.com** — Word doc, Excel, PDF, tracked changes, whatever works
 
 We'll update the skill and credit you publicly as the verified reviewer at [openaccountants.com](https://openaccountants.com).
 
@@ -72,4 +72,4 @@ Or if you're comfortable with GitHub: fork the repo, fix the source under `skill
 
 *OpenAccountants — open-source accounting skills for AI*
 *134 countries + 51 US states — [openaccountants.com](https://openaccountants.com)*
-*info@openaaccountants.com*
+*info@openaccountants.com*

--- a/packages/us-co/README.md
+++ b/packages/us-co/README.md
@@ -55,7 +55,7 @@ These Colorado tax skills need your eye. Every rate, threshold, and form referen
 
 1. Download the files in this folder
 2. Check the rates against your state tax authority's website and the IRS
-3. Email your corrections to **info@openaaccountants.com** — Word doc, Excel, PDF, tracked changes, whatever works
+3. Email your corrections to **info@openaccountants.com** — Word doc, Excel, PDF, tracked changes, whatever works
 
 We'll update the skill and credit you publicly as the verified reviewer at [openaccountants.com](https://openaccountants.com).
 
@@ -67,4 +67,4 @@ Or if you're comfortable with GitHub: fork the repo, fix the source under `skill
 
 *OpenAccountants — open-source accounting skills for AI*
 *134 countries + 51 US states — [openaccountants.com](https://openaccountants.com)*
-*info@openaaccountants.com*
+*info@openaccountants.com*

--- a/packages/us-ct/README.md
+++ b/packages/us-ct/README.md
@@ -55,7 +55,7 @@ These Connecticut tax skills need your eye. Every rate, threshold, and form refe
 
 1. Download the files in this folder
 2. Check the rates against your state tax authority's website and the IRS
-3. Email your corrections to **info@openaaccountants.com** — Word doc, Excel, PDF, tracked changes, whatever works
+3. Email your corrections to **info@openaccountants.com** — Word doc, Excel, PDF, tracked changes, whatever works
 
 We'll update the skill and credit you publicly as the verified reviewer at [openaccountants.com](https://openaccountants.com).
 
@@ -67,4 +67,4 @@ Or if you're comfortable with GitHub: fork the repo, fix the source under `skill
 
 *OpenAccountants — open-source accounting skills for AI*
 *134 countries + 51 US states — [openaccountants.com](https://openaccountants.com)*
-*info@openaaccountants.com*
+*info@openaccountants.com*

--- a/packages/us-dc/README.md
+++ b/packages/us-dc/README.md
@@ -55,7 +55,7 @@ These District of Columbia tax skills need your eye. Every rate, threshold, and 
 
 1. Download the files in this folder
 2. Check the rates against your state tax authority's website and the IRS
-3. Email your corrections to **info@openaaccountants.com** — Word doc, Excel, PDF, tracked changes, whatever works
+3. Email your corrections to **info@openaccountants.com** — Word doc, Excel, PDF, tracked changes, whatever works
 
 We'll update the skill and credit you publicly as the verified reviewer at [openaccountants.com](https://openaccountants.com).
 
@@ -67,4 +67,4 @@ Or if you're comfortable with GitHub: fork the repo, fix the source under `skill
 
 *OpenAccountants — open-source accounting skills for AI*
 *134 countries + 51 US states — [openaccountants.com](https://openaccountants.com)*
-*info@openaaccountants.com*
+*info@openaccountants.com*

--- a/packages/us-de/README.md
+++ b/packages/us-de/README.md
@@ -55,7 +55,7 @@ These Delaware tax skills need your eye. Every rate, threshold, and form referen
 
 1. Download the files in this folder
 2. Check the rates against your state tax authority's website and the IRS
-3. Email your corrections to **info@openaaccountants.com** — Word doc, Excel, PDF, tracked changes, whatever works
+3. Email your corrections to **info@openaccountants.com** — Word doc, Excel, PDF, tracked changes, whatever works
 
 We'll update the skill and credit you publicly as the verified reviewer at [openaccountants.com](https://openaccountants.com).
 
@@ -67,4 +67,4 @@ Or if you're comfortable with GitHub: fork the repo, fix the source under `skill
 
 *OpenAccountants — open-source accounting skills for AI*
 *134 countries + 51 US states — [openaccountants.com](https://openaccountants.com)*
-*info@openaaccountants.com*
+*info@openaccountants.com*

--- a/packages/us-fl/README.md
+++ b/packages/us-fl/README.md
@@ -55,7 +55,7 @@ These Florida tax skills need your eye. Every rate, threshold, and form referenc
 
 1. Download the files in this folder
 2. Check the rates against your state tax authority's website and the IRS
-3. Email your corrections to **info@openaaccountants.com** — Word doc, Excel, PDF, tracked changes, whatever works
+3. Email your corrections to **info@openaccountants.com** — Word doc, Excel, PDF, tracked changes, whatever works
 
 We'll update the skill and credit you publicly as the verified reviewer at [openaccountants.com](https://openaccountants.com).
 
@@ -67,4 +67,4 @@ Or if you're comfortable with GitHub: fork the repo, fix the source under `skill
 
 *OpenAccountants — open-source accounting skills for AI*
 *134 countries + 51 US states — [openaccountants.com](https://openaccountants.com)*
-*info@openaaccountants.com*
+*info@openaccountants.com*

--- a/packages/us-ga/README.md
+++ b/packages/us-ga/README.md
@@ -55,7 +55,7 @@ These Georgia tax skills need your eye. Every rate, threshold, and form referenc
 
 1. Download the files in this folder
 2. Check the rates against your state tax authority's website and the IRS
-3. Email your corrections to **info@openaaccountants.com** — Word doc, Excel, PDF, tracked changes, whatever works
+3. Email your corrections to **info@openaccountants.com** — Word doc, Excel, PDF, tracked changes, whatever works
 
 We'll update the skill and credit you publicly as the verified reviewer at [openaccountants.com](https://openaccountants.com).
 
@@ -67,4 +67,4 @@ Or if you're comfortable with GitHub: fork the repo, fix the source under `skill
 
 *OpenAccountants — open-source accounting skills for AI*
 *134 countries + 51 US states — [openaccountants.com](https://openaccountants.com)*
-*info@openaaccountants.com*
+*info@openaccountants.com*

--- a/packages/us-hi/README.md
+++ b/packages/us-hi/README.md
@@ -55,7 +55,7 @@ These Hawaii tax skills need your eye. Every rate, threshold, and form reference
 
 1. Download the files in this folder
 2. Check the rates against your state tax authority's website and the IRS
-3. Email your corrections to **info@openaaccountants.com** — Word doc, Excel, PDF, tracked changes, whatever works
+3. Email your corrections to **info@openaccountants.com** — Word doc, Excel, PDF, tracked changes, whatever works
 
 We'll update the skill and credit you publicly as the verified reviewer at [openaccountants.com](https://openaccountants.com).
 
@@ -67,4 +67,4 @@ Or if you're comfortable with GitHub: fork the repo, fix the source under `skill
 
 *OpenAccountants — open-source accounting skills for AI*
 *134 countries + 51 US states — [openaccountants.com](https://openaccountants.com)*
-*info@openaaccountants.com*
+*info@openaccountants.com*

--- a/packages/us-ia/README.md
+++ b/packages/us-ia/README.md
@@ -55,7 +55,7 @@ These Iowa tax skills need your eye. Every rate, threshold, and form reference w
 
 1. Download the files in this folder
 2. Check the rates against your state tax authority's website and the IRS
-3. Email your corrections to **info@openaaccountants.com** — Word doc, Excel, PDF, tracked changes, whatever works
+3. Email your corrections to **info@openaccountants.com** — Word doc, Excel, PDF, tracked changes, whatever works
 
 We'll update the skill and credit you publicly as the verified reviewer at [openaccountants.com](https://openaccountants.com).
 
@@ -67,4 +67,4 @@ Or if you're comfortable with GitHub: fork the repo, fix the source under `skill
 
 *OpenAccountants — open-source accounting skills for AI*
 *134 countries + 51 US states — [openaccountants.com](https://openaccountants.com)*
-*info@openaaccountants.com*
+*info@openaccountants.com*

--- a/packages/us-id/README.md
+++ b/packages/us-id/README.md
@@ -55,7 +55,7 @@ These Idaho tax skills need your eye. Every rate, threshold, and form reference 
 
 1. Download the files in this folder
 2. Check the rates against your state tax authority's website and the IRS
-3. Email your corrections to **info@openaaccountants.com** — Word doc, Excel, PDF, tracked changes, whatever works
+3. Email your corrections to **info@openaccountants.com** — Word doc, Excel, PDF, tracked changes, whatever works
 
 We'll update the skill and credit you publicly as the verified reviewer at [openaccountants.com](https://openaccountants.com).
 
@@ -67,4 +67,4 @@ Or if you're comfortable with GitHub: fork the repo, fix the source under `skill
 
 *OpenAccountants — open-source accounting skills for AI*
 *134 countries + 51 US states — [openaccountants.com](https://openaccountants.com)*
-*info@openaaccountants.com*
+*info@openaccountants.com*

--- a/packages/us-il/README.md
+++ b/packages/us-il/README.md
@@ -56,7 +56,7 @@ These Illinois tax skills need your eye. Every rate, threshold, and form referen
 
 1. Download the files in this folder
 2. Check the rates against your state tax authority's website and the IRS
-3. Email your corrections to **info@openaaccountants.com** — Word doc, Excel, PDF, tracked changes, whatever works
+3. Email your corrections to **info@openaccountants.com** — Word doc, Excel, PDF, tracked changes, whatever works
 
 We'll update the skill and credit you publicly as the verified reviewer at [openaccountants.com](https://openaccountants.com).
 
@@ -68,4 +68,4 @@ Or if you're comfortable with GitHub: fork the repo, fix the source under `skill
 
 *OpenAccountants — open-source accounting skills for AI*
 *134 countries + 51 US states — [openaccountants.com](https://openaccountants.com)*
-*info@openaaccountants.com*
+*info@openaccountants.com*

--- a/packages/us-in/README.md
+++ b/packages/us-in/README.md
@@ -55,7 +55,7 @@ These Indiana tax skills need your eye. Every rate, threshold, and form referenc
 
 1. Download the files in this folder
 2. Check the rates against your state tax authority's website and the IRS
-3. Email your corrections to **info@openaaccountants.com** — Word doc, Excel, PDF, tracked changes, whatever works
+3. Email your corrections to **info@openaccountants.com** — Word doc, Excel, PDF, tracked changes, whatever works
 
 We'll update the skill and credit you publicly as the verified reviewer at [openaccountants.com](https://openaccountants.com).
 
@@ -67,4 +67,4 @@ Or if you're comfortable with GitHub: fork the repo, fix the source under `skill
 
 *OpenAccountants — open-source accounting skills for AI*
 *134 countries + 51 US states — [openaccountants.com](https://openaccountants.com)*
-*info@openaaccountants.com*
+*info@openaccountants.com*

--- a/packages/us-ks/README.md
+++ b/packages/us-ks/README.md
@@ -55,7 +55,7 @@ These Kansas tax skills need your eye. Every rate, threshold, and form reference
 
 1. Download the files in this folder
 2. Check the rates against your state tax authority's website and the IRS
-3. Email your corrections to **info@openaaccountants.com** — Word doc, Excel, PDF, tracked changes, whatever works
+3. Email your corrections to **info@openaccountants.com** — Word doc, Excel, PDF, tracked changes, whatever works
 
 We'll update the skill and credit you publicly as the verified reviewer at [openaccountants.com](https://openaccountants.com).
 
@@ -67,4 +67,4 @@ Or if you're comfortable with GitHub: fork the repo, fix the source under `skill
 
 *OpenAccountants — open-source accounting skills for AI*
 *134 countries + 51 US states — [openaccountants.com](https://openaccountants.com)*
-*info@openaaccountants.com*
+*info@openaccountants.com*

--- a/packages/us-ky/README.md
+++ b/packages/us-ky/README.md
@@ -55,7 +55,7 @@ These Kentucky tax skills need your eye. Every rate, threshold, and form referen
 
 1. Download the files in this folder
 2. Check the rates against your state tax authority's website and the IRS
-3. Email your corrections to **info@openaaccountants.com** — Word doc, Excel, PDF, tracked changes, whatever works
+3. Email your corrections to **info@openaccountants.com** — Word doc, Excel, PDF, tracked changes, whatever works
 
 We'll update the skill and credit you publicly as the verified reviewer at [openaccountants.com](https://openaccountants.com).
 
@@ -67,4 +67,4 @@ Or if you're comfortable with GitHub: fork the repo, fix the source under `skill
 
 *OpenAccountants — open-source accounting skills for AI*
 *134 countries + 51 US states — [openaccountants.com](https://openaccountants.com)*
-*info@openaaccountants.com*
+*info@openaccountants.com*

--- a/packages/us-la/README.md
+++ b/packages/us-la/README.md
@@ -55,7 +55,7 @@ These Louisiana tax skills need your eye. Every rate, threshold, and form refere
 
 1. Download the files in this folder
 2. Check the rates against your state tax authority's website and the IRS
-3. Email your corrections to **info@openaaccountants.com** — Word doc, Excel, PDF, tracked changes, whatever works
+3. Email your corrections to **info@openaccountants.com** — Word doc, Excel, PDF, tracked changes, whatever works
 
 We'll update the skill and credit you publicly as the verified reviewer at [openaccountants.com](https://openaccountants.com).
 
@@ -67,4 +67,4 @@ Or if you're comfortable with GitHub: fork the repo, fix the source under `skill
 
 *OpenAccountants — open-source accounting skills for AI*
 *134 countries + 51 US states — [openaccountants.com](https://openaccountants.com)*
-*info@openaaccountants.com*
+*info@openaccountants.com*

--- a/packages/us-ma/README.md
+++ b/packages/us-ma/README.md
@@ -55,7 +55,7 @@ These Massachusetts tax skills need your eye. Every rate, threshold, and form re
 
 1. Download the files in this folder
 2. Check the rates against your state tax authority's website and the IRS
-3. Email your corrections to **info@openaaccountants.com** — Word doc, Excel, PDF, tracked changes, whatever works
+3. Email your corrections to **info@openaccountants.com** — Word doc, Excel, PDF, tracked changes, whatever works
 
 We'll update the skill and credit you publicly as the verified reviewer at [openaccountants.com](https://openaccountants.com).
 
@@ -67,4 +67,4 @@ Or if you're comfortable with GitHub: fork the repo, fix the source under `skill
 
 *OpenAccountants — open-source accounting skills for AI*
 *134 countries + 51 US states — [openaccountants.com](https://openaccountants.com)*
-*info@openaaccountants.com*
+*info@openaccountants.com*

--- a/packages/us-md/README.md
+++ b/packages/us-md/README.md
@@ -55,7 +55,7 @@ These Maryland tax skills need your eye. Every rate, threshold, and form referen
 
 1. Download the files in this folder
 2. Check the rates against your state tax authority's website and the IRS
-3. Email your corrections to **info@openaaccountants.com** — Word doc, Excel, PDF, tracked changes, whatever works
+3. Email your corrections to **info@openaccountants.com** — Word doc, Excel, PDF, tracked changes, whatever works
 
 We'll update the skill and credit you publicly as the verified reviewer at [openaccountants.com](https://openaccountants.com).
 
@@ -67,4 +67,4 @@ Or if you're comfortable with GitHub: fork the repo, fix the source under `skill
 
 *OpenAccountants — open-source accounting skills for AI*
 *134 countries + 51 US states — [openaccountants.com](https://openaccountants.com)*
-*info@openaaccountants.com*
+*info@openaccountants.com*

--- a/packages/us-me/README.md
+++ b/packages/us-me/README.md
@@ -55,7 +55,7 @@ These Maine tax skills need your eye. Every rate, threshold, and form reference 
 
 1. Download the files in this folder
 2. Check the rates against your state tax authority's website and the IRS
-3. Email your corrections to **info@openaaccountants.com** — Word doc, Excel, PDF, tracked changes, whatever works
+3. Email your corrections to **info@openaccountants.com** — Word doc, Excel, PDF, tracked changes, whatever works
 
 We'll update the skill and credit you publicly as the verified reviewer at [openaccountants.com](https://openaccountants.com).
 
@@ -67,4 +67,4 @@ Or if you're comfortable with GitHub: fork the repo, fix the source under `skill
 
 *OpenAccountants — open-source accounting skills for AI*
 *134 countries + 51 US states — [openaccountants.com](https://openaccountants.com)*
-*info@openaaccountants.com*
+*info@openaccountants.com*

--- a/packages/us-mi/README.md
+++ b/packages/us-mi/README.md
@@ -55,7 +55,7 @@ These Michigan tax skills need your eye. Every rate, threshold, and form referen
 
 1. Download the files in this folder
 2. Check the rates against your state tax authority's website and the IRS
-3. Email your corrections to **info@openaaccountants.com** — Word doc, Excel, PDF, tracked changes, whatever works
+3. Email your corrections to **info@openaccountants.com** — Word doc, Excel, PDF, tracked changes, whatever works
 
 We'll update the skill and credit you publicly as the verified reviewer at [openaccountants.com](https://openaccountants.com).
 
@@ -67,4 +67,4 @@ Or if you're comfortable with GitHub: fork the repo, fix the source under `skill
 
 *OpenAccountants — open-source accounting skills for AI*
 *134 countries + 51 US states — [openaccountants.com](https://openaccountants.com)*
-*info@openaaccountants.com*
+*info@openaccountants.com*

--- a/packages/us-mn/README.md
+++ b/packages/us-mn/README.md
@@ -55,7 +55,7 @@ These Minnesota tax skills need your eye. Every rate, threshold, and form refere
 
 1. Download the files in this folder
 2. Check the rates against your state tax authority's website and the IRS
-3. Email your corrections to **info@openaaccountants.com** — Word doc, Excel, PDF, tracked changes, whatever works
+3. Email your corrections to **info@openaccountants.com** — Word doc, Excel, PDF, tracked changes, whatever works
 
 We'll update the skill and credit you publicly as the verified reviewer at [openaccountants.com](https://openaccountants.com).
 
@@ -67,4 +67,4 @@ Or if you're comfortable with GitHub: fork the repo, fix the source under `skill
 
 *OpenAccountants — open-source accounting skills for AI*
 *134 countries + 51 US states — [openaccountants.com](https://openaccountants.com)*
-*info@openaaccountants.com*
+*info@openaccountants.com*

--- a/packages/us-mo/README.md
+++ b/packages/us-mo/README.md
@@ -55,7 +55,7 @@ These Missouri tax skills need your eye. Every rate, threshold, and form referen
 
 1. Download the files in this folder
 2. Check the rates against your state tax authority's website and the IRS
-3. Email your corrections to **info@openaaccountants.com** — Word doc, Excel, PDF, tracked changes, whatever works
+3. Email your corrections to **info@openaccountants.com** — Word doc, Excel, PDF, tracked changes, whatever works
 
 We'll update the skill and credit you publicly as the verified reviewer at [openaccountants.com](https://openaccountants.com).
 
@@ -67,4 +67,4 @@ Or if you're comfortable with GitHub: fork the repo, fix the source under `skill
 
 *OpenAccountants — open-source accounting skills for AI*
 *134 countries + 51 US states — [openaccountants.com](https://openaccountants.com)*
-*info@openaaccountants.com*
+*info@openaccountants.com*

--- a/packages/us-ms/README.md
+++ b/packages/us-ms/README.md
@@ -55,7 +55,7 @@ These Mississippi tax skills need your eye. Every rate, threshold, and form refe
 
 1. Download the files in this folder
 2. Check the rates against your state tax authority's website and the IRS
-3. Email your corrections to **info@openaaccountants.com** — Word doc, Excel, PDF, tracked changes, whatever works
+3. Email your corrections to **info@openaccountants.com** — Word doc, Excel, PDF, tracked changes, whatever works
 
 We'll update the skill and credit you publicly as the verified reviewer at [openaccountants.com](https://openaccountants.com).
 
@@ -67,4 +67,4 @@ Or if you're comfortable with GitHub: fork the repo, fix the source under `skill
 
 *OpenAccountants — open-source accounting skills for AI*
 *134 countries + 51 US states — [openaccountants.com](https://openaccountants.com)*
-*info@openaaccountants.com*
+*info@openaccountants.com*

--- a/packages/us-mt/README.md
+++ b/packages/us-mt/README.md
@@ -54,7 +54,7 @@ These Montana tax skills need your eye. Every rate, threshold, and form referenc
 
 1. Download the files in this folder
 2. Check the rates against your state tax authority's website and the IRS
-3. Email your corrections to **info@openaaccountants.com** — Word doc, Excel, PDF, tracked changes, whatever works
+3. Email your corrections to **info@openaccountants.com** — Word doc, Excel, PDF, tracked changes, whatever works
 
 We'll update the skill and credit you publicly as the verified reviewer at [openaccountants.com](https://openaccountants.com).
 
@@ -66,4 +66,4 @@ Or if you're comfortable with GitHub: fork the repo, fix the source under `skill
 
 *OpenAccountants — open-source accounting skills for AI*
 *134 countries + 51 US states — [openaccountants.com](https://openaccountants.com)*
-*info@openaaccountants.com*
+*info@openaccountants.com*

--- a/packages/us-nc/README.md
+++ b/packages/us-nc/README.md
@@ -55,7 +55,7 @@ These North Carolina tax skills need your eye. Every rate, threshold, and form r
 
 1. Download the files in this folder
 2. Check the rates against your state tax authority's website and the IRS
-3. Email your corrections to **info@openaaccountants.com** — Word doc, Excel, PDF, tracked changes, whatever works
+3. Email your corrections to **info@openaccountants.com** — Word doc, Excel, PDF, tracked changes, whatever works
 
 We'll update the skill and credit you publicly as the verified reviewer at [openaccountants.com](https://openaccountants.com).
 
@@ -67,4 +67,4 @@ Or if you're comfortable with GitHub: fork the repo, fix the source under `skill
 
 *OpenAccountants — open-source accounting skills for AI*
 *134 countries + 51 US states — [openaccountants.com](https://openaccountants.com)*
-*info@openaaccountants.com*
+*info@openaccountants.com*

--- a/packages/us-nd/README.md
+++ b/packages/us-nd/README.md
@@ -55,7 +55,7 @@ These North Dakota tax skills need your eye. Every rate, threshold, and form ref
 
 1. Download the files in this folder
 2. Check the rates against your state tax authority's website and the IRS
-3. Email your corrections to **info@openaaccountants.com** — Word doc, Excel, PDF, tracked changes, whatever works
+3. Email your corrections to **info@openaccountants.com** — Word doc, Excel, PDF, tracked changes, whatever works
 
 We'll update the skill and credit you publicly as the verified reviewer at [openaccountants.com](https://openaccountants.com).
 
@@ -67,4 +67,4 @@ Or if you're comfortable with GitHub: fork the repo, fix the source under `skill
 
 *OpenAccountants — open-source accounting skills for AI*
 *134 countries + 51 US states — [openaccountants.com](https://openaccountants.com)*
-*info@openaaccountants.com*
+*info@openaccountants.com*

--- a/packages/us-ne/README.md
+++ b/packages/us-ne/README.md
@@ -55,7 +55,7 @@ These Nebraska tax skills need your eye. Every rate, threshold, and form referen
 
 1. Download the files in this folder
 2. Check the rates against your state tax authority's website and the IRS
-3. Email your corrections to **info@openaaccountants.com** — Word doc, Excel, PDF, tracked changes, whatever works
+3. Email your corrections to **info@openaccountants.com** — Word doc, Excel, PDF, tracked changes, whatever works
 
 We'll update the skill and credit you publicly as the verified reviewer at [openaccountants.com](https://openaccountants.com).
 
@@ -67,4 +67,4 @@ Or if you're comfortable with GitHub: fork the repo, fix the source under `skill
 
 *OpenAccountants — open-source accounting skills for AI*
 *134 countries + 51 US states — [openaccountants.com](https://openaccountants.com)*
-*info@openaaccountants.com*
+*info@openaccountants.com*

--- a/packages/us-nh/README.md
+++ b/packages/us-nh/README.md
@@ -54,7 +54,7 @@ These New Hampshire tax skills need your eye. Every rate, threshold, and form re
 
 1. Download the files in this folder
 2. Check the rates against your state tax authority's website and the IRS
-3. Email your corrections to **info@openaaccountants.com** — Word doc, Excel, PDF, tracked changes, whatever works
+3. Email your corrections to **info@openaccountants.com** — Word doc, Excel, PDF, tracked changes, whatever works
 
 We'll update the skill and credit you publicly as the verified reviewer at [openaccountants.com](https://openaccountants.com).
 
@@ -66,4 +66,4 @@ Or if you're comfortable with GitHub: fork the repo, fix the source under `skill
 
 *OpenAccountants — open-source accounting skills for AI*
 *134 countries + 51 US states — [openaccountants.com](https://openaccountants.com)*
-*info@openaaccountants.com*
+*info@openaccountants.com*

--- a/packages/us-nj/README.md
+++ b/packages/us-nj/README.md
@@ -55,7 +55,7 @@ These New Jersey tax skills need your eye. Every rate, threshold, and form refer
 
 1. Download the files in this folder
 2. Check the rates against your state tax authority's website and the IRS
-3. Email your corrections to **info@openaaccountants.com** — Word doc, Excel, PDF, tracked changes, whatever works
+3. Email your corrections to **info@openaccountants.com** — Word doc, Excel, PDF, tracked changes, whatever works
 
 We'll update the skill and credit you publicly as the verified reviewer at [openaccountants.com](https://openaccountants.com).
 
@@ -67,4 +67,4 @@ Or if you're comfortable with GitHub: fork the repo, fix the source under `skill
 
 *OpenAccountants — open-source accounting skills for AI*
 *134 countries + 51 US states — [openaccountants.com](https://openaccountants.com)*
-*info@openaaccountants.com*
+*info@openaccountants.com*

--- a/packages/us-nm/README.md
+++ b/packages/us-nm/README.md
@@ -55,7 +55,7 @@ These New Mexico tax skills need your eye. Every rate, threshold, and form refer
 
 1. Download the files in this folder
 2. Check the rates against your state tax authority's website and the IRS
-3. Email your corrections to **info@openaaccountants.com** — Word doc, Excel, PDF, tracked changes, whatever works
+3. Email your corrections to **info@openaccountants.com** — Word doc, Excel, PDF, tracked changes, whatever works
 
 We'll update the skill and credit you publicly as the verified reviewer at [openaccountants.com](https://openaccountants.com).
 
@@ -67,4 +67,4 @@ Or if you're comfortable with GitHub: fork the repo, fix the source under `skill
 
 *OpenAccountants — open-source accounting skills for AI*
 *134 countries + 51 US states — [openaccountants.com](https://openaccountants.com)*
-*info@openaaccountants.com*
+*info@openaccountants.com*

--- a/packages/us-nv/README.md
+++ b/packages/us-nv/README.md
@@ -55,7 +55,7 @@ These Nevada tax skills need your eye. Every rate, threshold, and form reference
 
 1. Download the files in this folder
 2. Check the rates against your state tax authority's website and the IRS
-3. Email your corrections to **info@openaaccountants.com** — Word doc, Excel, PDF, tracked changes, whatever works
+3. Email your corrections to **info@openaccountants.com** — Word doc, Excel, PDF, tracked changes, whatever works
 
 We'll update the skill and credit you publicly as the verified reviewer at [openaccountants.com](https://openaccountants.com).
 
@@ -67,4 +67,4 @@ Or if you're comfortable with GitHub: fork the repo, fix the source under `skill
 
 *OpenAccountants — open-source accounting skills for AI*
 *134 countries + 51 US states — [openaccountants.com](https://openaccountants.com)*
-*info@openaaccountants.com*
+*info@openaccountants.com*

--- a/packages/us-ny/README.md
+++ b/packages/us-ny/README.md
@@ -60,7 +60,7 @@ These New York tax skills need your eye. Every rate, threshold, and form referen
 
 1. Download the files in this folder
 2. Check the rates against your state tax authority's website and the IRS
-3. Email your corrections to **info@openaaccountants.com** — Word doc, Excel, PDF, tracked changes, whatever works
+3. Email your corrections to **info@openaccountants.com** — Word doc, Excel, PDF, tracked changes, whatever works
 
 We'll update the skill and credit you publicly as the verified reviewer at [openaccountants.com](https://openaccountants.com).
 
@@ -72,4 +72,4 @@ Or if you're comfortable with GitHub: fork the repo, fix the source under `skill
 
 *OpenAccountants — open-source accounting skills for AI*
 *134 countries + 51 US states — [openaccountants.com](https://openaccountants.com)*
-*info@openaaccountants.com*
+*info@openaccountants.com*

--- a/packages/us-oh/README.md
+++ b/packages/us-oh/README.md
@@ -56,7 +56,7 @@ These Ohio tax skills need your eye. Every rate, threshold, and form reference w
 
 1. Download the files in this folder
 2. Check the rates against your state tax authority's website and the IRS
-3. Email your corrections to **info@openaaccountants.com** — Word doc, Excel, PDF, tracked changes, whatever works
+3. Email your corrections to **info@openaccountants.com** — Word doc, Excel, PDF, tracked changes, whatever works
 
 We'll update the skill and credit you publicly as the verified reviewer at [openaccountants.com](https://openaccountants.com).
 
@@ -68,4 +68,4 @@ Or if you're comfortable with GitHub: fork the repo, fix the source under `skill
 
 *OpenAccountants — open-source accounting skills for AI*
 *134 countries + 51 US states — [openaccountants.com](https://openaccountants.com)*
-*info@openaaccountants.com*
+*info@openaccountants.com*

--- a/packages/us-ok/README.md
+++ b/packages/us-ok/README.md
@@ -55,7 +55,7 @@ These Oklahoma tax skills need your eye. Every rate, threshold, and form referen
 
 1. Download the files in this folder
 2. Check the rates against your state tax authority's website and the IRS
-3. Email your corrections to **info@openaaccountants.com** — Word doc, Excel, PDF, tracked changes, whatever works
+3. Email your corrections to **info@openaccountants.com** — Word doc, Excel, PDF, tracked changes, whatever works
 
 We'll update the skill and credit you publicly as the verified reviewer at [openaccountants.com](https://openaccountants.com).
 
@@ -67,4 +67,4 @@ Or if you're comfortable with GitHub: fork the repo, fix the source under `skill
 
 *OpenAccountants — open-source accounting skills for AI*
 *134 countries + 51 US states — [openaccountants.com](https://openaccountants.com)*
-*info@openaaccountants.com*
+*info@openaccountants.com*

--- a/packages/us-or/README.md
+++ b/packages/us-or/README.md
@@ -54,7 +54,7 @@ These Oregon tax skills need your eye. Every rate, threshold, and form reference
 
 1. Download the files in this folder
 2. Check the rates against your state tax authority's website and the IRS
-3. Email your corrections to **info@openaaccountants.com** — Word doc, Excel, PDF, tracked changes, whatever works
+3. Email your corrections to **info@openaccountants.com** — Word doc, Excel, PDF, tracked changes, whatever works
 
 We'll update the skill and credit you publicly as the verified reviewer at [openaccountants.com](https://openaccountants.com).
 
@@ -66,4 +66,4 @@ Or if you're comfortable with GitHub: fork the repo, fix the source under `skill
 
 *OpenAccountants — open-source accounting skills for AI*
 *134 countries + 51 US states — [openaccountants.com](https://openaccountants.com)*
-*info@openaaccountants.com*
+*info@openaccountants.com*

--- a/packages/us-pa/README.md
+++ b/packages/us-pa/README.md
@@ -55,7 +55,7 @@ These Pennsylvania tax skills need your eye. Every rate, threshold, and form ref
 
 1. Download the files in this folder
 2. Check the rates against your state tax authority's website and the IRS
-3. Email your corrections to **info@openaaccountants.com** — Word doc, Excel, PDF, tracked changes, whatever works
+3. Email your corrections to **info@openaccountants.com** — Word doc, Excel, PDF, tracked changes, whatever works
 
 We'll update the skill and credit you publicly as the verified reviewer at [openaccountants.com](https://openaccountants.com).
 
@@ -67,4 +67,4 @@ Or if you're comfortable with GitHub: fork the repo, fix the source under `skill
 
 *OpenAccountants — open-source accounting skills for AI*
 *134 countries + 51 US states — [openaccountants.com](https://openaccountants.com)*
-*info@openaaccountants.com*
+*info@openaccountants.com*

--- a/packages/us-ri/README.md
+++ b/packages/us-ri/README.md
@@ -55,7 +55,7 @@ These Rhode Island tax skills need your eye. Every rate, threshold, and form ref
 
 1. Download the files in this folder
 2. Check the rates against your state tax authority's website and the IRS
-3. Email your corrections to **info@openaaccountants.com** — Word doc, Excel, PDF, tracked changes, whatever works
+3. Email your corrections to **info@openaccountants.com** — Word doc, Excel, PDF, tracked changes, whatever works
 
 We'll update the skill and credit you publicly as the verified reviewer at [openaccountants.com](https://openaccountants.com).
 
@@ -67,4 +67,4 @@ Or if you're comfortable with GitHub: fork the repo, fix the source under `skill
 
 *OpenAccountants — open-source accounting skills for AI*
 *134 countries + 51 US states — [openaccountants.com](https://openaccountants.com)*
-*info@openaaccountants.com*
+*info@openaccountants.com*

--- a/packages/us-sc/README.md
+++ b/packages/us-sc/README.md
@@ -55,7 +55,7 @@ These South Carolina tax skills need your eye. Every rate, threshold, and form r
 
 1. Download the files in this folder
 2. Check the rates against your state tax authority's website and the IRS
-3. Email your corrections to **info@openaaccountants.com** — Word doc, Excel, PDF, tracked changes, whatever works
+3. Email your corrections to **info@openaccountants.com** — Word doc, Excel, PDF, tracked changes, whatever works
 
 We'll update the skill and credit you publicly as the verified reviewer at [openaccountants.com](https://openaccountants.com).
 
@@ -67,4 +67,4 @@ Or if you're comfortable with GitHub: fork the repo, fix the source under `skill
 
 *OpenAccountants — open-source accounting skills for AI*
 *134 countries + 51 US states — [openaccountants.com](https://openaccountants.com)*
-*info@openaaccountants.com*
+*info@openaccountants.com*

--- a/packages/us-sd/README.md
+++ b/packages/us-sd/README.md
@@ -54,7 +54,7 @@ These South Dakota tax skills need your eye. Every rate, threshold, and form ref
 
 1. Download the files in this folder
 2. Check the rates against your state tax authority's website and the IRS
-3. Email your corrections to **info@openaaccountants.com** — Word doc, Excel, PDF, tracked changes, whatever works
+3. Email your corrections to **info@openaccountants.com** — Word doc, Excel, PDF, tracked changes, whatever works
 
 We'll update the skill and credit you publicly as the verified reviewer at [openaccountants.com](https://openaccountants.com).
 
@@ -66,4 +66,4 @@ Or if you're comfortable with GitHub: fork the repo, fix the source under `skill
 
 *OpenAccountants — open-source accounting skills for AI*
 *134 countries + 51 US states — [openaccountants.com](https://openaccountants.com)*
-*info@openaaccountants.com*
+*info@openaccountants.com*

--- a/packages/us-tn/README.md
+++ b/packages/us-tn/README.md
@@ -54,7 +54,7 @@ These Tennessee tax skills need your eye. Every rate, threshold, and form refere
 
 1. Download the files in this folder
 2. Check the rates against your state tax authority's website and the IRS
-3. Email your corrections to **info@openaaccountants.com** — Word doc, Excel, PDF, tracked changes, whatever works
+3. Email your corrections to **info@openaccountants.com** — Word doc, Excel, PDF, tracked changes, whatever works
 
 We'll update the skill and credit you publicly as the verified reviewer at [openaccountants.com](https://openaccountants.com).
 
@@ -66,4 +66,4 @@ Or if you're comfortable with GitHub: fork the repo, fix the source under `skill
 
 *OpenAccountants — open-source accounting skills for AI*
 *134 countries + 51 US states — [openaccountants.com](https://openaccountants.com)*
-*info@openaaccountants.com*
+*info@openaccountants.com*

--- a/packages/us-tx/README.md
+++ b/packages/us-tx/README.md
@@ -57,7 +57,7 @@ These Texas tax skills need your eye. Every rate, threshold, and form reference 
 
 1. Download the files in this folder
 2. Check the rates against your state tax authority's website and the IRS
-3. Email your corrections to **info@openaaccountants.com** — Word doc, Excel, PDF, tracked changes, whatever works
+3. Email your corrections to **info@openaccountants.com** — Word doc, Excel, PDF, tracked changes, whatever works
 
 We'll update the skill and credit you publicly as the verified reviewer at [openaccountants.com](https://openaccountants.com).
 
@@ -69,4 +69,4 @@ Or if you're comfortable with GitHub: fork the repo, fix the source under `skill
 
 *OpenAccountants — open-source accounting skills for AI*
 *134 countries + 51 US states — [openaccountants.com](https://openaccountants.com)*
-*info@openaaccountants.com*
+*info@openaccountants.com*

--- a/packages/us-ut/README.md
+++ b/packages/us-ut/README.md
@@ -55,7 +55,7 @@ These Utah tax skills need your eye. Every rate, threshold, and form reference w
 
 1. Download the files in this folder
 2. Check the rates against your state tax authority's website and the IRS
-3. Email your corrections to **info@openaaccountants.com** — Word doc, Excel, PDF, tracked changes, whatever works
+3. Email your corrections to **info@openaccountants.com** — Word doc, Excel, PDF, tracked changes, whatever works
 
 We'll update the skill and credit you publicly as the verified reviewer at [openaccountants.com](https://openaccountants.com).
 
@@ -67,4 +67,4 @@ Or if you're comfortable with GitHub: fork the repo, fix the source under `skill
 
 *OpenAccountants — open-source accounting skills for AI*
 *134 countries + 51 US states — [openaccountants.com](https://openaccountants.com)*
-*info@openaaccountants.com*
+*info@openaccountants.com*

--- a/packages/us-va/README.md
+++ b/packages/us-va/README.md
@@ -55,7 +55,7 @@ These Virginia tax skills need your eye. Every rate, threshold, and form referen
 
 1. Download the files in this folder
 2. Check the rates against your state tax authority's website and the IRS
-3. Email your corrections to **info@openaaccountants.com** — Word doc, Excel, PDF, tracked changes, whatever works
+3. Email your corrections to **info@openaccountants.com** — Word doc, Excel, PDF, tracked changes, whatever works
 
 We'll update the skill and credit you publicly as the verified reviewer at [openaccountants.com](https://openaccountants.com).
 
@@ -67,4 +67,4 @@ Or if you're comfortable with GitHub: fork the repo, fix the source under `skill
 
 *OpenAccountants — open-source accounting skills for AI*
 *134 countries + 51 US states — [openaccountants.com](https://openaccountants.com)*
-*info@openaaccountants.com*
+*info@openaccountants.com*

--- a/packages/us-vt/README.md
+++ b/packages/us-vt/README.md
@@ -55,7 +55,7 @@ These Vermont tax skills need your eye. Every rate, threshold, and form referenc
 
 1. Download the files in this folder
 2. Check the rates against your state tax authority's website and the IRS
-3. Email your corrections to **info@openaaccountants.com** — Word doc, Excel, PDF, tracked changes, whatever works
+3. Email your corrections to **info@openaccountants.com** — Word doc, Excel, PDF, tracked changes, whatever works
 
 We'll update the skill and credit you publicly as the verified reviewer at [openaccountants.com](https://openaccountants.com).
 
@@ -67,4 +67,4 @@ Or if you're comfortable with GitHub: fork the repo, fix the source under `skill
 
 *OpenAccountants — open-source accounting skills for AI*
 *134 countries + 51 US states — [openaccountants.com](https://openaccountants.com)*
-*info@openaaccountants.com*
+*info@openaccountants.com*

--- a/packages/us-wa/README.md
+++ b/packages/us-wa/README.md
@@ -55,7 +55,7 @@ These Washington tax skills need your eye. Every rate, threshold, and form refer
 
 1. Download the files in this folder
 2. Check the rates against your state tax authority's website and the IRS
-3. Email your corrections to **info@openaaccountants.com** — Word doc, Excel, PDF, tracked changes, whatever works
+3. Email your corrections to **info@openaccountants.com** — Word doc, Excel, PDF, tracked changes, whatever works
 
 We'll update the skill and credit you publicly as the verified reviewer at [openaccountants.com](https://openaccountants.com).
 
@@ -67,4 +67,4 @@ Or if you're comfortable with GitHub: fork the repo, fix the source under `skill
 
 *OpenAccountants — open-source accounting skills for AI*
 *134 countries + 51 US states — [openaccountants.com](https://openaccountants.com)*
-*info@openaaccountants.com*
+*info@openaccountants.com*

--- a/packages/us-wi/README.md
+++ b/packages/us-wi/README.md
@@ -55,7 +55,7 @@ These Wisconsin tax skills need your eye. Every rate, threshold, and form refere
 
 1. Download the files in this folder
 2. Check the rates against your state tax authority's website and the IRS
-3. Email your corrections to **info@openaaccountants.com** — Word doc, Excel, PDF, tracked changes, whatever works
+3. Email your corrections to **info@openaccountants.com** — Word doc, Excel, PDF, tracked changes, whatever works
 
 We'll update the skill and credit you publicly as the verified reviewer at [openaccountants.com](https://openaccountants.com).
 
@@ -67,4 +67,4 @@ Or if you're comfortable with GitHub: fork the repo, fix the source under `skill
 
 *OpenAccountants — open-source accounting skills for AI*
 *134 countries + 51 US states — [openaccountants.com](https://openaccountants.com)*
-*info@openaaccountants.com*
+*info@openaccountants.com*

--- a/packages/us-wv/README.md
+++ b/packages/us-wv/README.md
@@ -55,7 +55,7 @@ These West Virginia tax skills need your eye. Every rate, threshold, and form re
 
 1. Download the files in this folder
 2. Check the rates against your state tax authority's website and the IRS
-3. Email your corrections to **info@openaaccountants.com** — Word doc, Excel, PDF, tracked changes, whatever works
+3. Email your corrections to **info@openaccountants.com** — Word doc, Excel, PDF, tracked changes, whatever works
 
 We'll update the skill and credit you publicly as the verified reviewer at [openaccountants.com](https://openaccountants.com).
 
@@ -67,4 +67,4 @@ Or if you're comfortable with GitHub: fork the repo, fix the source under `skill
 
 *OpenAccountants — open-source accounting skills for AI*
 *134 countries + 51 US states — [openaccountants.com](https://openaccountants.com)*
-*info@openaaccountants.com*
+*info@openaccountants.com*

--- a/packages/us-wy/README.md
+++ b/packages/us-wy/README.md
@@ -54,7 +54,7 @@ These Wyoming tax skills need your eye. Every rate, threshold, and form referenc
 
 1. Download the files in this folder
 2. Check the rates against your state tax authority's website and the IRS
-3. Email your corrections to **info@openaaccountants.com** — Word doc, Excel, PDF, tracked changes, whatever works
+3. Email your corrections to **info@openaccountants.com** — Word doc, Excel, PDF, tracked changes, whatever works
 
 We'll update the skill and credit you publicly as the verified reviewer at [openaccountants.com](https://openaccountants.com).
 
@@ -66,4 +66,4 @@ Or if you're comfortable with GitHub: fork the repo, fix the source under `skill
 
 *OpenAccountants — open-source accounting skills for AI*
 *134 countries + 51 US states — [openaccountants.com](https://openaccountants.com)*
-*info@openaaccountants.com*
+*info@openaccountants.com*

--- a/packages/uzbekistan/README.md
+++ b/packages/uzbekistan/README.md
@@ -42,7 +42,7 @@ These Uzbekistan tax skills need your eye. Every rate, threshold, and form refer
 
 1. Download the files in this folder
 2. Check the rates against your national tax authority's website
-3. Email your corrections to **info@openaaccountants.com** — Word doc, Excel, PDF, tracked changes, whatever works
+3. Email your corrections to **info@openaccountants.com** — Word doc, Excel, PDF, tracked changes, whatever works
 
 We'll update the skill and credit you publicly as the verified reviewer at [openaccountants.com](https://openaccountants.com).
 
@@ -54,4 +54,4 @@ Or if you're comfortable with GitHub: fork the repo, fix the source file under `
 
 *OpenAccountants — open-source accounting skills for AI*
 *134 countries + 51 US states — [openaccountants.com](https://openaccountants.com)*
-*info@openaaccountants.com*
+*info@openaccountants.com*

--- a/packages/venezuela/README.md
+++ b/packages/venezuela/README.md
@@ -42,7 +42,7 @@ These Venezuela tax skills need your eye. Every rate, threshold, and form refere
 
 1. Download the files in this folder
 2. Check the rates against your national tax authority's website
-3. Email your corrections to **info@openaaccountants.com** — Word doc, Excel, PDF, tracked changes, whatever works
+3. Email your corrections to **info@openaccountants.com** — Word doc, Excel, PDF, tracked changes, whatever works
 
 We'll update the skill and credit you publicly as the verified reviewer at [openaccountants.com](https://openaccountants.com).
 
@@ -54,4 +54,4 @@ Or if you're comfortable with GitHub: fork the repo, fix the source file under `
 
 *OpenAccountants — open-source accounting skills for AI*
 *134 countries + 51 US states — [openaccountants.com](https://openaccountants.com)*
-*info@openaaccountants.com*
+*info@openaccountants.com*

--- a/packages/vietnam/README.md
+++ b/packages/vietnam/README.md
@@ -50,7 +50,7 @@ These Vietnam tax skills need your eye. Every rate, threshold, and form referenc
 
 1. Download the files in this folder
 2. Check the rates against General Department of Taxation's website
-3. Email your corrections to **info@openaaccountants.com** — Word doc, Excel, PDF, tracked changes, whatever works
+3. Email your corrections to **info@openaccountants.com** — Word doc, Excel, PDF, tracked changes, whatever works
 
 We'll update the skill and credit you publicly as the verified reviewer at [openaccountants.com](https://openaccountants.com).
 
@@ -62,4 +62,4 @@ Or if you're comfortable with GitHub: fork the repo, fix the source file under `
 
 *OpenAccountants — open-source accounting skills for AI*
 *134 countries + 51 US states — [openaccountants.com](https://openaccountants.com)*
-*info@openaaccountants.com*
+*info@openaccountants.com*

--- a/packages/zambia/README.md
+++ b/packages/zambia/README.md
@@ -42,7 +42,7 @@ These Zambia tax skills need your eye. Every rate, threshold, and form reference
 
 1. Download the files in this folder
 2. Check the rates against your national tax authority's website
-3. Email your corrections to **info@openaaccountants.com** — Word doc, Excel, PDF, tracked changes, whatever works
+3. Email your corrections to **info@openaccountants.com** — Word doc, Excel, PDF, tracked changes, whatever works
 
 We'll update the skill and credit you publicly as the verified reviewer at [openaccountants.com](https://openaccountants.com).
 
@@ -54,4 +54,4 @@ Or if you're comfortable with GitHub: fork the repo, fix the source file under `
 
 *OpenAccountants — open-source accounting skills for AI*
 *134 countries + 51 US states — [openaccountants.com](https://openaccountants.com)*
-*info@openaaccountants.com*
+*info@openaccountants.com*

--- a/packages/zimbabwe/README.md
+++ b/packages/zimbabwe/README.md
@@ -42,7 +42,7 @@ These Zimbabwe tax skills need your eye. Every rate, threshold, and form referen
 
 1. Download the files in this folder
 2. Check the rates against your national tax authority's website
-3. Email your corrections to **info@openaaccountants.com** — Word doc, Excel, PDF, tracked changes, whatever works
+3. Email your corrections to **info@openaccountants.com** — Word doc, Excel, PDF, tracked changes, whatever works
 
 We'll update the skill and credit you publicly as the verified reviewer at [openaccountants.com](https://openaccountants.com).
 
@@ -54,4 +54,4 @@ Or if you're comfortable with GitHub: fork the repo, fix the source file under `
 
 *OpenAccountants — open-source accounting skills for AI*
 *134 countries + 51 US states — [openaccountants.com](https://openaccountants.com)*
-*info@openaaccountants.com*
+*info@openaccountants.com*

--- a/scripts/build-packages.py
+++ b/scripts/build-packages.py
@@ -444,7 +444,7 @@ These {country_name} tax skills need your eye. Every rate, threshold, and form r
 
 1. Download the files in this folder
 2. Check the rates against {tax_authority}'s website
-3. Email your corrections to **info@openaaccountants.com** — Word doc, Excel, PDF, tracked changes, whatever works
+3. Email your corrections to **info@openaccountants.com** — Word doc, Excel, PDF, tracked changes, whatever works
 
 We'll update the skill and credit you publicly as the verified reviewer at [openaccountants.com](https://openaccountants.com).
 
@@ -456,7 +456,7 @@ Or if you're comfortable with GitHub: fork the repo, fix the source file under `
 
 *OpenAccountants — open-source accounting skills for AI*
 *134 countries + 51 US states — [openaccountants.com](https://openaccountants.com)*
-*info@openaaccountants.com*
+*info@openaccountants.com*
 """
 
 
@@ -694,7 +694,7 @@ These {state_name} tax skills need your eye. Every rate, threshold, and form ref
 
 1. Download the files in this folder
 2. Check the rates against your state tax authority's website and the IRS
-3. Email your corrections to **info@openaaccountants.com** — Word doc, Excel, PDF, tracked changes, whatever works
+3. Email your corrections to **info@openaccountants.com** — Word doc, Excel, PDF, tracked changes, whatever works
 
 We'll update the skill and credit you publicly as the verified reviewer at [openaccountants.com](https://openaccountants.com).
 
@@ -706,7 +706,7 @@ Or if you're comfortable with GitHub: fork the repo, fix the source under `skill
 
 *OpenAccountants — open-source accounting skills for AI*
 *134 countries + 51 US states — [openaccountants.com](https://openaccountants.com)*
-*info@openaaccountants.com*
+*info@openaccountants.com*
 """
 
 
@@ -864,7 +864,7 @@ These {province_name} tax skills need your eye. Every rate, threshold, and form 
 
 1. Download the files in this folder
 2. Check the rates against the CRA and your provincial/territorial finance department
-3. Email your corrections to **info@openaaccountants.com** — Word doc, Excel, PDF, tracked changes, whatever works
+3. Email your corrections to **info@openaccountants.com** — Word doc, Excel, PDF, tracked changes, whatever works
 
 We'll update the skill and credit you publicly as the verified reviewer at [openaccountants.com](https://openaccountants.com).
 
@@ -876,7 +876,7 @@ Or if you're comfortable with GitHub: fork the repo, fix the source under `skill
 
 *OpenAccountants — open-source accounting skills for AI*
 *134 countries + 51 US states + 13 Canadian provinces/territories — [openaccountants.com](https://openaccountants.com)*
-*info@openaaccountants.com*
+*info@openaccountants.com*
 """
 
 

--- a/skills/cross-border/cross-border-vat-gst.md
+++ b/skills/cross-border/cross-border-vat-gst.md
@@ -317,4 +317,4 @@ If earning across multiple platforms (YouTube, Patreon, Substack, Gumroad), **ag
 
 *Data reflects 2024–2026 rules. VAT/GST thresholds, rates, and registration requirements change frequently. Verify all figures with official sources and a qualified indirect tax advisor.*
 *Original content: [Artin (@ar-gen-tin)](https://github.com/ar-gen-tin/panrise) — MIT License.*
-*OpenAccountants — open-source accounting skills for AI — info@openaaccountants.com*
+*OpenAccountants — open-source accounting skills for AI — info@openaccountants.com*

--- a/skills/cross-border/forex-controls.md
+++ b/skills/cross-border/forex-controls.md
@@ -317,4 +317,4 @@ When receiving a CRS inquiry letter from Chinese tax authorities:
 
 *Data reflects 2024–2026 rules. Forex regulations are enforced with increasing rigor worldwide. Verify current limits and procedures with your bank and a qualified advisor before large cross-border transfers.*
 *Original content: [Artin (@ar-gen-tin)](https://github.com/ar-gen-tin/panrise) — MIT License.*
-*OpenAccountants — open-source accounting skills for AI — info@openaaccountants.com*
+*OpenAccountants — open-source accounting skills for AI — info@openaccountants.com*

--- a/skills/cross-border/international-incorporation.md
+++ b/skills/cross-border/international-incorporation.md
@@ -303,4 +303,4 @@ Every LLC — even single-member — needs an operating agreement covering:
 
 *Data reflects 2024–2026 rules. For amounts >$100,000 USD or life-changing decisions, verify current rules with a qualified advisor in each relevant jurisdiction.*
 *Original content: [Artin (@ar-gen-tin)](https://github.com/ar-gen-tin/panrise) — MIT License.*
-*OpenAccountants — open-source accounting skills for AI — info@openaaccountants.com*
+*OpenAccountants — open-source accounting skills for AI — info@openaccountants.com*

--- a/skills/cross-border/tax-residency-planning.md
+++ b/skills/cross-border/tax-residency-planning.md
@@ -287,4 +287,4 @@ Five "flags" that do NOT need to be in the same country:
 
 *Data reflects 2024–2026 rules. Tax residency changes are high-stakes decisions — verify all rules with a qualified cross-border tax advisor before acting.*
 *Original content: [Artin (@ar-gen-tin)](https://github.com/ar-gen-tin/panrise) — MIT License.*
-*OpenAccountants — open-source accounting skills for AI — info@openaaccountants.com*
+*OpenAccountants — open-source accounting skills for AI — info@openaccountants.com*


### PR DESCRIPTION
## Why
Cleanup pass after an external audit of the repo's trust signals.

## Changes
**1. Contact-email typo (highest impact)** — `info@openaaccountants.com` (double-a) appeared **787 times** vs the correct address 12 times. It was seeded by `scripts/build-packages.py` and stamped into every generated package. Fixed at the source + across all docs and packages (199 files).

**2. Reconcile coverage numbers** — surfaces disagreed (About: 133 countries; README: 890+ skills / 134 countries; release: 482 skills; website: 192 jurisdictions). Anchored to the production DB:
- **1,098 published skills** — 85 accountant-verified + 1,013 research-verified — across **192 jurisdictions**.
- README headline updated; new `docs/COVERAGE.md` is the single source of truth all surfaces should match.

**3. Fix the verification overclaim** — 'verified by accountants' → **'research-verified here, accountant-verified via MCP'** (most repo skills are research-verified; Tier-1 lives behind the MCP).

**4. Proof docs** — `docs/COVERAGE.md`, `docs/VERIFIERS.md`, `docs/ACCURACY-METHODOLOGY.md`, `docs/EXAMPLE-WORKING-PAPERS.md`.

**5. Example prompts** — added cross-border / scenario prompts to the README.

The repo About description and 4 contributor issues were updated separately.