### PR TITLE
examples: Mindee → OpenAccountants VAT-on-invoices demo

### DIFF
--- a/examples/mindee-vat/.gitignore
+++ b/examples/mindee-vat/.gitignore
@@ -1,0 +1,7 @@
+__pycache__/
+*.py[cod]
+.venv/
+venv/
+.env
+*.local
+.DS_Store

--- a/examples/mindee-vat/LICENSE
+++ b/examples/mindee-vat/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 OpenAccountants
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/examples/mindee-vat/README.md
+++ b/examples/mindee-vat/README.md
@@ -1,0 +1,73 @@
+# Mindee → OpenAccountants: VAT-on-invoices demo
+
+**The pitch in one line:** Mindee reads the invoice. OpenAccountants tells you whether the VAT on it is *correct* — under the verified rules of the right jurisdiction, signed off by a named licensed accountant.
+
+```
+invoice.pdf
+  └─ Mindee  →  { supplier_country, customer_country, vat_id, net, vat_rate, vat_amount, lines }
+        └─ OpenAccountants MCP  →  load the verified VAT skill for that jurisdiction
+              └─ Verdict:  ✅ reverse charge correctly applied   /   ⚠️ VAT charged in error
+                 · the rule that decided it (cited)
+                 · the named CPA who signed it off
+                 · one-call handoff to that accountant
+```
+
+![Mindee → OpenAccountants VAT demo](demo.svg)
+
+> Regenerate the visual: `python make_svg.py` (static SVG, no deps) · animated GIF: `brew install vhs && vhs demo.tape`
+
+## Why this is a partnership, not an overlap
+
+- **Mindee = the eyes.** Best-in-class extraction: document → structured JSON. Stops (by design) at *what's in the document*.
+- **OpenAccountants = the brain + the accountability.** Structured data → verified tax rules across 190+ jurisdictions → a working paper → a *named* licensed accountant's sign-off, served agent-native over an MCP server.
+
+Mindee's customers (fintechs, AP automation, accounting platforms) ask one question right after extraction: *"…is this VAT right?"* Today nothing in the pipeline answers it. This demo does — and it makes Mindee's extraction stickier and more valuable without Mindee having to build regulated tax logic or recruit a CPA network.
+
+## What it shows
+
+Three sample invoices (real Mindee extraction shape), run through the OpenAccountants MCP. Malta is used because it has a **named lead verifier** in the network, so the trust line shows end to end:
+
+| Sample | Scenario | Expected verdict |
+|--------|----------|------------------|
+| `mt_domestic.json` | MT supplier → MT customer, 18% VAT | ✅ Correct domestic VAT |
+| `mt_to_fr_reverse_charge.json` | MT → FR, both B2B (VAT IDs), €0 VAT + RC note | ✅ Reverse charge correctly applied |
+| `mt_to_fr_WRONG.json` | MT → FR B2B, **but 18% VAT charged** | ⚠️ **VAT charged in error — should be reverse charge** |
+
+That last one is the money shot: Mindee faithfully reads `VAT = €1,800`; **OpenAccountants is the layer that knows it shouldn't be there** — citing the rule, and the named CPA who signed it off.
+
+## Run it
+
+```bash
+cd examples/mindee-vat
+python pipeline.py                 # runs all three samples (mock mode, no keys needed)
+python pipeline.py samples/mt_to_fr_WRONG.json
+```
+
+### Go live
+
+Two env vars flip it from mocked to real:
+
+```bash
+export OA_MCP_TOKEN=...      # OpenAccountants account token (the MCP now requires auth)
+export MINDEE_API_KEY=...    # Mindee free-tier key for the invoice model
+python pipeline.py --pdf path/to/real_invoice.pdf
+```
+
+- With `OA_MCP_TOKEN` set, `oa_client.py` calls the live MCP at `https://www.openaccountants.com/api/mcp` (`start` → `get_skill`) — the verified rules + named verifier come back live.
+- With `MINDEE_API_KEY` set, `mindee_client.py` calls Mindee's invoice model instead of reading a bundled sample.
+- With neither, everything runs on the bundled samples so the flow is visible end-to-end today.
+
+## Files
+
+| File | Role |
+|------|------|
+| `pipeline.py` | Orchestrator + CLI: Mindee → OA → verdict report |
+| `mindee_client.py` | Mindee invoice extraction (live API or bundled sample) |
+| `oa_client.py` | OpenAccountants MCP JSON-RPC client (live or mock) |
+| `vat_check.py` | Applies the loaded OA rules to the extraction → verdict |
+| `samples/*.json` | Mindee-shaped invoice extractions |
+
+## Honest notes (read before the pitch)
+
+- The VAT decision logic in `vat_check.py` is a **deliberate simplification** of EU place-of-supply rules (domestic standard-rate vs intra-EU B2B reverse charge) — enough to make the demo land. In production the OA *skill* carries the full rule set and an AI agent reasons over it; the named-CPA sign-off is what makes the answer relianceable.
+- The bundled OA responses mirror the live MCP's shape; values marked `<<from live MCP>>` are filled the moment `OA_MCP_TOKEN` is set.

