### PR TITLE
OBBBA corrections to 4 US federal Guides (reviewed by Christopher Aryee, CPA)

### DIFF
--- a/packages/us-federal/us-form-1040-individual-return.md
+++ b/packages/us-federal/us-form-1040-individual-return.md
@@ -5,13 +5,16 @@ jurisdiction: US
 category: federal-tax
 tier: 2
 verified_by: pending
-last_updated: 2025-11-15
+reviewed_by: Christopher Aryee, CPA
+last_updated: 2026-07-04
 version: 0.1
 ---
 
 # US Form 1040 — Individual Income Tax Return (Non-Freelance)
 
 > Tier 2 federal content skill. Covers tax year **2025** under the One Big Beautiful Bill Act (OBBBA, P.L. 119-21, July 4 2025). MUST be loaded alongside `us-tax-workflow-base` v0.2 or later. Federal only — no state tax. Assumes a Circular 230 practitioner reviews and signs off on every output before delivery.
+
+> **OBBBA update (2026):** Rates, thresholds, and statutory citations in this Guide were corrected against the One Big Beautiful Bill Act following an in-progress professional review by **Christopher Aryee, CPA**.
 
 ## 1. Scope
 
@@ -70,6 +73,8 @@ Refuse and refer to a human credentialed preparer when:
 Additional standard deduction (age 65+ or blind):
 - **MFJ / QSS:** $1,600 per qualifying condition per spouse
 - **Single / HoH:** $2,000 per qualifying condition
+
+**2026 figures (OBBBA §70102):** the additional standard deduction rises to **$1,650 (married)** / **$2,050 (unmarried)** per qualifying condition. An MFJ couple with both spouses over 65 gets a total standard deduction of **$35,500 for 2026**.
 
 A taxpayer who can be **claimed as a dependent** on another return is limited to the greater of (a) $1,350 or (b) earned income + $450, capped at the regular standard deduction.
 
@@ -168,9 +173,9 @@ Reported on **Form 8959**, flows to Schedule 2 Line 11. Employer withholds the 0
 
 Pre-OBBBA: $10,000 cap (TCJA 2017).
 
-**OBBBA P.L. 119-21 §70401 raised the SALT cap to $40,000** for tax years 2025-2029 (MFS: $20,000), then reverts to $10,000 in 2030 unless further extended. **MFS taxpayers get half** ($20,000).
+**OBBBA P.L. 119-21 §70120 raised the SALT cap to $40,000** for 2025 (MFS: $20,000). The applicable amount is indexed: the **2026 applicable amount is $40,400**. The elevated cap **reverts to $10,000 after December 31, 2029** unless further extended. **MFS taxpayers get half** ($20,000). Source: OBBBA §70120; IRC §164(b)(7).
 
-> **PHASEOUT (OBBBA §70401(b)):** The elevated SALT cap phases down for taxpayers with MAGI over $500,000 ($250,000 MFS). The cap is reduced by 30% of excess MAGI, but **not below $10,000**. Practical effect: fully elevated $40k cap is available up to $500k MAGI; phases to $10k floor by approximately $600k MAGI.
+> **PHASEOUT (OBBBA §70120):** The elevated SALT cap phases down for taxpayers with MAGI over $500,000 ($250,000 MFS). The cap is reduced by 30% of excess MAGI, but **never below $10,000**. Practical effect: fully elevated $40k cap is available up to $500k MAGI; phases to $10k floor by approximately $600k MAGI.
 
 ### 2.8 Kiddie tax — §1(g)
 
@@ -185,16 +190,16 @@ Computed on **Form 8615**. Parents may elect to report the child's unearned inco
 
 ### 2.9 Other OBBBA changes
 
-- **§199A QBI**: made permanent at 20% for 2025, rises to 23% in 2026 (P.L. 119-21 §70201). Not applicable to pure W-2 / investment returns (Line 13 = 0) but flag if Schedule K-1 PTP income or REIT dividends are present — these qualify for QBI even without a trade or business.
+- **§199A QBI**: made permanent at **20%** — the rate **stayed 20%** (it was **not** raised to 23%). OBBBA P.L. 119-21 §70105 raised the phase-in threshold to **$75,000 ($150,000 joint)** and added a **$400 minimum deduction**. Not applicable to pure W-2 / investment returns (Line 13 = 0) but flag if Schedule K-1 PTP income or REIT dividends are present — these qualify for QBI even without a trade or business.
 - **§1(j) brackets**: permanent (see §2.2).
 - **Standard deduction**: TCJA levels permanent (see §2.1).
-- **Child Tax Credit**: $2,000 per qualifying child under 17 (§24(h)), refundable portion $1,700 in 2025 (Rev. Proc. 2024-40), made permanent by OBBBA §70301. Phaseout begins $400k MFJ / $200k other.
-- **§25D Residential Clean Energy Credit** (30% solar, geothermal, battery, etc.): **AUDIT FLASH POINT — OBBBA accelerated termination.** Pre-OBBBA the credit phased to 26% in 2033 and 22% in 2034. OBBBA P.L. 119-21 §70501 **terminated the credit for property placed in service after December 31 2025** for most categories (solar, geothermal heat pump, small wind, biomass) — verify against IRS guidance Notice 2025-XX before claiming for late-2025 installations. Battery storage and fuel cells may have different effective dates. **Flag to reviewer.**
+- **Child Tax Credit**: made permanent at **$2,200 per qualifying child** under 17 (§24(h)) by OBBBA §70104, refundable portion $1,700 in 2025 (Rev. Proc. 2024-40). Phaseout begins $400k MFJ / $200k other.
+- **§25D Residential Clean Energy Credit** (30% solar, geothermal, battery, etc.): **AUDIT FLASH POINT — OBBBA accelerated termination.** Pre-OBBBA the credit phased to 26% in 2033 and 22% in 2034. OBBBA P.L. 119-21 §70506 **terminated the credit for property placed in service after December 31 2025** for most categories (solar, geothermal heat pump, small wind, biomass) — verify against IRS guidance Notice 2025-XX before claiming for late-2025 installations. Battery storage and fuel cells may have different effective dates. **Flag to reviewer.**
 - **§30D Clean Vehicle Credit** (up to $7,500 new EV): **OBBBA P.L. 119-21 §70502 terminated §30D for vehicles acquired after September 30 2025.** Vehicles placed in service through 9/30/2025 still qualify under the existing point-of-sale transferable election rules. **Flag to reviewer for any 2025 EV purchase — confirm date of acquisition vs date of placement in service.**
 - **§25E Used Clean Vehicle Credit** (up to $4,000): also terminated 9/30/2025 under OBBBA §70502.
-- **Tip income deduction**: NEW under OBBBA §70601 — up to $25,000 of qualified tip income deductible above-the-line for occupations on the IRS-published tip-receiving occupations list (Treasury list issued under OBBBA §70601(d)). Phases out above $150k single / $300k MFJ. Reported on Schedule 1.
-- **Overtime pay deduction**: NEW under OBBBA §70602 — up to $12,500 single / $25,000 MFJ of FLSA-mandated overtime premium pay deductible above-the-line. Same phaseout. Reported on Schedule 1.
-- **Auto loan interest deduction**: NEW under OBBBA §70603 — up to $10,000 of interest on a loan for a US-assembled passenger vehicle deductible above-the-line. Phases out $100k single / $200k MFJ. Reported on Schedule 1.
+- **Tip income deduction**: NEW under OBBBA §70201 — up to $25,000 of qualified tip income deductible above-the-line for occupations on the IRS-published tip-receiving occupations list (Treasury list issued under OBBBA §70201(d)). Phases out above $150k single / $300k MFJ. Reported on Schedule 1.
+- **Overtime pay deduction**: NEW under OBBBA §70202 — up to $12,500 single / $25,000 MFJ of FLSA-mandated overtime premium pay deductible above-the-line. Same phaseout. Reported on Schedule 1.
+- **Auto loan interest deduction**: NEW under OBBBA §70203 — up to $10,000 of interest on a loan for a US-assembled passenger vehicle deductible above-the-line. Phases out $100k single / $200k MFJ. Reported on Schedule 1.
 
 ## 3. Filing status and dependents
 
@@ -352,7 +357,7 @@ Line 9 minus Line 10.
 | 7 | Unemployment compensation | 1099-G Box 1 |
 | 8a | Net operating loss | §172 |
 | 8b | Gambling winnings | W-2G; losses deductible only as itemized misc up to winnings under §165(d) |
-| 8c | Cancellation of debt | 1099-C — but check §108 exclusions (insolvency, qualified principal residence indebtedness extended under OBBBA §70405 through 2026, bankruptcy, qualified farm/real property business) |
+| 8c | Cancellation of debt | 1099-C — but check §108 exclusions (insolvency, qualified principal residence indebtedness — **NOT extended by OBBBA** (§70405 enhances the dependent-care credit, not QPRI), bankruptcy, qualified farm/real property business). The student-loan discharge exclusion under §108(f)(5) is **permanent under OBBBA §70119**. |
 | 8d | Foreign earned income exclusion | Form 2555 (NEGATIVE amount) — refer to `us-foreign-earned-income-2555` |
 | 8e | Income from Form 8853 (Archer MSA) | |
 | 8f | Income from Form 8889 (HSA distributions for non-medical) | |
@@ -380,7 +385,7 @@ Line 9 minus Line 10.
 
 | Line | Item | Notes |
 |---|---|---|
