### PR TITLE
Fix verifier list: remove Kenya (erroneous tier-1 promotion), add ID/…

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,8 +51,8 @@ AI:     Entity type comparison (Ltd vs partnership vs sole trader)
 
 ---
 
-**Verified accountants on the network:**
-Werner Britz CA(SA) · Michael Cutajar CPA (Malta) · Ariane Marrocos CRC/SP · James Power (UK) · Mayur Deokar CA (India)
+**Verified accountants:**
+Werner Britz CA(SA) · Michael Cutajar CPA (Malta) · Ariane Marrocos CRC/SP · James Power (UK) · Mayur Deokar CA (India) · Rilia Putri CA (Indonesia) · Ashish Bista CA (Nepal) · Mário Vale CA (Portugal) · Mehran Habib (Saudi Arabia) · Amir Pelinkovic CPA (US)
 
 ---
 
@@ -118,14 +118,19 @@ The AI asks a few questions, loads the right skills, and produces a working pape
 
 These licensed practitioners have reviewed and signed off skills for their jurisdictions. Their name appears on every answer the AI gives.
 
-| Jurisdiction | Verifier | Profile |
-|---|---|---|
-| South Africa | Werner Britz CA(SA) | [openaccountants.com/network](https://www.openaccountants.com/network/28a3ec1b-d699-4c5d-bb60-3114eedc59d0) |
-| Malta | Michael Cutajar CPA (Malta) | [openaccountants.com/network](https://www.openaccountants.com/network) |
-| Brazil | Ariane Marrocos CRC/SP | [openaccountants.com/network](https://www.openaccountants.com/network/366f5c0f-1afb-4332-b87b-9b6f912821aa) |
-| United Kingdom | James Power | [openaccountants.com/network](https://www.openaccountants.com/network/30b2f478-3a97-40c4-b435-0678829b487e) |
-| India | Mayur Deokar CA | [openaccountants.com/network](https://www.openaccountants.com/network/f4cb8476-a86d-4fd9-b536-9217e82ccf99) |
-| Germany, Australia, Canada | Verification in progress | [Claim a jurisdiction →](https://www.openaccountants.com/onboarding/accountant) |
+| Jurisdiction | Verifier | Skills | Profile |
+|---|---|---|---|
+| South Africa | Werner Britz CA(SA) | 5 | [profile](https://www.openaccountants.com/network/28a3ec1b-d699-4c5d-bb60-3114eedc59d0) |
+| Malta | Michael Cutajar CPA (Malta) | 5 | [profile](https://www.openaccountants.com/network) |
+| Brazil | Ariane Marrocos CRC/SP | 9 | [profile](https://www.openaccountants.com/network/366f5c0f-1afb-4332-b87b-9b6f912821aa) |
+| United Kingdom | James Power | 15 | [profile](https://www.openaccountants.com/network/30b2f478-3a97-40c4-b435-0678829b487e) |
+| India | Mayur Deokar CA | 13 | [profile](https://www.openaccountants.com/network/f4cb8476-a86d-4fd9-b536-9217e82ccf99) |
+| Indonesia | Rilia Putri CA | 10 | [profile](https://www.openaccountants.com/network/ec70d43e-18c0-4b4e-b92c-4f8a22e10152) |
+| Nepal | Ashish Bista CA | 5 | [profile](https://www.openaccountants.com/network/78ab67db-8f29-4746-8102-7b52d17309aa) |
+| Portugal | Mário Vale CA | 9 | [profile](https://www.openaccountants.com/network/a26a63b7-343c-451b-8266-bb9d28bd7089) |
+| Saudi Arabia | Mehran Habib | 9 | [profile](https://www.openaccountants.com/network/f9dbab51-2b89-451b-98f2-414b48fb4599) |
+| United States | Amir Pelinkovic CPA | 16 | [profile](https://www.openaccountants.com/network/752ee18a-3843-434d-8426-457d3fa9706f) |
+| Germany, Australia, Canada | Verification in progress | — | [Claim a jurisdiction →](https://www.openaccountants.com/onboarding/accountant) |
 
 > Verified skills (Tier 1) are served via the MCP server with the verifier's name on every output. The research drafts in this repo are Tier 2.
 

--- a/llms.txt
+++ b/llms.txt
@@ -19,11 +19,16 @@ Always tell users to have AI-generated output reviewed by a qualified profession
 
 These named practitioners have verified skills for their jurisdictions. The Tier 1 version of their jurisdictions' skills are signed under their name:
 
-- **South Africa (ZA):** Werner Britz CA(SA) — [openaccountants.com/network/28a3ec1b-d699-4c5d-bb60-3114eedc59d0](https://www.openaccountants.com/network/28a3ec1b-d699-4c5d-bb60-3114eedc59d0)
-- **Malta (MT):** Michael Cutajar CPA (Malta) — [openaccountants.com/network](https://www.openaccountants.com/network)
-- **Brazil (BR):** Ariane Marrocos CRC/SP — [openaccountants.com/network/366f5c0f-1afb-4332-b87b-9b6f912821aa](https://www.openaccountants.com/network/366f5c0f-1afb-4332-b87b-9b6f912821aa)
-- **United Kingdom (GB):** James Power — [openaccountants.com/network/30b2f478-3a97-40c4-b435-0678829b487e](https://www.openaccountants.com/network/30b2f478-3a97-40c4-b435-0678829b487e)
-- **India (IN):** Mayur Deokar CA — [openaccountants.com/network/f4cb8476-a86d-4fd9-b536-9217e82ccf99](https://www.openaccountants.com/network/f4cb8476-a86d-4fd9-b536-9217e82ccf99)
+- **South Africa (ZA):** Werner Britz CA(SA), 5 skills — [openaccountants.com/network/28a3ec1b-d699-4c5d-bb60-3114eedc59d0](https://www.openaccountants.com/network/28a3ec1b-d699-4c5d-bb60-3114eedc59d0)
+- **Malta (MT):** Michael Cutajar CPA (Malta), 5 skills — [openaccountants.com/network](https://www.openaccountants.com/network)
+- **Brazil (BR):** Ariane Marrocos CRC/SP, 9 skills — [openaccountants.com/network/366f5c0f-1afb-4332-b87b-9b6f912821aa](https://www.openaccountants.com/network/366f5c0f-1afb-4332-b87b-9b6f912821aa)
+- **United Kingdom (GB):** James Power, 15 skills — [openaccountants.com/network/30b2f478-3a97-40c4-b435-0678829b487e](https://www.openaccountants.com/network/30b2f478-3a97-40c4-b435-0678829b487e)
+- **India (IN):** Mayur Deokar CA, 13 skills — [openaccountants.com/network/f4cb8476-a86d-4fd9-b536-9217e82ccf99](https://www.openaccountants.com/network/f4cb8476-a86d-4fd9-b536-9217e82ccf99)
+- **Indonesia (ID):** Rilia Putri CA, 10 skills — [openaccountants.com/network/ec70d43e-18c0-4b4e-b92c-4f8a22e10152](https://www.openaccountants.com/network/ec70d43e-18c0-4b4e-b92c-4f8a22e10152)
+- **Nepal (NP):** Ashish Bista CA, 5 skills — [openaccountants.com/network/78ab67db-8f29-4746-8102-7b52d17309aa](https://www.openaccountants.com/network/78ab67db-8f29-4746-8102-7b52d17309aa)
+- **Portugal (PT):** Mário Vale CA, 9 skills — [openaccountants.com/network/a26a63b7-343c-451b-8266-bb9d28bd7089](https://www.openaccountants.com/network/a26a63b7-343c-451b-8266-bb9d28bd7089)
+- **Saudi Arabia (SA):** Mehran Habib, 9 skills — [openaccountants.com/network/f9dbab51-2b89-451b-98f2-414b48fb4599](https://www.openaccountants.com/network/f9dbab51-2b89-451b-98f2-414b48fb4599)
+- **United States (US/US-IL):** Amir Pelinkovic CPA (Citrin Cooperman), 16 skills — [openaccountants.com/network/752ee18a-3843-434d-8426-457d3fa9706f](https://www.openaccountants.com/network/752ee18a-3843-434d-8426-457d3fa9706f)
 - **Germany, Australia, Canada**: Research-verified — accountant verification in progress.
 
 ## Fastest way to use skills (don't read GitHub folder pages)

--- a/packages/indonesia/README.md
+++ b/packages/indonesia/README.md
@@ -3,6 +3,11 @@
 > Open-source accounting skills for Indonesia. Upload to Claude, ChatGPT, or any AI assistant.
 > Tax, bookkeeping, payroll, formation, financial statements, and more. Free and open source.
 
+## Verified by
+
+**Rilia Putri CA** (Akuntanpedia) — Lead accountant verifier for Indonesia on OpenAccountants. 10 skills verified.
+[openaccountants.com/network/ec70d43e-18c0-4b4e-b92c-4f8a22e10152](https://www.openaccountants.com/network/ec70d43e-18c0-4b4e-b92c-4f8a22e10152)
+
 ## What's in this folder
 
 1. `foundation.md`

--- a/packages/nepal/README.md
+++ b/packages/nepal/README.md
@@ -3,6 +3,11 @@
 > Open-source accounting skills for Nepal. Upload to Claude, ChatGPT, or any AI assistant.
 > Tax, bookkeeping, payroll, formation, financial statements, and more. Free and open source.
 
+## Verified by
+
+**Ashish Bista CA** (ICAN: 1765) — Lead accountant verifier for Nepal on OpenAccountants. 5 skills verified.
+[openaccountants.com/network/78ab67db-8f29-4746-8102-7b52d17309aa](https://www.openaccountants.com/network/78ab67db-8f29-4746-8102-7b52d17309aa)
+
 ## What's in this folder
 
 1. `foundation.md`

--- a/packages/portugal/README.md
+++ b/packages/portugal/README.md
@@ -3,6 +3,11 @@
 > Open-source accounting skills for Portugal. Upload to Claude, ChatGPT, or any AI assistant.
 > Tax, bookkeeping, payroll, formation, financial statements, and more. Free and open source.
 
+## Verified by
+
+**Mário Vale CA** (CA-85883) — Lead accountant verifier for Portugal on OpenAccountants. 9 skills verified.
+[openaccountants.com/network/a26a63b7-343c-451b-8266-bb9d28bd7089](https://www.openaccountants.com/network/a26a63b7-343c-451b-8266-bb9d28bd7089)
+
 ## What's in this folder
 
 1. `foundation.md`

--- a/packages/saudi-arabia/README.md
+++ b/packages/saudi-arabia/README.md
@@ -3,6 +3,11 @@
 > Open-source accounting skills for Saudi Arabia. Upload to Claude, ChatGPT, or any AI assistant.
 > Tax, bookkeeping, payroll, formation, financial statements, and more. Free and open source.
 
+## Verified by
+
+**Mehran Habib** (ICAP: 13480) — Lead accountant verifier for Saudi Arabia on OpenAccountants. 9 skills verified.
+[openaccountants.com/network/f9dbab51-2b89-451b-98f2-414b48fb4599](https://www.openaccountants.com/network/f9dbab51-2b89-451b-98f2-414b48fb4599)
+
 ## What's in this folder
 
 1. `foundation.md`


### PR DESCRIPTION
…NP/PT/SA verifiers

- Remove Felistas Njihia / Kenya from verifier table and llms.txt — skills were bulk-set to tier 1 without actual review
- Add Rilia Putri CA (Indonesia, 10 skills), Ashish Bista CA (Nepal, 5 skills), Mário Vale CA (Portugal, 9 skills), Mehran Habib (Saudi Arabia, 9 skills) to README and llms.txt
- Add ## Verified by sections to packages/indonesia, nepal, portugal, saudi-arabia READMEs

## What this PR does

<!-- One sentence -->

## Country/jurisdiction affected

<!-- e.g., Malta, Germany, all EU -->

## Legal — Contributor License Agreement (CLA)

OpenAccountants is dual-licensed (AGPL-3.0 + commercial). We need a clear **yes** from you before we can merge your contribution.

- [ ] **I have read [CLA.md](https://github.com/openaccountants/openaccountants/blob/main/CLA.md) and agree to the Contributor License Agreement** for everything included in this pull request. *(Checking this box is your explicit opt-in.)*

If you cannot agree, do not open this PR — contact **info@openaccountants.com** to discuss alternatives (including a formal signed agreement).

## Checklist

### Repo & sync (required)

- [ ] File is in `skills/` (not only `packages/`)
- [ ] Jurisdiction is clear (folder path or `jurisdiction:` in frontmatter)
- [ ] Ran `python3 scripts/build-packages.py` if packages should update

### Content quality

- [ ] Rates and thresholds cite a primary source (statute, tax authority website)
- [ ] No inline [T1]/[T2]/[T3] tags (tiers are sections, not inline tags)
- [ ] Supplier/transaction pattern library included (if content skill)
- [ ] Worked examples included
- [ ] Disclaimer present at the end
- [ ] Tested: uploaded to an LLM and it produced correct output