--- a/examples/mindee-vat/demo.svg
+++ b/examples/mindee-vat/demo.svg
@@ -1,0 +1,29 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1336" height="630" viewBox="0 0 1336 630" font-family="SFMono-Regular,Consolas,Menlo,monospace" font-size="14">
+<rect width="1336" height="630" rx="10" fill="#0d1117"/>
+<circle cx="20" cy="18" r="6" fill="#ff5f56"/>
+<circle cx="40" cy="18" r="6" fill="#ffbd2e"/>
+<circle cx="60" cy="18" r="6" fill="#27c93f"/>
+<text x="24" y="40" xml:space="preserve" fill="#58a6ff">Mindee → OpenAccountants · VAT-on-invoices demo  [MOCK (set OA_MCP_TOKEN + MINDEE_API_KEY to go live)]</text>
+<text x="24" y="84" xml:space="preserve" fill="#e6edf3">📄  mt_domestic.json</text>
+<text x="24" y="106" xml:space="preserve" fill="#8b949e">    Mindee → Valletta Software Ltd (MT) → Sliema Trading Ltd (MT)</text>
+<text x="24" y="128" xml:space="preserve" fill="#8b949e">           net EUR 10000.00 · VAT EUR 1800.00 (18%) · customer VAT ID MT12345678</text>
+<text x="24" y="150" xml:space="preserve" fill="#39c5cf">    OpenAccountants → Malta — VAT place of supply &amp; reverse charge  (tier 1, signed off by Michael Cutajar, CPA (Malta))</text>
+<text x="24" y="172" xml:space="preserve" fill="#3fb950">    ✅ Correct domestic VAT (18%)</text>
+<text x="24" y="194" xml:space="preserve" fill="#c9d1d9">       MT domestic supply taxed at the verified standard rate 18%.</text>
+<text x="24" y="216" xml:space="preserve" fill="#8b949e">       rule: MT domestic supply → standard rate 18%.</text>
+<text x="24" y="260" xml:space="preserve" fill="#e6edf3">📄  mt_to_fr_WRONG.json</text>
+<text x="24" y="282" xml:space="preserve" fill="#8b949e">    Mindee → Valletta Software Ltd (MT) → Lefebvre Distribution SARL (FR)</text>
+<text x="24" y="304" xml:space="preserve" fill="#8b949e">           net EUR 10000.00 · VAT EUR 1800.00 (18%) · customer VAT ID FR40303265045</text>
+<text x="24" y="326" xml:space="preserve" fill="#39c5cf">    OpenAccountants → Malta — VAT place of supply &amp; reverse charge  (tier 1, signed off by Michael Cutajar, CPA (Malta))</text>
+<text x="24" y="348" xml:space="preserve" fill="#d29922">    ⚠️  VAT charged in error — should be reverse charge</text>
+<text x="24" y="370" xml:space="preserve" fill="#c9d1d9">       Intra-EU B2B supply (MT → FR, customer VAT ID FR40303265045). Supplier should invoice 0% and the customer self-accounts. This invoice charged EUR 1800.00.</text>
+<text x="24" y="392" xml:space="preserve" fill="#8b949e">       rule: Intra-EU B2B: place of supply is the customer's country → reverse charge.</text>
+<text x="24" y="414" xml:space="preserve" fill="#8b949e">       → handoff: request_accountant_review (route to the named jurisdiction lead)</text>
+<text x="24" y="458" xml:space="preserve" fill="#e6edf3">📄  mt_to_fr_reverse_charge.json</text>
+<text x="24" y="480" xml:space="preserve" fill="#8b949e">    Mindee → Valletta Software Ltd (MT) → Lefebvre Distribution SARL (FR)</text>
+<text x="24" y="502" xml:space="preserve" fill="#8b949e">           net EUR 10000.00 · VAT EUR 0.00 (0%) · customer VAT ID FR40303265045</text>
+<text x="24" y="524" xml:space="preserve" fill="#39c5cf">    OpenAccountants → Malta — VAT place of supply &amp; reverse charge  (tier 1, signed off by Michael Cutajar, CPA (Malta))</text>
+<text x="24" y="546" xml:space="preserve" fill="#3fb950">    ✅ Reverse charge correctly applied</text>
+<text x="24" y="568" xml:space="preserve" fill="#c9d1d9">       Intra-EU B2B supply (MT → FR). Supplier correctly invoiced 0% VAT; customer self-accounts.</text>
+<text x="24" y="590" xml:space="preserve" fill="#8b949e">       rule: Intra-EU B2B: place of supply is the customer's country → reverse charge.</text>
+</svg>