-| 11 | Educator expenses | Up to $300 for K-12 teachers, instructors, counselors who worked 900+ hours |
+| 11 | Educator expenses | OBBBA §70110 **removes the dollar limitation** (previously $300) — adds IRC §67(b)(13)/§67(g). Eligible educators now also include **interscholastic sports administrators and coaches**; deductible items now include **nonathletic supplies**. K-12 instructors/counselors who worked 900+ hours qualify. |
 | 12 | Business expenses for reservists, performing artists, fee-basis gov officials | Form 2106 |
 | 13 | HSA deduction | Form 8889 — 2025 limits: $4,300 self-only / $8,550 family, +$1,000 catch-up age 55+ |
 | 14 | Moving expenses | Active-duty military PCS only (TCJA §11049) |
@@ -446,10 +451,10 @@ Compare standard deduction (§2.1) against the sum of Schedule A items. The taxp
 - Line 7: Sum 5e + 6
 
 **Interest paid — Lines 8-10**:
-- Line 8a: Home mortgage interest from 1098 (acquisition debt up to **$750,000** post-12/15/2017 origination; **$1,000,000** grandfathered for older debt — §163(h)(3) as amended by TCJA, made permanent by OBBBA §70110)
+- Line 8a: Home mortgage interest from 1098 (acquisition debt up to **$750,000** post-12/15/2017 origination; **$1,000,000** grandfathered for older debt — §163(h)(3) as amended by TCJA, made permanent by OBBBA §70108)
 - Line 8b: Mortgage interest not on 1098 (seller-financed; report payee name, address, SSN/EIN)
 - Line 8c: Points not on 1098
-- Line 8d: Reserved (mortgage insurance premium deduction expired after 2021 and not reinstated by OBBBA)
+- Line 8d: Mortgage insurance premiums — **deductible as interest**. OBBBA §70108 amended IRC §163(h)(3)(F) so qualified mortgage insurance premiums are again treated as deductible mortgage interest; Line 8d is **no longer "Reserved."**
 - Line 8e: Sum
 - Line 9: Investment interest (Form 4952) — limited to net investment income
 - Line 10: Sum 8e + 9
@@ -457,14 +462,16 @@ Compare standard deduction (§2.1) against the sum of Schedule A items. The taxp
 > Home equity interest is deductible **only if proceeds used to buy, build, or substantially improve** the residence securing the loan (§163(h)(3)(F) post-TCJA). Cash-out for personal use is nondeductible.
 
 **Gifts to charity — Lines 11-14**:
-- Line 11: Cash contributions (limit: 60% of AGI for public charities under §170(b)(1)(G), made permanent by OBBBA §70203; 30% for non-cash to public; 20% for capital gain property to private foundations)
+- Line 11: Cash contributions (limit: 60% of AGI for public charities under §170(b)(1)(G); 30% for non-cash to public; 20% for capital gain property to private foundations)
 - Line 12: Other than cash (Form 8283 required if > $500; qualified appraisal if > $5,000)
 - Line 13: Carryover from prior year (5-year carryforward under §170(d))
 - Line 14: Total
 
+> **NEW 0.5%-of-AGI floor (OBBBA §70425; IRC §170(b)(1)(I)):** Only aggregate charitable contributions **exceeding 0.5% of AGI** are deductible. Example: a taxpayer with $100,000 AGI subtracts a $500 floor from total contributions before deducting. Apply this floor to the Line 14 total.
+
 > **AUDIT FLASH POINT — Charitable contributions outsized vs AGI:** A red flag is non-cash contributions over $5,000 without a qualified appraisal attached (Form 8283 Section B). The IRS DIF score weights charitable deductions relative to AGI heavily. For non-cash gifts of vehicles, refer to Pub 4303 and the contemporaneous written acknowledgment requirement under §170(f)(8). Conservation easements (§170(h)) and syndicated conservation easements are an enforcement priority — refer to a tax controversy specialist if encountered.
 
-**Casualty and theft losses — Line 15**: deductible only if loss is in a **federally declared disaster area** (§165(h)(5) post-TCJA, permanent under OBBBA §70112). Subject to $100 floor per event and 10% AGI floor. Form 4684.
+**Casualty and theft losses — Line 15**: OBBBA §70109 **expanded the deduction to include losses in a STATE-declared disaster area** (in addition to federally declared disasters) under §165(h)(5). Subject to $100 floor per event and 10% AGI floor. Form 4684.
 
 **Other itemized — Line 16**: gambling losses up to gambling winnings (§165(d)), federal estate tax on income in respect of a decedent (§691(c)), impairment-related work expenses, deduction for unrecovered investment in pension at death, amortizable bond premium on pre-10/23/86 taxable bonds.
 
@@ -472,7 +479,7 @@ Compare standard deduction (§2.1) against the sum of Schedule A items. The taxp
 
 ### 6.3 Pease limitation
 
-Pease (§68 overall limitation on itemized deductions) was suspended by TCJA and made **permanent** by OBBBA §70114. **No Pease limitation for 2025.**
+Pease (§68 overall limitation on itemized deductions) was suspended by TCJA; the §68 modification was made **permanent** by OBBBA §70111. **No Pease limitation for 2025.**
 
 ## 7. Line 12-15 — Standard/itemized deduction, QBI, taxable income
 
@@ -546,7 +553,7 @@ Acquired-date day excluded; sale-date day counted. To get long-term, sale must b
 
 ### 10.5 §1202 QSBS
 
-Up to 100% gain exclusion (post-9/27/2010 acquisitions held > 5 years) on $10M / 10× basis cap. Disqualified for FIRE (Finance Insurance Real Estate, etc.) businesses.
+For QSBS **acquired after July 4, 2025**, OBBBA §70431 (IRC §1202(a)) replaces the flat 5-year rule with a **phased exclusion**: **50%** if held **≥ 3 years**, **75%** if held **≥ 4 years**, **100%** if held **≥ 5 years**. The per-issuer cap rises to **$15 million** and the aggregate gross asset test rises to **$75 million**. Disqualified for FIRE (Finance Insurance Real Estate, etc.) businesses. (QSBS acquired on or before July 4, 2025 remains under prior law — flat 100% exclusion after 5 years, $10M / 10× basis cap.)
 
 ### 10.6 §121 home sale exclusion
 
@@ -590,7 +597,7 @@ For MAGI: add back foreign earned income exclusion. Otherwise MAGI ≈ AGI for m
 | 5b | Energy efficient home improvement credit (§25C) | Form 5695 — **OBBBA accelerated termination flag** | — |
 | 6 | Other nonrefundable credits | various | — |
 | 6a | General business credit | Form 3800 | — |
-| 6b | Adoption credit | Form 8839 ($17,280 in 2025, Rev. Proc. 2024-40) | — |
+| 6b | Adoption credit | Form 8839 ($17,280 in 2025, Rev. Proc. 2024-40; up to $5,000 now refundable under OBBBA §70402) | — |
 | 6c | DC first-time homebuyer (legacy) | — | — |
 | 6d | Mortgage interest credit | Form 8396 | — |
 | 6e | Plug-in electric vehicle credit (§30D personal use) | Form 8936 — **OBBBA termination 9/30/2025, see §2.9** | — |
@@ -620,14 +627,14 @@ For MAGI: add back foreign earned income exclusion. Otherwise MAGI ≈ AGI for m
 
 | Credit | Refundable? | Cap 2025 | Phaseout begins (MFJ) |
 |---|---|---|---|
-| Child Tax Credit (CTC) | Partially ($1,700 ACTC) | $2,000/child <17 | $400,000 |
+| Child Tax Credit (CTC) | Partially ($1,700 ACTC) | $2,200/child <17 (OBBBA §70104) | $400,000 |
 | Credit for Other Dependents (ODC) | No | $500/dependent | $400,000 |
 | Earned Income Credit (EITC) | Yes | $649 – $8,046 by # kids | varies by household |
 | Child & Dependent Care | No | $3,000 / $6,000 expenses × 20-35% | $43,000 (rate drops to 20%) |
 | AOTC | 40% refundable | $2,500 (100% first $2k + 25% next $2k) | $160k MFJ ($80k other) |
 | LLC | No | $2,000 (20% of $10k) | $160k MFJ ($80k other) |
 | Saver's Credit | No | $1,000 ($2,000 MFJ) | $79,000 MFJ |
-| Adoption Credit | No (refundable portion under OBBBA §70302 if §36C(a)(2) election) | $17,280 | $259,190 |
+| Adoption Credit | Partially — up to **$5,000 refundable** under OBBBA §70402 (IRC §23(a)(4)); no "36C" election required | $17,280 | $259,190 |
 | Residential Clean Energy (§25D) | No | 30% of qualified spend | none — but OBBBA terminated for property placed in service after 12/31/2025; flag |
 | EV Credit (§30D) | No (transferable at point of sale) | $7,500 new / $4,000 used | $300k MFJ income / $80k MSRP — OBBBA terminated 9/30/2025 |
 
@@ -723,7 +730,7 @@ Rental real estate losses are generally passive. Up to **$25,000** of rental los
 
 ### 17.7 §461(l) excess business loss
 
-For 2025: excess business loss disallowed when business losses exceed business income by more than **$313,000** ($626,000 MFJ) — these thresholds indexed per Rev. Proc. 2024-40. Disallowed amount becomes part of NOL carryforward to next year. OBBBA §70205 made §461(l) permanent.
+For 2025: excess business loss disallowed when business losses exceed business income by more than **$313,000** ($626,000 MFJ) — these thresholds indexed per Rev. Proc. 2024-40. Disallowed amount becomes part of NOL carryforward to next year. OBBBA §70601 made the §461(l) limitation permanent; note the threshold figures now index to the **new 2024 base year** under §70601(b).
 
 ## 18. Common errors checklist
 
@@ -967,8 +974,8 @@ NIIT check: AGI $72,300 < $200k — none. RMD check: Walter is 73, RMD age (73 u
 
 ### 20.1 Primary authority
 
-- **Internal Revenue Code** (Title 26 USC): §§1, 1(g), 1(h), 1(j), 2, 24, 25A, 25D, 30D, 32, 55, 56, 57, 63, 68, 86, 121, 151, 152, 162, 163, 164, 165, 170, 172, 183, 199A, 213, 408, 411, 469, 691, 877A, 1091, 1202, 1211, 1250, 1402, 1411
-- **OBBBA (One Big Beautiful Bill Act, P.L. 119-21)**: §70101 (rate permanence), §70110 (mortgage cap permanence), §70112 (casualty loss), §70113 (misc itemized suspension permanent), §70114 (Pease permanent), §70201 (QBI 23% in 2026), §70203 (60% charity limit permanent), §70205 (§461(l) permanent), §70301 (CTC permanence), §70302 (adoption credit), §70401 ($40k SALT cap 2025-2029), §70405 (§108 QPRI extension), §70501 (§25D termination), §70502 (§30D / §25E termination), §70601 (tip deduction), §70602 (overtime deduction), §70603 (auto loan interest)
+- **Internal Revenue Code** (Title 26 USC): §§1, 1(g), 1(h), 1(j), 2, 23, 24, 25A, 25D, 25E, 30D, 32, 55, 56, 57, 63, 67, 68, 86, 121, 151, 152, 162, 163, 164, 165, 170, 172, 183, 199A, 213, 408, 411, 469, 691, 877A, 1091, 1202, 1211, 1250, 1402, 1411
+- **OBBBA (One Big Beautiful Bill Act, P.L. 119-21)**: §70101 (rate permanence), §70102 (standard deduction / additional standard deduction), §70104 (CTC $2,200 permanence), §70105 (§199A QBI — stays 20%, phase-in threshold + $400 minimum), §70108 (mortgage cap permanence; §163(h)(3)(F) mortgage insurance deductible), §70109 (casualty loss — state-declared disasters), §70110 (educator expenses — dollar limitation removed), §70111 (Pease / §68 permanent), §70113 (misc itemized suspension permanent), §70119 (student-loan discharge exclusion permanent), §70120 ($40k SALT cap + phase-down), §70201 (tip deduction), §70202 (overtime deduction), §70203 (auto loan interest), §70402 (adoption credit — up to $5,000 refundable), §70405 (dependent-care credit enhancement; NOT QPRI), §70425 (0.5%-of-AGI charitable floor), §70431 (§1202 QSBS phased exclusion), §70502 (§30D / §25E termination), §70506 (§25D termination), §70601 (§461(l) permanent)
 - **TCJA (Tax Cuts and Jobs Act, P.L. 115-97)**: §11045 (misc itemized suspension), §11049 (moving expense), §11051 (alimony)
 - **SECURE 2.0 Act (Division T of Consolidated Appropriations Act, 2023)**: §107 (RMD age), §302 (RMD penalty reduction)
 - **Inflation Reduction Act (P.L. 117-169)**: §13301 (§25C/§25D pre-OBBBA), §13401 (§30D pre-OBBBA)
@@ -1012,7 +1019,7 @@ The reviewer must confirm:
 6. Additional Medicare Tax (Form 8959) reconciled to W-2 Box 6 + 1099 withholding.
 7. AMT (Form 6251) at least run mentally for ISO exercises, large PAB interest, or high LTCG with ordinary AMTI in phaseout.
 8. Schedule B questions Part III answered correctly (foreign account, foreign trust).
-9. SALT phaseout (OBBBA §70401(b)) applied if MAGI > $500k.
+9. SALT phaseout (OBBBA §70120) applied if MAGI > $500k.
 10. §25D / §30D OBBBA termination dates verified for any 2025 credit claim.
 11. Kiddie tax Form 8615 for dependents with unearned income > $2,700.
 12. RMD satisfied for taxpayers age 73+ (§401(a)(9), §4974); 25% / 10% penalty on Form 5329 if not.
@@ -1054,3 +1061,9 @@ verified rules together with the name of the accountant who signed them off.
 
 **→ Install the free connector:** <https://www.openaccountants.com/connect>
 **MCP endpoint:** `https://www.openaccountants.com/api/mcp`
+
+---
+
+## Changelog
+
+- **2026-07-04** — OBBBA corrections applied from an in-progress review by Christopher Aryee, CPA: SALT §70120 + phase-down, §199A stays 20%, CTC §70104, §25D §70506, tips/overtime/auto §70201–203, 2026 standard deduction, educator expenses uncapped, mortgage insurance deductible, 0.5% charitable floor, state-disaster casualty losses, Pease §70111, §1202 phased exclusion, adoption credit refundable, §461(l) §70601.

--- a/packages/us-federal/us-form-1041-trust-and-estate-income.md
+++ b/packages/us-federal/us-form-1041-trust-and-estate-income.md
@@ -5,7 +5,8 @@ jurisdiction: US
 category: federal-tax
 tier: 2
 verified_by: pending
-last_updated: 2025-11-15
+reviewed_by: Christopher Aryee, CPA
+last_updated: 2026-07-04
 version: 0.1
 ---
 
@@ -15,6 +16,8 @@ version: 0.1
 > (Enrolled Agent, CPA, attorney) reviews and signs every 1041 before it reaches the
 > fiduciary or the IRS. Where computations interact with state fiduciary income tax,
 > defer to a state-level skill — the federal mechanics here are the input layer.
+
+> **OBBBA update (2026):** Rates, thresholds, and statutory citations in this Guide were corrected against the One Big Beautiful Bill Act following a professional review by **Christopher Aryee, CPA**.
 
 ---
 
@@ -317,6 +320,11 @@ Compare to single individual 2025: 37% top rate starts at $626,350 of taxable in
 
 An estate or trust hits the 37% bracket at $15,650 — 1/40th of the threshold for a
 single individual.
+
+> **Comparison figure — standard deduction (2025).** The 2025 single standard deduction
+> is **$15,750** (OBBBA §70102; IRC §63(c)). Note that trusts and estates get **no**
+> standard deduction — a fiduciary's only equivalent is the §642(b) exemption ($600
+> estate / $300 simple trust / $100 complex trust; see §12).
 
 ### 6.2 The 2025 Long-Term Capital Gain / Qualified Dividend Schedule (§1(h))
 
@@ -750,12 +758,32 @@ Note that §67(e) was held in Knight v. Commissioner (552 U.S. 181 (2008)) and t
 TCJA-era regulations to permit deduction of fiduciary fees and other "uniquely
 fiduciary" expenses on the 1041 above-the-line, NOT subject to the §67(g) suspension
 of miscellaneous itemized deductions. Investment advisory fees, however, are NOT
-uniquely fiduciary and remain suspended under §67(g) for 2018–2025.
+uniquely fiduciary and remain suspended under §67(g).
+
+> **OBBBA update — §67(g) suspension is now PERMANENT.** The suspension of miscellaneous
+> itemized deductions (originally the TCJA 2018–2025 window) was made **permanent** by
+> OBBBA for tax years after Dec 31, 2025 (OBBBA §70110; IRC §67(g)). These deductions do
+> **NOT** return in 2026 as previously scheduled under the TCJA sunset. Investment
+> advisory fees and other non-"uniquely-fiduciary" expenses stay non-deductible on the
+> 1041 going forward; the §67(e) uniquely-fiduciary above-the-line treatment (Knight)
+> is unaffected.
 
 ### 15.2 Partial Allocation Allowed
 
 The election can be made item-by-item — e.g. deduct attorney fees on 1041 and executor
 commissions on 706 — provided each item is wholly assigned to one or the other.
+
+### 15.3 OBBBA SALT Deduction Cap Increase — Effect on Fiduciary Taxable Income and DNI
+
+For tax years beginning after **Dec 31, 2024**, OBBBA raised the cap on individual state
+and local tax (SALT) deductions from **$10,000 to $40,000** (**$20,000 for married filing
+separately**), scheduled to run **through 2029** (OBBBA §70120; IRC §164(b)(6)–(7)). For a
+fiduciary that itemizes deductible state and local taxes on Form 1041, the higher cap can
+increase the estate's or trust's allowable SALT deduction, which reduces **taxable income**
+and, through it, **Distributable Net Income (DNI)** — flowing a smaller amount of taxable
+income out to beneficiaries on their K-1s. Model the cap when a fiduciary carries material
+state and local tax; the interaction with DNI (§7) changes both the entity's tax and the
+beneficiaries' K-1 amounts.
 
 ---
 
@@ -878,6 +906,13 @@ phaseout — for 2025, the trust/estate AMT exemption is approximately $30,700 w
 phaseout beginning at approximately $102,500 (figures indexed annually; verify against
 Rev. Proc. 2024-40 or the 2025 instructions to Form 1041 Schedule I).
 
+> **OBBBA / verification note.** These 2025 figures ($30,700 exemption; $102,500
+> phase-out) are estimates and should be **verified against the final 2025 Form 1041
+> Schedule I instructions**. OBBBA (§70107; IRC §55(d)(4)) **permanently extended** the
+> increased AMT exemption and phase-out, with new inflation-adjustment and phase-out-rate
+> modifications taking effect from Jan 1, 2026 — so 2026-onward figures follow the
+> revised OBBBA mechanics, not a TCJA sunset.
+
 ### 19.3 Intangible Drilling Costs, Depletion
 
 Trusts and estates pass through depreciation, depletion, and amortization directly
@@ -891,9 +926,12 @@ A non-grantor trust is treated as a separate taxpayer for §199A QBI purposes. T
 gets its own QBI deduction (up to 20% of QBI) on its own retained QBI income. To the
 extent QBI flows out via K-1, the beneficiary takes the QBI deduction on her own 1040.
 The §199A thresholds for trusts are the single-individual amounts — i.e. trust hits the