--- a/examples/mindee-vat/demo.tape
+++ b/examples/mindee-vat/demo.tape
@@ -1,0 +1,15 @@
+# VHS tape — renders an animated GIF of the demo.
+#   brew install vhs   (https://github.com/charmbracelet/vhs)
+#   vhs demo.tape      -> demo.gif
+
+Output demo.gif
+
+Set FontSize 16
+Set Width 1100
+Set Height 760
+Set Theme "Github Dark"
+Set Padding 20
+
+Type "python pipeline.py"
+Enter
+Sleep 4s

--- a/examples/mindee-vat/make_svg.py
+++ b/examples/mindee-vat/make_svg.py
@@ -1,0 +1,84 @@
+#!/usr/bin/env python3
+"""Render the demo's terminal output to a self-contained SVG (no external tools).
+
+    python make_svg.py          # writes demo.svg
+
+For an animated GIF instead, see demo.tape (needs `vhs`).
+"""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+from xml.sax.saxutils import escape
+
+BG = "#0d1117"
+DEFAULT = "#c9d1d9"
+MUTED = "#8b949e"
+WHITE = "#e6edf3"
+CYAN = "#39c5cf"
+GREEN = "#3fb950"
+AMBER = "#d29922"
+ACCENT = "#58a6ff"
+
+CHAR_W = 8.0
+LINE_H = 22
+PAD_X = 24
+PAD_Y = 34
+
+
+def color_for(line: str) -> str:
+    s = line.strip()
+    if s.startswith("Mindee → OpenAccountants"):
+        return ACCENT
+    if s.startswith("📄"):
+        return WHITE
+    if "✅" in s:
+        return GREEN
+    if "⚠" in s:
+        return AMBER
+    if s.startswith("OpenAccountants →"):
+        return CYAN
+    if s.startswith("Mindee →") or s.startswith("net ") or "·" in s and "VAT" in s:
+        return MUTED
+    if s.startswith("rule:") or s.startswith("→ handoff"):
+        return MUTED
+    return DEFAULT
+
+
+def main() -> int:
+    out = subprocess.run(
+        [sys.executable, "pipeline.py"], capture_output=True, text=True
+    ).stdout.rstrip("\n")
+    lines = out.split("\n")
+
+    width = int(max((len(ln) for ln in lines), default=60) * CHAR_W + PAD_X * 2)
+    height = len(lines) * LINE_H + PAD_Y + 24
+
+    parts = [
+        f'<svg xmlns="http://www.w3.org/2000/svg" width="{width}" height="{height}" '
+        f'viewBox="0 0 {width} {height}" font-family="SFMono-Regular,Consolas,Menlo,monospace" font-size="14">',
+        f'<rect width="{width}" height="{height}" rx="10" fill="{BG}"/>',
+        # window dots
+        '<circle cx="20" cy="18" r="6" fill="#ff5f56"/>',
+        '<circle cx="40" cy="18" r="6" fill="#ffbd2e"/>',
+        '<circle cx="60" cy="18" r="6" fill="#27c93f"/>',
+    ]
+    y = PAD_Y + 6
+    for ln in lines:
+        if ln.strip():
+            parts.append(
+                f'<text x="{PAD_X}" y="{y}" xml:space="preserve" '
+                f'fill="{color_for(ln)}">{escape(ln)}</text>'
+            )
+        y += LINE_H
+    parts.append("</svg>")
+
+    with open("demo.svg", "w") as fh:
+        fh.write("\n".join(parts))
+    print(f"wrote demo.svg ({width}x{height}, {len(lines)} lines)")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/examples/mindee-vat/mindee_client.py
+++ b/examples/mindee-vat/mindee_client.py
@@ -1,0 +1,86 @@
+"""Mindee invoice extraction.
+
+In live mode (MINDEE_API_KEY set) this would call Mindee's invoice model. For the
+demo it loads a bundled sample with the same field shape Mindee returns, then
+normalizes it to the handful of facts the VAT check needs.
+
+Keeping the Mindee SDK call as a thin, swappable seam is deliberate — the live
+swap is a few lines, and the rest of the pipeline doesn't change.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+
+MINDEE_API_KEY = os.environ.get("MINDEE_API_KEY")
+
+
+def extract(source: str) -> dict:
+    """Return a Mindee-shaped invoice prediction.
+
+    source: a path to a bundled sample .json, or (live) a path to a PDF/image.
+    """
+    if MINDEE_API_KEY and source.lower().endswith((".pdf", ".png", ".jpg", ".jpeg")):
+        return _extract_live(source)
+    with open(source) as fh:
+        return json.load(fh)
+
+
+def _extract_live(path: str) -> dict:  # pragma: no cover - needs a real key
+    """Live Mindee call. Wired but inert until MINDEE_API_KEY + the SDK are present.
+
+        pip install mindee
+    """
+    from mindee import Client, product  # type: ignore
+
+    mindee_client = Client(api_key=MINDEE_API_KEY)
+    doc = mindee_client.source_from_path(path)
+    result = mindee_client.parse(product.InvoiceV4, doc)
+    pred = result.document.inference.prediction
+    # Map the SDK object onto the same dict shape as the bundled samples.
+    return {
+        "supplier_name": str(pred.supplier_name.value or ""),
+        "supplier_country": _country(pred.supplier_address),
+        "customer_name": str(pred.customer_name.value or ""),
+        "customer_country": _country(pred.customer_address),
+        "customer_vat_id": _vat_id(pred.customer_company_registrations),
+        "currency": str(pred.locale.currency or ""),
+        "total_net": float(pred.total_net.value or 0),
+        "total_tax": float(pred.total_tax.value or 0),
+        "taxes": [{"rate": float(t.rate or 0), "value": float(t.value or 0)} for t in pred.taxes],
+        "notes": " ".join(str(getattr(pred, "notes", "") or "")),
+    }
+
+
+def _country(addr) -> str:  # pragma: no cover
+    return (getattr(addr, "country", None) or "").upper()
+
+
+def _vat_id(regs) -> str | None:  # pragma: no cover
+    for r in regs or []:
+        if getattr(r, "type", "").upper() in ("VAT NUMBER", "VAT"):
+            return str(r.value)
+    return None
+
+
+def normalize(prediction: dict) -> dict:
+    """Reduce a Mindee prediction to the facts the VAT check needs."""
+    taxes = prediction.get("taxes") or []
+    vat_amount = sum(t.get("value", 0) for t in taxes)
+    # Mindee gives rate per tax line; take the headline non-zero rate, else 0.
+    rates = [t.get("rate", 0) for t in taxes if t.get("value", 0)]
+    vat_rate = (rates[0] / 100.0) if rates else 0.0
+    notes = (prediction.get("notes") or "").lower()
+    return {
+        "supplier_name": prediction.get("supplier_name", ""),
+        "supplier_country": (prediction.get("supplier_country") or "").upper(),
+        "customer_name": prediction.get("customer_name", ""),
+        "customer_country": (prediction.get("customer_country") or "").upper(),
+        "customer_vat_id": prediction.get("customer_vat_id"),
+        "currency": prediction.get("currency", "EUR"),
+        "net": float(prediction.get("total_net", 0)),
+        "vat_amount": float(vat_amount),
+        "vat_rate": float(vat_rate),
+        "reverse_charge_note": "reverse charge" in notes,
+    }

--- a/examples/mindee-vat/oa_client.py
+++ b/examples/mindee-vat/oa_client.py
@@ -1,0 +1,124 @@
+"""OpenAccountants MCP client.
+
+Talks to the OpenAccountants MCP server over JSON-RPC 2.0 at
+https://www.openaccountants.com/api/mcp. The MCP now requires authentication on
+tool calls, so a token (OA_MCP_TOKEN) is needed for live mode. Without one, this
+client returns bundled sample responses that mirror the live shape so the demo
+runs end to end.
+
+Exposes the two calls the VAT pipeline needs:
+  - start(intent, jurisdiction)  -> which verified skill(s) govern this question
+  - get_skill(slug)              -> the rules + tier + named verifier
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import urllib.request
+import urllib.error
+
+MCP_URL = os.environ.get("OA_MCP_URL", "https://www.openaccountants.com/api/mcp")
+MCP_TOKEN = os.environ.get("OA_MCP_TOKEN")
+
+
+class OAClient:
+    def __init__(self, token: str | None = MCP_TOKEN, url: str = MCP_URL):
+        self.token = token
+        self.url = url
+        self._id = 0
+
+    @property
+    def live(self) -> bool:
+        return bool(self.token)
+
+    # -- public API ---------------------------------------------------------
+
+    def start(self, intent: str, jurisdiction: str) -> dict:
+        if not self.live:
+            return _MOCK_START.get(jurisdiction.upper(), _MOCK_START["_DEFAULT"])
+        return self._call("start", {"intent": intent, "jurisdiction": jurisdiction})
+
+    def get_skill(self, slug: str) -> dict:
+        if not self.live:
+            return _MOCK_SKILL.get(slug, _MOCK_SKILL["_DEFAULT"])
+        return self._call("get_skill", {"slug": slug})
+
+    # -- transport ----------------------------------------------------------
+
+    def _call(self, tool: str, arguments: dict) -> dict:
+        self._id += 1
+        body = json.dumps(
+            {
+                "jsonrpc": "2.0",
+                "id": self._id,
+                "method": "tools/call",
+                "params": {"name": tool, "arguments": arguments},
+            }
+        ).encode()
+        headers = {"Content-Type": "application/json", "Accept": "application/json"}
+        if self.token:
+            # Exact scheme TBD once OA shares the connector token format; Bearer
+            # is the assumption. Swap here if OA uses an apikey/header instead.
+            headers["Authorization"] = f"Bearer {self.token}"
+        req = urllib.request.Request(self.url, data=body, headers=headers)
+        try:
+            with urllib.request.urlopen(req, timeout=30) as resp:
+                payload = json.load(resp)
+        except urllib.error.HTTPError as e:
+            raise RuntimeError(f"OA MCP HTTP {e.code}: {e.read().decode()[:300]}") from e
+        if "error" in payload and payload["error"]:
+            raise RuntimeError(f"OA MCP error: {payload['error']}")
+        result = payload.get("result", {})
+        # tool results come back as structuredContent (preferred) or text JSON
+        if isinstance(result.get("structuredContent"), (dict, list)):
+            return result["structuredContent"]
+        text = (result.get("content") or [{}])[0].get("text", "{}")
+        return json.loads(text)
+
+
+# --- Bundled sample responses (mirror live MCP shape) ----------------------
+# Values that come from the live MCP are marked <<from live MCP>>.
+
+_MOCK_START = {
+    "MT": {
+        "jurisdiction": "MT",
+        "intent": "VAT treatment on a cross-border invoice",
+        "skills_to_load": ["mt-vat-place-of-supply"],
+        "next_action": "Load the skill, then apply its rules to the invoice facts.",
+    },
+    "_DEFAULT": {
+        "jurisdiction": "EU",
+        "skills_to_load": ["eu-vat-place-of-supply"],
+        "next_action": "Load the skill, then apply its rules to the invoice facts.",
+    },
+}
+
+_MOCK_SKILL = {
+    # Malta has a named lead verifier in OpenAccountants (Michael Cutajar, the
+    # MT jurisdiction lead), so the demo shows the full trust line. Live, these
+    # fields come straight from get_skill.
+    "mt-vat-place-of-supply": {
+        "slug": "mt-vat-place-of-supply",
+        "name": "Malta — VAT place of supply & reverse charge",
+        "jurisdiction": "MT",
+        "tier": 1,  # <<from live MCP>>
+        "verifier": "Michael Cutajar, CPA (Malta)",  # <<from live MCP>>
+        "rules": {
+            # Illustrative — production reads these from the skill markdown / via an LLM.
+            "standard_rate": 0.18,
+            "reduced_rates": [0.07, 0.05],
+            "intra_eu_b2b": "reverse_charge",  # supplier invoices 0%, customer self-accounts
+        },
+        "source": "https://www.openaccountants.com/skills/mt-vat-place-of-supply",
+    },
+    "_DEFAULT": {
+        "slug": "eu-vat-place-of-supply",
+        "name": "EU — VAT place of supply & reverse charge",
+        "jurisdiction": "EU",
+        "tier": 2,
+        "verifier": None,
+        "rules": {"standard_rate": None, "intra_eu_b2b": "reverse_charge"},
+        "source": "https://www.openaccountants.com/skills",
+    },
+}