-phaseout at the single threshold (~$241,950 for 2025 indexed). This is one of the few
-places trusts do NOT face compressed brackets; the §199A thresholds are at individual
-levels.
+phaseout at the single (non-joint) threshold. For **2025** that threshold is **$197,300**,
+with a **$50,000 phase-out range** for non-joint filers (fully out at **$247,300**) —
+NOT ~$241,950, which is the 2024 figure (Rev. Proc. 2024-40; IRC §199A). Starting **2026**,
+OBBBA (§70105) **raises the phase-in threshold to $75,000 ($150,000 joint)**. This is one
+of the few places trusts do NOT face compressed brackets; the §199A thresholds are at
+individual levels.
 
 Caveat — anti-abuse rules under Reg. §1.643(f)-1 disregard trusts created principally
 to avoid federal income tax, including for §199A purposes.
@@ -1308,6 +1346,9 @@ beneficiaries' marginal brackets can be precisely estimated.
       filed if needed.
 - [ ] §642(g) election filed on 1041 (in writing) if administrative expenses claimed
       on 1041 — 706 deduction waived for those items.
+- [ ] SALT deduction cap applied at the OBBBA amount — $40,000 ($20,000 MFS) for tax
+      years after Dec 31, 2024 through 2029 (was $10,000), if the fiduciary itemizes
+      state/local taxes on 1041; remember it reduces taxable income and DNI (§15.3).
 - [ ] §691 IRD items identified, included on 1041 income, basis NOT stepped up.
 - [ ] §691(c) deduction computed if 706 was filed and IRD was in gross estate.
 - [ ] K-1s issued to each beneficiary with character allocated pro rata to DNI
@@ -1426,3 +1467,9 @@ verified rules together with the name of the accountant who signed them off.
 
 **→ Install the free connector:** <https://www.openaccountants.com/connect>
 **MCP endpoint:** `https://www.openaccountants.com/api/mcp`
+
+---
+
+## Changelog
+
+- **2026-07-04** — OBBBA corrections applied from a review by Christopher Aryee, CPA: SALT $40k cap + DNI impact, QBI 2025 threshold $197,300, permanent §67(g) suspension, standard deduction $15,750, fiduciary AMT verification note.

--- a/packages/us-federal/us-form-1065-partnership.md
+++ b/packages/us-federal/us-form-1065-partnership.md
@@ -1,17 +1,20 @@
 ---
 name: us-form-1065-partnership
-description: Tier 2 US federal content skill for preparing Form 1065 — the US partnership return. Covers tax year 2025 including the March 15 due date and Form 7004 6-month extension, the $245-per-partner-per-month §6698 penalty even for no-tax-due returns, the tax basis capital account reporting requirement, the Centralized Partnership Audit Regime (CPAR/BBA) and the Schedule B-2 election out, Schedule K-1 preparation including §199A passthrough codes, Schedules K-2 and K-3 for international items, §704(b) special allocations, §704(c) contributed property, §752 liability share, basis/at-risk/passive limits, and the post-Soroban scrutiny on limited-partner SE exemption.
+description: Tier 2 US federal content skill for preparing Form 1065 — the US partnership return. Covers tax year 2025 including the March 15 due date and Form 7004 6-month extension, the $255-per-partner-per-month §6698 penalty even for no-tax-due returns, the tax basis capital account reporting requirement, the Centralized Partnership Audit Regime (CPAR/BBA) and the Schedule B-2 election out, Schedule K-1 preparation including §199A passthrough codes, Schedules K-2 and K-3 for international items, §704(b) special allocations, §704(c) contributed property, §752 liability share, basis/at-risk/passive limits, and the post-Soroban scrutiny on limited-partner SE exemption.
 jurisdiction: US
 category: federal-tax
 tier: 2
 verified_by: pending
-last_updated: 2025-11-15
+reviewed_by: Christopher Aryee, CPA
+last_updated: 2026-07-04
 version: 0.1
 ---
 
 # US Form 1065 — Partnership Return (Tax Year 2025)
 
 > **Tier 2 federal content skill.** MUST be loaded alongside `us-tax-workflow-base` v0.2+. This skill provides the partnership-return rules; the workflow base provides the intake, runbook, and reviewer-package scaffolding. Federal only. State pass-through entity (PTE) filings are deferred to the relevant state skill.
+
+> **OBBBA update (2026):** Rates, thresholds, and statutory citations in this Guide were corrected against the One Big Beautiful Bill Act following a professional review by **Christopher Aryee, CPA**.
 
 ---
 
@@ -145,6 +148,10 @@ Form 7004 is **automatic** — no reason needs to be stated. But:
 - [ ] Extended due date computed and calendared
 - [ ] Partners notified of K-1 delivery target date
 
+### 3.5 Mandatory electronic filing
+
+Beginning with returns required to be filed in 2024, a partnership **must e-file** Form 1065 (and Form 7004) if it is required to file **10 or more returns of ANY type** during the calendar year. The 10-return count is aggregate across all return types — it includes information returns such as Forms 1099 and W-2, not just income tax returns. A partnership with, for example, five 1099-NEC forms, three W-2s, and its Form 1065 has crossed the 10-return threshold and must e-file. (Source: Instructions for Form 1065 (2025), Electronic Filing.)
+
 ---
 
 ## 4. The §6698 Late-Filing Penalty
@@ -153,25 +160,25 @@ Form 7004 is **automatic** — no reason needs to be stated. But:
 
 IRC §6698 imposes a penalty for failure to file a complete and timely Form 1065:
 
-> **$245 per partner, per month (or fraction thereof), for up to 12 months.**
+> **$255 per partner, per month (or fraction thereof), for up to 12 months.**
 
-The $245 figure is the 2025 indexed amount under §6698(b)(1) and §6698(e). The base amount was set at $195 by the Tax Increase Prevention Act of 2014 and is adjusted annually for inflation under §6698(e). Historical recent values (verify against Rev. Proc. 2024-40 or successor for the exact 2025 figure):
+The $255 figure is the 2025 indexed amount under §6698(b)(1) and §6698(e), per the Instructions for Form 1065 (2025), Penalties. The base amount was set at $195 by the Tax Increase Prevention Act of 2014 and is adjusted annually for inflation under §6698(e). Historical recent values:
 
 | Tax year | Per-partner / per-month |
 |----------|------------------------|
 | 2023 | $220 |
 | 2024 | $235 |
-| 2025 | $245 (verify; ~$245 per Rev. Proc. 2024-40 §3.61) |
+| 2025 | $255 (per Instructions for Form 1065 (2025), Penalties) |
 
 **The penalty applies even when the partnership owes no tax** — which it almost never does. This is the most common compliance failure cost in partnership practice.
 
 ### 4.2 Examples
 
-- **3-partner LLC, return filed 2 months late, no extension:** 3 partners × $245 × 2 months = **$1,470**.
-- **3-partner LLC, return filed 13 months late:** 3 × $245 × 12 (capped) = **$8,820**.
-- **20-partner LP, return filed 6 months late:** 20 × $245 × 6 = **$29,400**.
+- **3-partner LLC, return filed 2 months late, no extension:** 3 partners × $255 × 2 months = **$1,530**.
+- **3-partner LLC, return filed 13 months late:** 3 × $255 × 12 (capped) = **$9,180**.
+- **20-partner LP, return filed 6 months late:** 20 × $255 × 6 = **$30,600**.
 
-The penalty scales linearly with partner count. A 50-partner FLP filed 12 months late owes **$147,000** in §6698 penalties — for a return showing zero tax.
+The penalty scales linearly with partner count. A 50-partner FLP filed 12 months late owes **$153,000** in §6698 penalties — for a return showing zero tax.
 
 ### 4.3 Reasonable cause relief — Rev. Proc. 84-35
 
@@ -317,6 +324,10 @@ For a limited partner (Item G "Limited partner or other LLC member"): historical
 ### 6.5 Reconciliation check
 
 Reviewer test: Σ over all K-1s of (Box 1 + Box 4a + Box 4b + Box 5 + Box 6a + Box 7 + Box 8 + Box 9a + Box 10 + Box 11 + …) − (Box 12 + Box 13 +  …) should reconcile to Schedule K. The skill produces a per-line reconciliation table in the reviewer brief.
+
+### 6.6 Qualified farmland gain — installment election (Box 20, Code ZZ)
+
+Under **P.L. 119-21 §1062 (OBBBA §70437)**, a partner may elect to pay the tax on gain from the sale of **qualified farmland** in **four equal annual installments**. The partnership reports the information supporting this election through **Schedule K-1, Box 20, Code ZZ**, together with the required covenant copy (the statement of the covenant restricting the land to continued qualified agricultural use). The election is made and administered at the partner level; the partnership's job is to furnish the complete Box 20, Code ZZ statement. (Source: Instructions for Form 1065 (2025).)
 
 ---
 
@@ -572,8 +583,8 @@ Multiple layers accumulate over the life of a partnership. Real estate partnersh
 ### 12.4 Disclosure on K-1
 
 - Item M asks whether the partner contributed property with a built-in gain or loss
-- Item N reports the partner's share of net unrecognized §704(c) gain or loss — beginning and ending
-- Box 20 carries §704(c) information in a statement (codes vary by year; verify against 2025 instructions)
+- Item N reports each partner's share of net unrecognized §704(c) gains or losses at **both the beginning and the end of the tax year** on Schedule K-1
+- Box 20 carries §704(c) information in a statement. Report the **sum** of the partner's net unrecognized §704(c) gains/losses in **Box 20, Code AA** (for partners that are not publicly traded partnerships) when the partnership's taxable income is affected. (Source: Instructions for Form 1065 (2025).)
 
 ### 12.5 What this skill does
 
@@ -745,7 +756,9 @@ Excluded from SE income (regardless of partner type):
 
 §199A (enacted by TCJA, made permanent at 20% by OBBBA P.L. 119-21 §70105 effective for tax years beginning after Dec 31, 2024) provides a deduction up to 20% of qualified business income (QBI) from a domestic trade or business operated as a sole proprietorship, partnership, S corporation, trust, or estate. For partnerships, QBI flows out to partners on K-1.
 
-For tax year 2025, the deduction rate remains 20%. (OBBBA sets the rate at 23% for tax years beginning after Dec 31, 2025 — i.e., tax year 2026.)
+The §199A deduction rate **stays 20%** — OBBBA made the deduction permanent but did **not** raise the rate to 23%. (Source: IRC §199A(a); OBBBA §70105.)
+
+OBBBA also added a new **minimum deduction of $400** for "applicable taxpayers." An applicable taxpayer is one whose **aggregate active QBI** from all of the taxpayer's active qualified trades or businesses is **at least $1,000**. Such a taxpayer's §199A deduction is no less than $400 (indexed for inflation in later years). This minimum is computed at the partner level; the partnership supplies the QBI inputs. (Source: IRC §199A(a), §199A(i); OBBBA §70105.)
 
 ### 16.2 What the partnership reports
 
@@ -789,7 +802,7 @@ The partner can also aggregate at their own level — but cannot disaggregate it
 | **4562** Depreciation and Amortization | Any depreciation, amortization, §179, listed property, or property placed in service this year | §179 expense flows out separately on K-1 (subject to §179(d)(8) partner-level limit) |
 | **4797** Sales of Business Property | §1231 gain/loss, §1245/1250 recapture, ordinary gain on §1239 sales | §1231 gain flows to K-1 Box 10 |
 | **8825** Rental Real Estate Income and Expenses | Any rental real estate activity | Replaces Schedule E logic for partnerships; output flows to K Line 2 / K-1 Box 2 |
-| **8990** §163(j) Limitation on Business Interest Expense | Partnership not eligible for §163(j) small-business exemption (gross receipts > $30M for 2025, verify against §448(c)) | Excess business interest is allocated to partners and carried at the partner level; complex 11-step §163(j) partner-level rule |
+| **8990** §163(j) Limitation on Business Interest Expense | Partnership not eligible for §163(j) small-business exemption. For 2025 the exemption applies when average annual gross receipts for the 3 prior tax years are **$31 million or less** (§448(c)); a partnership **exceeding** $31 million generally must file Form 8990 | Excess business interest is allocated to partners and carried at the partner level; complex 11-step §163(j) partner-level rule |
 | **6765** Credit for Increasing Research Activities | Qualified research expenses | Credit flows on K-1 Box 15 |
 | **8283** Noncash Charitable Contributions | Property contribution > $500 | Special partnership rules apply for partner-level deduction |
 | **8332** Release of Claim to Exemption | Not applicable to partnerships, but partners may need at their level | n/a |
@@ -800,6 +813,13 @@ The partner can also aggregate at their own level — but cannot disaggregate it
 | **8918** Material Advisor Disclosure | Material advisor to a reportable transaction | Rare; reviewer attention |
 | **8275 / 8275-R** Disclosure Statement | Any position requiring disclosure to avoid §6662 penalty | Attach when needed |
 | **Schedule M-3** | Total assets ≥ $10M at end of year (or other §1.6011-4 triggers) | Much more detailed than M-1; can be very time-intensive |
+
+### 17.1 What's New — OBBBA construction and R&D changes
+
+Two OBBBA provisions change how partnerships engaged in construction or research treat their expenses:
+
+- **(a) Residential construction — percentage-of-completion exception (OBBBA §70430).** OBBBA §70430 **expanded** the exception to the percentage-of-completion method (§460) to cover **residential construction contracts**, applying the **3-year completion test**. Qualifying residential construction contracts may therefore use a permitted alternative to percentage-of-completion accounting. (Source: OBBBA §70430.)
+- **(b) Domestic R&D — new IRC §174A (OBBBA §70302).** New **IRC §174A** allows **current expensing of domestic research and experimental expenditures** for tax years beginning after 2024 (reversing the §174 capitalize-and-amortize requirement for domestic R&D). Foreign R&D remains subject to capitalization. (Source: OBBBA §70302.)
 
 ---
 
@@ -1065,7 +1085,7 @@ So in this fact pattern, the LP/GP characterization for §1402 is **moot** becau
 - IRC §§704, 707, 752 (allocation, capital accounts, liabilities)
 - IRC §§465, 469, 461(l) (loss limits)
 - IRC §1402 (self-employment tax); §1402(a)(13) (limited partner exclusion)
-- IRC §199A (QBI deduction); made permanent at 20% (2025) / 23% (2026+) by OBBBA P.L. 119-21 §70105
+- IRC §199A (QBI deduction); made permanent at 20% by OBBBA P.L. 119-21 §70105 (rate stays 20% — not raised to 23%; new $400 minimum deduction for applicable taxpayers with aggregate active QBI ≥ $1,000 under §199A(i))
 - IRC §§6221–6241 (Centralized Partnership Audit Regime / BBA)
 - Treas. Reg. §301.7701-1 through -3 (entity classification)
 - Treas. Reg. §1.704-1, -2, -3 (substantial economic effect; §704(c) methods)
@@ -1096,10 +1116,13 @@ So in this fact pattern, the LP/GP characterization for §1402 is **moot** becau
 
 ### 21.4 Statutory changes from OBBBA (P.L. 119-21, July 4, 2025) potentially affecting this skill
 
-- §199A made permanent at 20% (2025) / 23% (2026+) — confirmed
+- §199A made permanent at 20% (rate stays 20% — OBBBA did NOT raise it to 23%); new $400 minimum deduction added for applicable taxpayers (aggregate active QBI ≥ $1,000) under §199A(i) — confirmed
 - §461(l) excess business loss limit made permanent
-- §163(j) interest limitation — small business exemption threshold (gross receipts) — verify Rev. Proc. 2024-40 for 2025 threshold
-- §6698 penalty amount — verify 2025 indexed figure
+- §163(j) interest limitation — small business exemption threshold is average annual gross receipts of **$31 million or less** (3 prior years) for 2025; exceeding it generally requires Form 8990 (Instructions for Form 1065 (2025))
+- §6698 penalty amount — **$255** per partner per month (or fraction), max 12 months, for 2025 (Instructions for Form 1065 (2025), Penalties)
+- Residential construction — OBBBA §70430 expanded the §460 percentage-of-completion exception to residential construction contracts (3-year completion test)
+- Domestic R&D — new IRC §174A (OBBBA §70302) allows current expensing of domestic research expenditures for tax years beginning after 2024
+- Qualified farmland gain — P.L. 119-21 §1062 (OBBBA §70437) four-equal-installment election, reported via Schedule K-1 Box 20, Code ZZ
 - §1402 self-employment tax — no statutory change; Soroban case law continues to develop
 
 ### 21.5 Disclaimer
@@ -1142,3 +1165,9 @@ verified rules together with the name of the accountant who signed them off.
 
 **→ Install the free connector:** <https://www.openaccountants.com/connect>
 **MCP endpoint:** `https://www.openaccountants.com/api/mcp`
+
+---
+
+## Changelog
+
+- **2026-07-04** — OBBBA corrections applied from a review by Christopher Aryee, CPA: §6698 penalty $255, §199A stays 20% + $400 minimum, §163(j) $31M, residential-construction & §174A, farmland installment election (Box 20 ZZ), e-file 10-return threshold, §704(c) Item N / Box 20 AA.

--- a/packages/us-federal/us-form-1120-c-corp.md
+++ b/packages/us-federal/us-form-1120-c-corp.md
@@ -1,11 +1,12 @@
 ---
 name: us-form-1120-c-corp
-description: Tier 2 US federal content skill for preparing Form 1120 — the US C-corporation income tax return. Covers tax year 2025 under OBBBA including the 21% flat rate, DRD tiers (50/65/100%), §163(j) interest limit, §174 R&D capitalization, §250 GILTI/FDII deduction at 50%/37.5%, the 15% Corporate AMT on AFSI > $1B (IRA 2022), required schedules (B, C, J, K, L, M-1/M-3, O, UTP), and common attached forms (4562, 4626, 5471/5472 refer-out, 6765, 8993, 1125-A, 1125-E). Filing due 15th day of 4th month; Form 7004 6-month extension; quarterly estimated 25/25/25/25 with no 110% safe harbor for corps.
+description: Tier 2 US federal content skill for preparing Form 1120 — the US C-corporation income tax return. Covers tax year 2025 under OBBBA including the 21% flat rate, DRD tiers (50/65/100%), §163(j) interest limit (EBITDA add-back restored), §174A domestic R&D immediate expensing (foreign R&D 15-year amortization), §250 GILTI/FDII deduction (50%/37.5% for tax years beginning in 2025; new permanent OBBBA rates of 40%/33.34% from 2026), the 15% Corporate AMT on AFSI > $1B (IRA 2022), required schedules (B, C, J, K, L, M-1/M-3, O, UTP), and common attached forms (4562, 4626, 5471/5472 refer-out, 6765, 8993, 1125-A, 1125-E). Filing due 15th day of 4th month; Form 7004 6-month extension; quarterly estimated 25/25/25/25 with no 110% safe harbor for corps.
 jurisdiction: US
 category: federal-tax
 tier: 2
 verified_by: pending
-last_updated: 2025-11-15
+reviewed_by: Christopher Aryee, CPA
+last_updated: 2026-07-04
 version: 0.1
 ---
 