--- a/examples/mindee-vat/pipeline.py
+++ b/examples/mindee-vat/pipeline.py
@@ -1,0 +1,78 @@
+#!/usr/bin/env python3
+"""Mindee -> OpenAccountants VAT-on-invoices pipeline.
+
+    python pipeline.py                         # run all bundled samples (mock mode)
+    python pipeline.py samples/de_to_fr_WRONG.json
+    python pipeline.py --pdf invoice.pdf       # live (needs MINDEE_API_KEY + OA_MCP_TOKEN)
+
+The flow:
+    Mindee extract  ->  OA MCP (start -> get_skill)  ->  apply rules  ->  verdict
+"""
+
+from __future__ import annotations
+
+import glob
+import os
+import sys
+
+import mindee_client
+import vat_check
+from oa_client import OAClient
+
+STATUS = {"ok": "✅", "warn": "⚠️ ", "info": "ℹ️ "}
+
+
+def run_one(source: str, oa: OAClient) -> None:
+    prediction = mindee_client.extract(source)
+    facts = mindee_client.normalize(prediction)
+
+    # 1. Mindee read the invoice
+    print(f"\n📄  {os.path.basename(source)}")
+    print(f"    Mindee → {facts['supplier_name']} ({facts['supplier_country']}) "
+          f"→ {facts['customer_name']} ({facts['customer_country']})")
+    print(f"           net {facts['currency']} {facts['net']:.2f} · "
+          f"VAT {facts['currency']} {facts['vat_amount']:.2f} "
+          f"({facts['vat_rate']:.0%})"
+          + (f" · customer VAT ID {facts['customer_vat_id']}" if facts['customer_vat_id'] else ""))
+
+    # 2. OpenAccountants — which verified rules govern this?
+    plan = oa.start("Check VAT treatment on a cross-border invoice", facts["supplier_country"] or "EU")
+    slug = (plan.get("skills_to_load") or [None])[0]
+    skill = oa.get_skill(slug) if slug else {}
+
+    # 3. Apply the rules
+    verdict = vat_check.check(facts, skill)
+
+    # 4. Report
+    tier = verdict.get("tier")
+    verifier = verdict.get("verifier")
+    trust = (f"tier {tier}"
+             + (f", signed off by {verifier}" if verifier else ", no named verifier yet"))
+    print(f"    OpenAccountants → {verdict.get('oa_skill_name') or 'VAT rules'}  ({trust})")
+    print(f"    {STATUS.get(verdict['status'], '')} {verdict['headline']}")
+    print(f"       {verdict['detail']}")
+    print(f"       rule: {verdict['rule_cited']}")
+    if verdict["status"] == "warn":
+        print("       → handoff: request_accountant_review (route to the named jurisdiction lead)")
+
+
+def main(argv: list[str]) -> int:
+    oa = OAClient()
+    mode = "LIVE" if oa.live else "MOCK (set OA_MCP_TOKEN + MINDEE_API_KEY to go live)"
+    print(f"Mindee → OpenAccountants · VAT-on-invoices demo  [{mode}]")
+
+    if "--pdf" in argv:
+        source = argv[argv.index("--pdf") + 1]
+        run_one(source, oa)
+    elif len(argv) > 1:
+        run_one(argv[1], oa)
+    else:
+        here = os.path.dirname(os.path.abspath(__file__))
+        for sample in sorted(glob.glob(os.path.join(here, "samples", "*.json"))):
+            run_one(sample, oa)
+    print()
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv))