@@ -13,11 +14,13 @@ version: 0.1
 
 > Tier 2 federal content skill. MUST be loaded alongside `us-tax-workflow-base` v0.2 or later. Federal only — state corporate income tax is out of scope; route to the relevant state skill when needed.
 
+> **OBBBA update (2026):** Rates, thresholds, and statutory citations in this Guide were corrected against the One Big Beautiful Bill Act following a professional review by **Christopher Aryee, CPA**.
+
 ---
 
 ## 1. Scope
 
-This skill covers the preparation of **Form 1120, U.S. Corporation Income Tax Return**, for tax year 2025 for a domestic C-corporation operating in the United States. It walks through the income computation, the tax computation on Schedule J, the required schedules (B, C, J, K, L, M-1/M-3, O, UTP where applicable), the most common attached forms, and the corporate-specific provisions that differ from individual taxation (DRD, NOL post-TCJA, §163(j), §174 capitalization, §250 GILTI/FDII deduction, and the 15% Corporate Alternative Minimum Tax).
+This skill covers the preparation of **Form 1120, U.S. Corporation Income Tax Return**, for tax year 2025 for a domestic C-corporation operating in the United States. It walks through the income computation, the tax computation on Schedule J, the required schedules (B, C, J, K, L, M-1/M-3, O, UTP where applicable), the most common attached forms, and the corporate-specific provisions that differ from individual taxation (DRD, NOL post-TCJA, §163(j), §174A R&D expensing, §250 GILTI/FDII deduction, and the 15% Corporate Alternative Minimum Tax).
 
 **In scope:**
 - Calendar-year and fiscal-year domestic C-corporations chartered in any US state or DC
@@ -27,8 +30,8 @@ This skill covers the preparation of **Form 1120, U.S. Corporation Income Tax Re
 - Schedule C dividends-received deduction (DRD)
 - Net operating loss (NOL) treatment under the post-TCJA regime (80% limitation, indefinite carryforward, no carryback)
 - §163(j) business interest expense limitation
-- §174 specified research and experimental (SRE) capitalization
-- §250 GILTI/FDII deduction (at the post-TCJA, pre-sunset 2025 rates of 50% / 37.5%)
+- §174A specified research and experimental (SRE) expensing — domestic immediate expensing, foreign 15-year amortization (OBBBA §70302)
+- §250 GILTI/FDII deduction (50% / 37.5% for tax years beginning in 2025; new permanent OBBBA rates of 40% / 33.34% from 2026)
 - Corporate Alternative Minimum Tax (CAMT) under IRC §55(b)(2) and §59(k) for applicable corporations
 - Estimated tax requirements under IRC §6655 with the corporate safe-harbor rules
 - Late filing (§6651) and late payment (§6651(a)(2)) penalties
@@ -235,7 +238,7 @@ Form 1120 income flows in this order: gross income → total income (line 11) �
 | 23 | Pension, profit-sharing, etc. | Employer contributions; see §404 timing rules. |
 | 24 | Employee benefit programs | Health, group term life, dependent care, etc., not deducted elsewhere. |
 | 25 | Reserved (formerly DPAD; repealed by TCJA). | Leave blank. |
-| 26 | Other deductions | Attach statement. Common items: insurance, utilities, professional fees, office expense, travel and meals (50% limit per §274(n)), software subscriptions, bank fees, R&E expenses subject to §174 capitalization (see §9). |
+| 26 | Other deductions | Attach statement. Common items: insurance, utilities, professional fees, office expense, travel and meals (50% limit per §274(n)), software subscriptions, bank fees, domestic R&E expenses now immediately deductible under §174A (see §10). |
 | 27 | Total deductions. | |
 | 28 | Taxable income before NOL deduction and special deductions = Line 11 − Line 27. | |
 | 29a | Net operating loss deduction. | See §7. |
@@ -377,11 +380,13 @@ For tax years beginning after December 31, 2017, IRC §163(j) limits the deducti
 
 Disallowed business interest **carries forward indefinitely** and is deducted in future years subject to the same limit.
 
-### 9.2 ATI definition (post-2022)
+### 9.2 ATI definition — EBITDA add-back restored by OBBBA
 
-For tax years **beginning before January 1, 2022**, ATI was computed by adding back depreciation, amortization, and depletion to taxable income — effectively an **EBITDA** base. For tax years **beginning on or after January 1, 2022** (a TCJA-driven change that became effective in 2022 and was **not reversed by OBBBA**), ATI is computed without that add-back, making it effectively an **EBIT** base. This makes the §163(j) limit substantially tighter for capital-intensive businesses.
+From tax years beginning in 2022 through 2024, ATI was computed on an **EBIT** base (no add-back for depreciation, amortization, or depletion), which tightened the §163(j) limit for capital-intensive businesses. **OBBBA (§70303) permanently restored the EBITDA add-back** for tax years **beginning after December 31, 2024**.
 
-**For 2025:** ATI is **EBIT-based** — do not add back depreciation, amortization, or depletion when computing ATI. Confirm against the Form 8990 instructions current for 2025. (Legislative proposals to restore the EBITDA add-back have circulated repeatedly but were not enacted in OBBBA.)
+**For 2025:** ATI is **EBITDA-based** — **add back depreciation, amortization, and depletion** (in addition to business interest expense, any NOL deduction, and the §250 deduction) when computing ATI. This loosens the limit for capital-intensive businesses. Confirm against the Form 8990 instructions current for 2025.
+
+Source: OBBBA §70303; IRC §163(j).
 
 ### 9.3 Small-business exemption
 
@@ -406,44 +411,44 @@ Computed on **Form 8990, Limitation on Business Interest Expense Under Section 1
 - Business interest income = $50,000
 - Floor plan financing = $0
 
-**ATI computation (EBIT-based, 2025):**
+**ATI computation (EBITDA-based, 2025 — OBBBA add-back restored):**
 - Start with taxable income before interest = $5,000,000
 - Add back: business interest expense ($1,800,000) — yes
+- Add back: depreciation/amortization/depletion ($1,500,000) — **yes** (restored by OBBBA §70303)
 - Add back: NOL deduction — yes
 - Add back: §250 deduction — yes
-- Do NOT add back depreciation/amortization (post-2021 rule).
-- ATI = $5,000,000 + $1,800,000 = $6,800,000 (assume no NOL or §250)
+- ATI = $5,000,000 + $1,800,000 + $1,500,000 = $8,300,000 (assume no NOL or §250)
 
 **Limit:**
-- 30% × $6,800,000 = $2,040,000
-- Plus business interest income $50,000 = $2,090,000
+- 30% × $8,300,000 = $2,490,000
+- Plus business interest income $50,000 = $2,540,000
 
 **Result:**
-- Business interest of $1,800,000 ≤ $2,090,000 limit → fully deductible.
+- Business interest of $1,800,000 ≤ $2,540,000 limit → fully deductible.
 
 **Alternative (tight scenario):**
-- If business interest = $2,500,000:
-- Deductible = $50,000 (interest income) + $2,040,000 (30% × ATI) = $2,090,000
-- Disallowed and carried forward = $2,500,000 − $2,090,000 = $410,000
+- If business interest = $3,000,000:
+- Deductible = $50,000 (interest income) + $2,490,000 (30% × ATI) = $2,540,000
+- Disallowed and carried forward = $3,000,000 − $2,540,000 = $460,000
 
 ---
 
-## 10. §174 R&D capitalization
+## 10. §174 / §174A R&D expensing
 
-### 10.1 The post-TCJA rule
+### 10.1 The rule after OBBBA — new §174A
 
-Effective for tax years beginning after December 31, 2021, TCJA's §174 amendment requires **capitalization and amortization** of "specified research and experimental expenditures" (SREs):
+The TCJA required **capitalization and amortization** of "specified research and experimental expenditures" (SREs) for tax years beginning after December 31, 2021 (domestic over 5 years, foreign over 15 years). **OBBBA (§70302) enacted a new IRC §174A that reverses this for domestic R&D:**
 
-- **Domestic SREs:** capitalize and amortize over **5 years** (60 months), straight-line, beginning with the midpoint of the year incurred (half-year convention).
-- **Foreign SREs** (R&E performed outside the US): capitalize and amortize over **15 years** (180 months), beginning at the midpoint of the year incurred.
+- **Domestic SREs:** for tax years **beginning after December 31, 2024**, domestic research or experimental expenditures may be **fully expensed IMMEDIATELY** in the year incurred under §174A. (A taxpayer may instead elect to capitalize and amortize over not less than 60 months, but immediate expensing is the default.) The domestic §174A deduction **must be reduced by the §41 research credit** unless the §280C(c)(2) reduced-credit election is made.
+- **Foreign SREs** (R&E performed outside the US): **no change** — these remain subject to **15-year (180-month)** capitalization and amortization, beginning at the midpoint of the year incurred.
 
-Prior to 2022, taxpayers could elect to deduct R&E currently under §174(a) — that election is no longer available; capitalization is mandatory.
+Source: OBBBA §70302; IRC §174A.
 
-### 10.2 Status as of 2025
+### 10.2 Status after OBBBA
 
-**The §174 capitalization rule remains in effect for 2025.** Multiple legislative proposals (e.g., the Tax Relief for American Families and Workers Act of 2024, various standalone bills, the "Build It in America Act") sought to restore current-year deductibility for domestic R&E. **None has been enacted as of the OBBBA enactment date (July 4, 2025).** OBBBA itself did not change §174.
+**OBBBA (§70302) restored immediate expensing of domestic R&D through new IRC §174A**, effective for tax years beginning after December 31, 2024. For any 2025 return, domestic SREs are **deductible in full in the year incurred** (subject to the §41-credit reduction); they are no longer capitalized over 5 years. The long line of restoration proposals (the Tax Relief for American Families and Workers Act of 2024, the "Build It in America Act," etc.) has therefore been overtaken — the fix is now law.
 
-Watch for legislative developments mid-2025 / 2026 — the 119th Congress has continued to introduce restoration bills, often packaged with §163(j) EBITDA restoration and §168(k) bonus extension. If a restoration is enacted retroactively for 2025, the return may need to be amended.
+Only **foreign** R&E remains on the 15-year amortization schedule. Confirm which expenditures are domestic vs. foreign, because the treatment now diverges sharply.
 
 ### 10.3 What counts as SRE
 
@@ -459,9 +464,9 @@ What does NOT count: market research, quality control, advertising, management s
 
 ### 10.4 Mechanics on Form 1120
 
-- SREs incurred in 2025 are **not directly deductible** on Lines 13, 22, 26, etc.
-- Capitalize on Form 4562 (intangibles section) and amortize over 5 or 15 years.
-- The current-year amortization deduction (1/10 of domestic SREs in year 1 under half-year convention, then 1/5 per year for 4 years, then 1/10 in year 6 — actually: 10% / 20% / 20% / 20% / 20% / 10% over 6 calendar years for 5-year period under half-year, OR 1/2 month start of midpoint convention depending on interpretation; the IRS in Rev. Proc. 2023-8 / Rev. Proc. 2023-11 has clarified mechanics) flows to Form 1120 Line 26 (or appropriate line) as "amortization of §174 costs."
+- **Domestic SREs incurred in 2025 are directly deductible** in full under §174A — take them on the appropriate expense line (e.g., Line 26, "Other deductions"). They are no longer capitalized on Form 4562.
+- **Foreign SREs** are still capitalized on Form 4562 (intangibles section) and amortized over 15 years (180 months), beginning at the midpoint of the year incurred; the current-year amortization flows to Form 1120 Line 26 as "amortization of §174 costs."
+- Remember to reduce the domestic §174A deduction by the §41 credit under §280C(c) unless the reduced-credit election is made (see §10.5).
 
 **Refer R&D mechanics to `us-r-and-d-credit-and-174` for detail.** This skill notes the existence of the rule and flags it for the preparer; for any return with material R&E spend (defined here as >$50k of arguable SRE), the R&D skill should be loaded alongside.
 