--- a/examples/mindee-vat/requirements.txt
+++ b/examples/mindee-vat/requirements.txt
@@ -1,0 +1,3 @@
+# The demo runs on the Python standard library alone (urllib + json).
+# Only needed for LIVE Mindee extraction from real PDFs/images:
+mindee>=4.0 ; extra == "live"

--- a/examples/mindee-vat/samples/mt_domestic.json
+++ b/examples/mindee-vat/samples/mt_domestic.json
@@ -1,0 +1,14 @@
+{
+  "_comment": "Mindee-shaped invoice prediction. Domestic MT supply, 18% VAT (correct).",
+  "supplier_name": "Valletta Software Ltd",
+  "supplier_country": "MT",
+  "customer_name": "Sliema Trading Ltd",
+  "customer_country": "MT",
+  "customer_vat_id": "MT12345678",
+  "locale": { "country": "MT", "currency": "EUR" },
+  "currency": "EUR",
+  "total_net": 10000.00,
+  "total_tax": 1800.00,
+  "taxes": [{ "rate": 18.0, "value": 1800.00, "base": 10000.00 }],
+  "notes": "Payment due within 30 days."
+}

--- a/examples/mindee-vat/samples/mt_to_fr_WRONG.json
+++ b/examples/mindee-vat/samples/mt_to_fr_WRONG.json
@@ -1,0 +1,14 @@
+{
+  "_comment": "Mindee-shaped invoice prediction. Intra-EU B2B (MT -> FR) but 18% VAT charged in error (should be reverse charge). The money shot.",
+  "supplier_name": "Valletta Software Ltd",
+  "supplier_country": "MT",
+  "customer_name": "Lefebvre Distribution SARL",
+  "customer_country": "FR",
+  "customer_vat_id": "FR40303265045",
+  "locale": { "country": "MT", "currency": "EUR" },
+  "currency": "EUR",
+  "total_net": 10000.00,
+  "total_tax": 1800.00,
+  "taxes": [{ "rate": 18.0, "value": 1800.00, "base": 10000.00 }],
+  "notes": "Payment due within 30 days."
+}