@@ -480,14 +485,18 @@ For tax years beginning after December 31, 2017, IRC §250 (added by TCJA §1420
 1. **GILTI** (Global Intangible Low-Taxed Income inclusion under §951A) — a **50% deduction**, effectively bringing the GILTI tax rate to 10.5% (50% × 21%).
 2. **FDII** (Foreign-Derived Intangible Income, generally income from US-based serving of foreign markets) — a **37.5% deduction**, effectively bringing the FDII rate to 13.125% (62.5% × 21%).
 
-### 11.2 The 2025 rates and the 2026 sunset
+### 11.2 The 2025 rates and the new permanent OBBBA rates from 2026
 
-Under §250(a)(3), the deduction percentages were scheduled to drop for tax years beginning after December 31, 2025:
+**For tax years beginning in 2025, the 50% (GILTI) / 37.5% (FDII) deduction rates still apply.**
 
-- GILTI: 50% → **37.5%** (effective rate 13.125%)
-- FDII: 37.5% → **21.875%** (effective rate ~16.41%)
+The pre-OBBBA law scheduled a drop to 37.5% / 21.875% after 2025. **OBBBA (§70321) repealed that scheduled cut and set NEW PERMANENT deduction rates for tax years beginning after December 31, 2025:**
 
-**Status as of OBBBA:** OBBBA did not extend the higher rates. **For tax years beginning in 2025, the 50% / 37.5% rates still apply.** For tax years beginning in 2026, the lower 37.5% / 21.875% rates apply unless further legislation intervenes. Flag this on multi-year planning for clients with material GILTI/FDII.
+- **FDII deduction: 33.34%** (not the old 21.875%).
+- **GILTI deduction: 40%** — GILTI is also **renamed "net CFC tested income"** under OBBBA.
+
+So from 2026 the deductions are **higher** than the old scheduled sunset rates, and permanent. Update multi-year planning for clients with material GILTI/net CFC tested income and FDII.
+
+Source: OBBBA §70321; IRC §250(a)(1).
 
 ### 11.3 The taxable-income limitation — §250(a)(2)
 
@@ -504,6 +513,18 @@ GILTI inclusion itself flows to Schedule C Line 14 (as "other dividends" — his
 The actual GILTI computation (tested income, QBAI return, allocated deductions, high-tax exclusion election under §951A(c)(2)(B)(ii) Reg. §1.951A-2(c)(7)) is highly technical. Similarly, the FDII computation (deduction-eligible income, foreign-derived deduction-eligible income, deemed intangible income) involves multi-step allocations under Reg. §1.250(b)-1 through -6. For any return with material GILTI or FDII, refer to `us-gilti-fdii-computation` (separate skill).
 
 This skill notes the existence of the deduction, the 2025 rates, and the form (8993), and ensures the line items flow correctly on Form 1120 and Schedule C.
+
+### 11.6 OBBBA restriction on Deduction Eligible Income (DEI)
+
+**OBBBA (§70322) narrowed the FDII base.** For **sales or dispositions after June 16, 2025**, Deduction Eligible Income (DEI) **excludes any gain from the sale or disposition of intangible property and of depreciable, amortizable, or depletable property**. In addition, **interest expense and research and experimental expenditures are no longer subtracted** in arriving at DEI. Both changes reduce the FDII base for affected taxpayers. Apply the new DEI rules to any post-June 16, 2025 disposition when computing FDII on Form 8993.
+
+Source: OBBBA §70322; IRC §250(b)(3)(A)(i)(VII).
+
+### 11.7 OBBBA FTC haircut on §951A-related PTEP distributions
+
+**Warning:** **OBBBA (§70312(b)) disallows 10% of the foreign taxes** deemed paid on **distributions of previously-taxed earnings and profits (PTEP) attributable to §951A (GILTI / net CFC tested income) inclusions**, for distributions **after June 28, 2025**. In other words, only 90% of those foreign taxes are creditable. Report the affected taxes on **Schedule G of Form 1118**. This interacts with the Schedule J foreign tax credit — do not claim the full 100% on §951A-related PTEP distributions after that date.
+
+Source: OBBBA §70312(b); IRC §960(d)(4).
 
 ---
 
@@ -675,7 +696,7 @@ Failure to file Schedule UTP when required does not have a stand-alone penalty (
 |------|--------------|
 | **Form 1125-A — Cost of Goods Sold** | Mandatory if there is any COGS on Form 1120 Line 2. |
 | **Form 1125-E — Compensation of Officers** | Mandatory if total receipts are **$500,000 or more**. See §15. |
-| **Form 4562 — Depreciation and Amortization** | Attach if any §168(k) bonus, §179, MACRS placed in service this year, or any amortization (§174, §195, §197). |
+| **Form 4562 — Depreciation and Amortization** | Attach if any §168(k) bonus, §179, MACRS placed in service this year, or any amortization (§174A foreign, §195, §197). **§179 (OBBBA §70306):** for property placed in service in tax years beginning after December 31, 2024, the §179 expensing **limit is $2.5 million** and the **phase-out threshold is $4 million** (both up from the prior $1.25M / $3.13M and indexed thereafter). Source: OBBBA §70306; IRC §179(b). |
 | **Form 4626 — CAMT** | Attach if the corp is an "applicable corporation" under §59(k); see §12. |
 | **Form 4797 — Sales of Business Property** | §1231 gains/losses, §1245/§1250 recapture, §1252/§1254/§1255 recapture, ordinary income from §1239 related-party gain. |
 | **Schedule D (Form 1120)** | Capital gain net income on Line 8; net of short-term and long-term. |
@@ -959,7 +980,7 @@ Reduces the line 31 tax via Schedule J, computed on Form 1118. (Refer to FTC ski
 - Schedule M-3 likely required (assets ≥ $10M).
 
 **Comment on 2026 rate change:**
-For 2026, the §250 deduction percentages drop to 37.5% / 21.875% (see §11). If GlobalTech's GILTI inclusion were the same in 2026, the §250 deduction on GILTI alone would drop from $2.1M to $1.575M, increasing 2026 tax by $110,250. Flag for tax planning.
+For tax years beginning in 2026, OBBBA sets new permanent §250 deduction rates of **40% on GILTI (renamed "net CFC tested income") and 33.34% on FDII** (see §11.2) — higher than the old scheduled sunset rates of 37.5% / 21.875%. If GlobalTech's GILTI inclusion were the same in 2026, the §250 deduction on GILTI alone would drop from $2.1M (50% × $4.2M) to $1.68M (40% × $4.2M), increasing 2026 tax by roughly $88,200 (= $420,000 × 21%). Flag for tax planning.
 
 ### 19.3 Example C — CAMT-triggered large corp
 
@@ -1004,17 +1025,37 @@ Effective rate = $135M / $300M = 45% on regular taxable income, but actually 15%
 
 ---
 
-## 20. Provenance and disclaimer
+## 20. §1202 Qualified Small Business Stock (QSBS) — OBBBA phased exclusion
 
-### 20.1 Statutory citations relied on
+QSBS status is a **C-corp-level attribute**: the exclusion is claimed by the shareholder on sale, but only if the issuing corporation was a **qualified small business (QSB)** C-corporation when the stock was issued and throughout the holding period. OBBBA (§70431) liberalized §1202 for **stock issued after July 4, 2025**:
+
+- **Phased gain exclusion** (replacing the old flat 5-year / 100% rule for newly issued stock):
+  - **50%** exclusion if held **at least 3 years**,
+  - **75%** exclusion if held **at least 4 years**,
+  - **100%** exclusion if held **at least 5 years**.
+- **Per-issuer cap raised to $15 million** (from $10 million) of eligible gain.
+- **Aggregate gross asset test raised to $75 million** (from $50 million) — a corporation may now be a QSB with up to $75M of aggregate gross assets at issuance.
+
+For a C-corp that may issue stock to founders or investors, confirm QSB eligibility at issuance (the $75M gross-asset test, active-business requirement, and the excluded lines of business) and document it contemporaneously, because the shareholder exclusion depends on the corporation's facts.
+
+Source: OBBBA §70431; IRC §1202(a).
+
+---
+
+## 21. Provenance and disclaimer
+
+### 21.1 Statutory citations relied on
 
 - IRC §11 (corporate rate, 21%)
 - IRC §55(b)(2), §59(k), §56A (CAMT, IRA 2022)
-- IRC §163(j) (interest limitation)
+- IRC §163(j) (interest limitation; EBITDA add-back restored by OBBBA §70303)
 - IRC §172 (NOL, post-TCJA rules)
-- IRC §174 (R&E capitalization, TCJA)
+- IRC §174A (domestic R&D immediate expensing, foreign R&D 15-year amortization; OBBBA §70302)
+- IRC §179(b) (§179 limit $2.5M / phase-out $4M; OBBBA §70306)
 - IRC §243, §245, §245A, §246, §246A (DRD)
-- IRC §250 (GILTI/FDII deduction)
+- IRC §250 (GILTI/FDII deduction; OBBBA §70321 permanent 40%/33.34% rates and §70322 DEI restriction)
+- IRC §960(d)(4) (10% FTC haircut on §951A-related PTEP distributions; OBBBA §70312(b))
+- IRC §1202(a) (QSBS phased exclusion 50/75/100%, $15M cap, $75M gross-asset test; OBBBA §70431)
 - IRC §382 (NOL after ownership change)
 - IRC §448(c) (small-business threshold $31M for 2025)
 - IRC §6012(a)(2) (filing requirement)
@@ -1028,13 +1069,13 @@ Effective rate = $135M / $300M = 45% on regular taxable income, but actually 15%
 - Reg. §1.951A (GILTI)
 - Reg. §1.6011-4 (Schedule M-3 threshold)
 
-### 20.2 Legislative provenance
+### 21.2 Legislative provenance
 
 - **Tax Cuts and Jobs Act (TCJA), P.L. 115-97 (December 22, 2017)** — 21% rate, §163(j), §174 capitalization (delayed effective date), DRD reduction, NOL 80%/no-carryback, §250 enactment, FDII/GILTI.
 - **Inflation Reduction Act (IRA), P.L. 117-169 (August 16, 2022)** — CAMT under §55(b)(2) and §59(k), stock buyback excise tax under §4501.
-- **One Big Beautiful Bill Act (OBBBA), P.L. 119-21 (July 4, 2025)** — did NOT modify the corporate rate, the CAMT, §163(j), §174, §250, or DRD. Confirmed in conference report. Made certain individual TCJA provisions permanent but did not extend the §250 elevated deduction (50%/37.5%) past 2025.
+- **One Big Beautiful Bill Act (OBBBA), P.L. 119-21 (July 4, 2025)** — did NOT modify the corporate 21% rate, the CAMT, or the DRD. It DID: restore immediate expensing of **domestic** R&D via new **§174A** (§70302, tax years beginning after Dec 31, 2024, foreign R&D still 15-year); permanently **restore the §163(j) EBITDA add-back** (§70303, after Dec 31, 2024); set **new permanent §250 rates** of 40% GILTI ("net CFC tested income") / 33.34% FDII (§70321, after Dec 31, 2025) and **narrow the FDII/DEI base** (§70322, dispositions after June 16, 2025); impose a **10% FTC haircut on §951A-related PTEP distributions** (§70312(b)/§960(d)(4), after June 28, 2025); raise **§179** to $2.5M / $4M (§70306, after Dec 31, 2024); and enact the **§1202 QSBS** phased 50/75/100% exclusion with a $15M per-issuer cap and $75M gross-asset test (§70431, stock issued after July 4, 2025).
 
-### 20.3 IRS guidance
+### 21.3 IRS guidance
 
 - Form 1120 Instructions for 2024 (used as template for 2025 — verify against released 2025 instructions before filing).
 - Form 4626 Instructions (2023 revision for IRA CAMT).
@@ -1045,7 +1086,7 @@ Effective rate = $135M / $300M = 45% on regular taxable income, but actually 15%
 - Notice 2023-7 and subsequent CAMT notices (Notice 2023-20, 2023-64, 2024-10, 2024-66, 2025 updates).
 - REG-112129-23 (CAMT proposed regs, September 2024).
 
-### 20.4 Disclaimer
+### 21.4 Disclaimer
 
 This skill provides a structured walkthrough for preparing Form 1120 for tax year 2025 under federal law. It is intended for use by a Circular 230 practitioner (CPA, EA, or attorney) and must be reviewed and signed by such a practitioner before the return is filed. The skill does not constitute tax advice to any specific taxpayer.
 
@@ -1053,7 +1094,7 @@ This skill provides a structured walkthrough for preparing Form 1120 for tax yea
 
 1. Confirm the 2025 Form 1120 and instructions as released by the IRS in late 2025 / early 2026 (changes from the 2024 form possible).
 2. Confirm the 2025 Rev. Proc. inflation adjustments (small-business threshold, §6651 minimum penalty, §6655 large-corp threshold).
-3. Confirm no late-2025 or early-2026 legislation altered §174, §163(j), §250 sunset, or CAMT thresholds. Watch for the routinely-proposed (and routinely-stalled) R&D restoration / EBITDA restoration / bonus depreciation extension package.
+3. Apply the OBBBA changes now in law: §174A domestic R&D immediate expensing, the restored §163(j) EBITDA add-back, the new permanent §250 rates (40%/33.34% from 2026) and DEI narrowing, the §960(d)(4) FTC haircut on §951A-related PTEP, §179 at $2.5M/$4M, and the §1202 QSBS phased exclusion. Confirm no further late-2025 or 2026 legislation altered these or the CAMT thresholds.
 4. Confirm the corporation's state filings — this skill addresses federal only.
 5. For any item flagged "refer out" (consolidated returns, foreign subsidiaries, BEAT, R&D, FTC, CAMT mechanics, stock buyback excise), engage the specialized skill or specialist.
 
@@ -1091,3 +1132,9 @@ verified rules together with the name of the accountant who signed them off.
 
 **→ Install the free connector:** <https://www.openaccountants.com/connect>
 **MCP endpoint:** `https://www.openaccountants.com/api/mcp`
+
+---
+
+## Changelog
+
+- **2026-07-04** — OBBBA corrections applied from a review by Christopher Aryee, CPA: §174A domestic R&D immediate expensing, §163(j) EBITDA add-back, GILTI/FDII permanent rates, §250 DEI restriction, §960 FTC-on-PTEP haircut, §179 $2.5M/$4M, §1202 phased exclusion.


### PR DESCRIPTION
## OBBBA corrections from a professional review

Christopher Aryee, CPA reviewed four core US federal Guides and returned ~33 sourced corrections, almost all bringing the Guides in line with **OBBBA** (the One Big Beautiful Bill Act). This applies them and credits him on each Guide (`reviewed_by` frontmatter, a top OBBBA-update note, and a changelog entry).

### What changed (per Guide)

**`us-form-1120-c-corp`** — §174A domestic R&D immediate expensing (foreign stays 15-yr); §163(j) EBITDA add-back permanently restored (worked example corrected to $2,540,000 allowable); new permanent GILTI/FDII rates (net CFC tested income 40% / FDII 33.34%, not the old 37.5%/21.875% sunset); §250 DEI restriction; §960 10% FTC-on-PTEP haircut; §179 $2.5M / $4M; §1202 phased exclusion.

**`us-form-1065-partnership`** — §6698 penalty $245 → **$255**/partner/month (examples updated); §199A rate **stays 20%** (not 23%) + new $400 minimum; §163(j) threshold $31M; residential-construction % completion + §174A; farmland 4-installment election (Box 20 ZZ); 10-return e-file threshold; §704(c) Item N / Box 20 AA.

**`us-form-1041-trust-and-estate-income`** — SALT $40k cap + DNI impact; QBI 2025 threshold $241,950 → **$197,300**; §67(g) suspension now permanent; standard-deduction $15,750 comparison note; fiduciary AMT verification note.

**`us-form-1040-individual-return`** *(from an in-progress review)* — SALT §70120 + high-income phase-down; §199A stays 20%; CTC §70104 ($2,200); §25D §70506; tips/overtime/auto §70201–203; 2026 standard deduction; uncapped educator expenses; deductible mortgage insurance; 0.5% charitable floor; state-declared-disaster casualty losses; Pease §70111; §1202 phased exclusion; refundable adoption credit; §461(l) §70601. Provenance/citation indexes reconciled.

### Reviewer notes / follow-ups
- **1040 is from an in-progress review** (Christopher had not finalized it) and is labelled as such in its changelog.
- **1040 §19.2 Worked Example B** still computes CTC at 2 × $2,000; with the $2,200/child update its arithmetic is now slightly stale. Left as-is rather than re-derive downstream refund figures — worth a quick refresh.
- **1041 standard deduction**: the flagged $15,000 figure isn't present in that Guide (it's the trust rate schedule), so the correct $15,750 was added as a comparison note rather than overwriting nothing.
- **1065 §6699** (the 1120-S parallel penalty) left at $245 since the review only scoped §6698; likely tracks the same indexed base — confirm with Christopher.

Scope: only `packages/us-federal/` Guide files; no other files touched.