--- a/examples/mindee-vat/samples/mt_to_fr_reverse_charge.json
+++ b/examples/mindee-vat/samples/mt_to_fr_reverse_charge.json
@@ -1,0 +1,14 @@
+{
+  "_comment": "Mindee-shaped invoice prediction. Intra-EU B2B (MT -> FR), 0% VAT + reverse charge note (correct).",
+  "supplier_name": "Valletta Software Ltd",
+  "supplier_country": "MT",
+  "customer_name": "Lefebvre Distribution SARL",
+  "customer_country": "FR",
+  "customer_vat_id": "FR40303265045",
+  "locale": { "country": "MT", "currency": "EUR" },
+  "currency": "EUR",
+  "total_net": 10000.00,
+  "total_tax": 0.00,
+  "taxes": [{ "rate": 0.0, "value": 0.00, "base": 10000.00 }],
+  "notes": "Reverse charge — VAT to be accounted for by the recipient under Article 196 of the EU VAT Directive."
+}

--- a/examples/mindee-vat/vat_check.py
+++ b/examples/mindee-vat/vat_check.py
@@ -1,0 +1,80 @@
+"""Apply the loaded OpenAccountants VAT rules to a Mindee extraction.
+
+DELIBERATE SIMPLIFICATION: this covers the two cases the demo needs — a domestic
+supply (standard rate should apply) and an intra-EU B2B supply (reverse charge:
+supplier invoices 0%, customer self-accounts). Real life has many more (goods vs
+services, OSS/distance selling, exemptions, special schemes). In production the
+OA *skill* carries the full rule set and an AI agent reasons over it; here we do a
+transparent check on the core fields so the value is visible without an LLM.
+"""
+
+from __future__ import annotations
+
+EU = {
+    "AT", "BE", "BG", "HR", "CY", "CZ", "DE", "DK", "EE", "ES", "FI", "FR",
+    "GR", "HU", "IE", "IT", "LT", "LU", "LV", "MT", "NL", "PL", "PT", "RO",
+    "SE", "SI", "SK",
+}
+
+
+def check(facts: dict, oa_skill: dict) -> dict:
+    rules = oa_skill.get("rules", {})
+    verifier = oa_skill.get("verifier")
+    tier = oa_skill.get("tier")
+    base = {
+        "oa_skill": oa_skill.get("slug"),
+        "oa_skill_name": oa_skill.get("name"),
+        "tier": tier,
+        "verifier": verifier,
+        "source": oa_skill.get("source"),
+    }
+
+    sc = facts["supplier_country"]
+    cc = facts["customer_country"]
+    charged_vat = facts["vat_amount"] > 0.005
+    is_b2b = bool(facts.get("customer_vat_id"))
+
+    # --- Domestic supply --------------------------------------------------
+    if sc and cc and sc == cc:
+        std = rules.get("standard_rate")
+        if std is None:
+            return {**base, "status": "info",
+                    "headline": "Domestic supply — standard rate applies",
+                    "detail": "Could not confirm the standard rate from the loaded skill.",
+                    "rule_cited": "Domestic supply: standard rate applies."}
+        if abs(facts["vat_rate"] - std) < 0.001:
+            return {**base, "status": "ok",
+                    "headline": f"Correct domestic VAT ({std:.0%})",
+                    "detail": f"{sc} domestic supply taxed at the verified standard rate {std:.0%}.",
+                    "rule_cited": f"{sc} domestic supply → standard rate {std:.0%}."}
+        return {**base, "status": "warn",
+                "headline": f"VAT rate looks wrong (invoice {facts['vat_rate']:.0%} vs verified {std:.0%})",
+                "detail": f"Invoice applied {facts['vat_rate']:.0%}; the verified {sc} standard rate is {std:.0%}.",
+                "rule_cited": f"{sc} domestic supply → standard rate {std:.0%}."}
+
+    # --- Intra-EU B2B supply ---------------------------------------------
+    if sc in EU and cc in EU and sc != cc and is_b2b:
+        if charged_vat:
+            return {**base, "status": "warn",
+                    "headline": "VAT charged in error — should be reverse charge",
+                    "detail": (f"Intra-EU B2B supply ({sc} → {cc}, customer VAT ID "
+                               f"{facts['customer_vat_id']}). Supplier should invoice 0% and the "
+                               f"customer self-accounts. This invoice charged "
+                               f"{facts['currency']} {facts['vat_amount']:.2f}."),
+                    "rule_cited": "Intra-EU B2B: place of supply is the customer's country → reverse charge."}
+        return {**base, "status": "ok",
+                "headline": "Reverse charge correctly applied",
+                "detail": (f"Intra-EU B2B supply ({sc} → {cc}). Supplier correctly invoiced 0% VAT; "
+                           f"customer self-accounts."
+                           + ("" if facts["reverse_charge_note"] else
+                              "  Note: no explicit 'reverse charge' wording detected on the invoice — verify it's present.")),
+                "rule_cited": "Intra-EU B2B: place of supply is the customer's country → reverse charge."}
+
+    # --- Everything else --------------------------------------------------
+    return {**base, "status": "info",
+            "headline": "Scenario outside this demo's rule set",
+            "detail": (f"{sc or '?'} → {cc or '?'}"
+                       + (", B2B" if is_b2b else ", B2C")
+                       + ". Cases like B2C distance selling (OSS), exports, or non-EU parties need the "
+                         "full OA skill / an agent reasoning step — not covered by the demo's two rules."),
+            "rule_cited": "n/a"}


### PR DESCRIPTION
A small, runnable reference integration showing **Mindee + OpenAccountants**.

**The flow:** Mindee extracts an invoice → OpenAccountants validates the VAT treatment (domestic standard rate vs intra-EU B2B reverse charge) under the verified rules of the jurisdiction → cites the rule + the named CPA who signed it off.

It catches the case extraction alone can't: an intra-EU B2B invoice that **charged VAT when it should have been reverse-charged**.

- Lives in `examples/mindee-vat/`.
- Runs on bundled Malta samples in **mock mode** (no keys).
- Goes live with `OA_MCP_TOKEN` + `MINDEE_API_KEY`.
- Built as a partner-facing artifact (warm intro to Mindee's devrel/founders).