### PR TITLE
Animated README demo + structured UK rates.2025.json (resolves #47)

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,7 +161,7 @@ The AI asks a few questions, loads the right Guides, and produces a working pape
 | `[country]-guided-intake.md` | Full guided experience (13 countries) |
 | `[country]-return-assembly.md` | Cross-checks: VAT × IT × SSC (13 countries) |
 
-**Special packages:** `_cross-border/` (37 skills) · `_verticals/` (14 industry skills) · `_integrations/` (10 platform skills: Xero, QuickBooks, Stripe, Wise, Shopify, and more) · `us-federal/` (US federal form guides + machine-readable `rates.2025.json` / `rates.2026.json`)
+**Special packages:** `_cross-border/` (37 skills) · `_verticals/` (14 industry skills) · `_integrations/` (10 platform skills: Xero, QuickBooks, Stripe, Wise, Shopify, and more) · `us-federal/` (US federal form guides + machine-readable `rates.2025.json` / `rates.2026.json`) · `uk/` (structured `rates.2025.json`, 2025/26, every figure statute-cited)
 
 ---
 

--- a/assets/demo.svg
+++ b/assets/demo.svg
@@ -1,4 +1,26 @@
 <svg xmlns="http://www.w3.org/2000/svg" width="720" height="400" viewBox="0 0 720 400" font-family="ui-monospace,SFMono-Regular,Menlo,Consolas,monospace" font-size="14">
+  <style>
+    .l { opacity: 0; animation: rise .45s ease-out forwards; }
+    .d1 { animation-delay: .4s; }
+    .d2 { animation-delay: 1.5s; }
+    .d3 { animation-delay: 2.4s; }
+    .d4 { animation-delay: 2.75s; }
+    .d5 { animation-delay: 3.1s; }
+    .d6 { animation-delay: 3.45s; }
+    .d7 { animation-delay: 4.1s; }
+    .d8 { animation-delay: 4.5s; }
+    .d9 { animation-delay: 4.9s; }
+    .d10 { animation-delay: 5.6s; }
+    .caret { animation: blink 1s step-end infinite; }
+    .badge { transform-origin: 40px 343px; opacity: 0; animation: pop .5s cubic-bezier(.2,1.4,.4,1) 4.5s forwards; }
+    @keyframes rise { from { opacity: 0; transform: translateY(6px); } to { opacity: 1; transform: none; } }
+    @keyframes blink { 50% { opacity: 0; } }
+    @keyframes pop { from { opacity: 0; transform: scale(.85); } to { opacity: 1; transform: scale(1); } }
+    @media (prefers-reduced-motion: reduce) {
+      .l, .badge { animation: none; opacity: 1; }
+      .caret { animation: none; }
+    }
+  </style>
   <defs>
     <linearGradient id="bg" x1="0" y1="0" x2="0" y2="1">
       <stop offset="0" stop-color="#101614"/>
@@ -13,22 +35,28 @@
   <circle cx="62" cy="18" r="5.5" fill="#28C840"/>
   <text x="360" y="23" text-anchor="middle" fill="#7B8A82" font-size="12">your AI, with OpenAccountants connected</text>
 
-  <text x="28" y="72" fill="#E6EDE9"><tspan fill="#5EEAD4" font-weight="bold">you</tspan>  I want to file my VAT return in Brazil.</text>
+  <g class="l d1">
+    <text x="28" y="72" fill="#E6EDE9"><tspan fill="#5EEAD4" font-weight="bold">you</tspan>  I want to file my VAT return in Brazil.<tspan class="caret" fill="#5EEAD4">▍</tspan></text>
+  </g>
 
-  <text x="28" y="106" fill="#7B8A82">↓  loads br-indirect-tax, brazil-vat, brazil-einvoice</text>
+  <g class="l d2">
+    <text x="28" y="106" fill="#7B8A82">↓  loads br-indirect-tax, brazil-vat, brazil-einvoice</text>
+  </g>
 
-  <text x="28" y="142" fill="#E6EDE9"><tspan fill="#A5B4FC" font-weight="bold">ai</tspan>   Brazil indirect tax rules (PIS/COFINS/ICMS)</text>
-  <text x="28" y="168" fill="#E6EDE9">     Filing workflow, step by step</text>
-  <text x="28" y="194" fill="#E6EDE9">     Required documents checklist</text>
-  <text x="28" y="220" fill="#E6EDE9">     E-invoice compliance check</text>
+  <g class="l d3"><text x="28" y="142" fill="#E6EDE9"><tspan fill="#A5B4FC" font-weight="bold">ai</tspan>   Brazil indirect tax rules (PIS/COFINS/ICMS)</text></g>
+  <g class="l d4"><text x="28" y="168" fill="#E6EDE9">     Filing workflow, step by step</text></g>
+  <g class="l d5"><text x="28" y="194" fill="#E6EDE9">     Required documents checklist</text></g>
+  <g class="l d6"><text x="28" y="220" fill="#E6EDE9">     E-invoice compliance check</text></g>
 
-  <line x1="28" y1="244" x2="692" y2="244" stroke="#2A3630" stroke-width="1"/>
+  <g class="l d7"><line x1="28" y1="244" x2="692" y2="244" stroke="#2A3630" stroke-width="1"/></g>
 
-  <text x="28" y="274" fill="#34D399" font-weight="bold">✓ Reviewed by Ariane Marrocos CRC/SP</text>
-  <text x="28" y="300" fill="#7B8A82">a licensed accountant, publicly on the record</text>
+  <g class="l d8"><text x="28" y="274" fill="#34D399" font-weight="bold">✓ Reviewed by Ariane Marrocos CRC/SP</text></g>
+  <g class="l d9"><text x="28" y="300" fill="#7B8A82">a licensed accountant, publicly on the record</text></g>
 
-  <rect x="28" y="326" width="290" height="34" rx="8" fill="#173B2E" stroke="#34D399" stroke-width="1"/>
-  <text x="44" y="348" fill="#6EE7B7">Request accountant review →</text>
+  <g class="badge">
+    <rect x="28" y="326" width="290" height="34" rx="8" fill="#173B2E" stroke="#34D399" stroke-width="1"/>
+    <text x="44" y="348" fill="#6EE7B7">Request accountant review →</text>
+  </g>
 
-  <text x="692" y="382" text-anchor="end" fill="#4B5A52" font-size="12">openaccountants.com</text>
+  <g class="l d10"><text x="692" y="382" text-anchor="end" fill="#4B5A52" font-size="12">openaccountants.com</text></g>
 </svg>

--- a/packages/uk/README.md
+++ b/packages/uk/README.md
@@ -39,6 +39,7 @@ _Scope: the “Verified rates & thresholds” blocks inside these skill files ar
 25. `crypto-tax-workflow-base.md`
 26. `uk-guided-intake.md`
 27. `uk-return-assembly.md`
+28. `rates.2025.json` — machine-readable 2025/26 rates & thresholds extracted from the guides above, with per-figure authority citations
 
 ## Also known as
 

--- a/packages/uk/rates.2025.json
+++ b/packages/uk/rates.2025.json
@@ -1,0 +1,147 @@
+{
+  "jurisdiction": "GB",
+  "tax_year": 2025,
+  "tax_year_label": "2025/26",
+  "tax_year_period": "2025-04-06 to 2026-04-05",
+  "currency": "GBP",
+  "valid_as_of": "2026-06-03",
+  "legislative_basis": "ITA 2007; ITEPA 2003; ITTOIA 2005; TCGA 1992; SSCBA 1992; VATA 1994; TMA 1970; Scotland Act 2016; Finance Act 2024; Finance Act 2025; National Insurance Contributions (Reduction in Rates) Act 2024; Autumn Budget 2024; Finance (No. 2) Act 2023 s.5 (threshold freeze through 2027-28)",
+  "last_updated_by": "openaccountants",
+  "reviewed_by": "James Power (2026-06-03) — verified rates & thresholds blocks in the source guides",
+  "source_guides": [
+    "packages/uk/uk-income-tax-sa100.md",
+    "packages/uk/uk-national-insurance.md",
+    "packages/uk/uk-vat-return.md",
+    "packages/uk/uk-capital-gains-sa108.md",
+    "packages/uk/uk-dividends.md",
+    "packages/uk/uk-self-employment-sa103.md"
+  ],
+  "_conventions": "Every figure is extracted from the source_guides above with the authority citation the guide states. Rates are decimals (0.20 = 20%). Bracket arrays are half-open intervals: a band applies to income above `from` up to and including `to`; `to: null` means no upper limit. Amounts are GBP.",
+  "income_tax": {
+    "bands_ruk": {
+      "source": "ITA 2007 (uk-income-tax-sa100, verified block); freeze through 2027-28 per Finance (No. 2) Act 2023 s.5",
+      "bands": [
+        { "rate": 0.00, "from": 0, "to": 12570, "label": "personal allowance" },
+        { "rate": 0.20, "from": 12570, "to": 50270, "label": "basic rate" },
+        { "rate": 0.40, "from": 50270, "to": 125140, "label": "higher rate" },
+        { "rate": 0.45, "from": 125140, "to": null, "label": "additional rate" }
+      ]
+    },
+    "bands_scotland": {
+      "source": "Scotland Act 2016 (uk-income-tax-sa100 §1.4, Scottish bands 2025-26; non-savings, non-dividend income only)",
+      "bands": [
+        { "rate": 0.00, "from": 0, "to": 12570, "label": "personal allowance" },
+        { "rate": 0.19, "from": 12570, "to": 15397, "label": "starter rate" },
+        { "rate": 0.20, "from": 15397, "to": 27491, "label": "basic rate" },
+        { "rate": 0.21, "from": 27491, "to": 43662, "label": "intermediate rate" },
+        { "rate": 0.42, "from": 43662, "to": 75000, "label": "higher rate" },
+        { "rate": 0.45, "from": 75000, "to": 125140, "label": "advanced rate" },
+        { "rate": 0.48, "from": 125140, "to": null, "label": "top rate" }
+      ]
+    },
+    "personal_allowance": { "value": 12570, "source": "ITA 2007 s35 (uk-income-tax-sa100)" },
+    "personal_allowance_taper_start": { "value": 100000, "source": "ITA 2007 s35(4) (uk-income-tax-sa100); £1 reduction per £2 of adjusted net income above threshold" },
+    "personal_allowance_fully_withdrawn": { "value": 125140, "source": "ITA 2007 (uk-income-tax-sa100)" },
+    "basic_rate_band_width": { "value": 37700, "source": "ITA 2007 s10 (uk-income-tax-sa100)" },
+    "personal_savings_allowance_basic_rate": { "value": 1000, "source": "ITA 2007 ss 12A-12B (uk-income-tax-sa100)" },
+    "personal_savings_allowance_higher_rate": { "value": 500, "source": "ITA 2007 ss 12A-12B (uk-income-tax-sa100)" },
+    "personal_savings_allowance_additional_rate": { "value": 0, "source": "ITA 2007 ss 12A-12B (uk-income-tax-sa100)" },
+    "marriage_allowance_transfer": { "value": 1260, "source": "ITA 2007 s55B (uk-income-tax-sa100)" },
+    "marriage_allowance_tax_reducer": { "value": 252, "source": "ITA 2007 s55B (uk-income-tax-sa100); always at 20%, even for Scottish taxpayers" },
+    "pension_annual_allowance": { "value": 60000, "source": "Finance Act (uk-income-tax-sa100, verified block); pension relief FA 2004 ss 188-195" },
+    "hicbc_taper_start": { "value": 60000, "source": "ITEPA 2003 ss 681B-681H, as amended by FA 2024 (uk-income-tax-sa100 §5.9)" },
+    "hicbc_full_clawback": { "value": 80000, "source": "ITEPA 2003 ss 681B-681H, as amended by FA 2024 (uk-income-tax-sa100 §5.9)" }
+  },
+  "national_insurance": {
+    "class_1_employee": {
+      "main_rate": { "value": 0.08, "source": "SSCBA 1992; National Insurance Contributions (Reduction in Rates) Act 2024 (uk-national-insurance §1; rate 8% from 6 April 2024)" },
+      "additional_rate_above_uel": { "value": 0.02, "source": "SSCBA 1992 (uk-national-insurance §1)" },
+      "primary_threshold_annual": { "value": 12570, "source": "SSCBA 1992 (uk-national-insurance §1)" },
+      "upper_earnings_limit_annual": { "value": 50270, "source": "SSCBA 1992 (uk-national-insurance §1; frozen through 2027-28)" }
+    },
+    "class_1_employer": {
+      "rate": { "value": 0.15, "source": "SSCBA 1992; Autumn Budget 2024 Class 1 employer changes (uk-national-insurance §1; 15% from 6 April 2025, was 13.8%)" },
+      "secondary_threshold_annual": { "value": 5000, "source": "Autumn Budget 2024 Class 1 employer changes (uk-national-insurance §1; £5,000/yr from 6 April 2025, was £9,100)" },
+      "employment_allowance": { "value": 10500, "source": "Autumn Budget 2024 Class 1 employer changes (uk-national-insurance §1; doubled from £5,000)" }
+    },
+    "class_2": {
+      "status": "Abolished from 6 April 2024 — voluntary only. Profits >= Small Profits Threshold are treated as paid automatically (zero-rate credit).",
+      "voluntary_weekly_rate": { "value": 3.50, "source": "Finance Act 2024 (uk-national-insurance, verified block; voluntary from 6 April 2024)" },
+      "voluntary_annual_cost": { "value": 182.00, "source": "Calculated (uk-national-insurance, verified block)" },
+      "small_profits_threshold": { "value": 6845, "source": "SSCBA 1992 (uk-national-insurance, verified block)" }
+    },
+    "class_4": {
+      "main_rate": { "value": 0.06, "source": "SSCBA 1992 (uk-national-insurance, verified block; 6% on £12,570 – £50,270)" },
+      "additional_rate": { "value": 0.02, "source": "SSCBA 1992 (uk-national-insurance, verified block; 2% above £50,270)" },
+      "lower_profits_limit": { "value": 12570, "source": "SSCBA 1992 (uk-national-insurance, verified block)" },
+      "upper_profits_limit": { "value": 50270, "source": "SSCBA 1992 (uk-national-insurance, verified block)" }
+    }
+  },
+  "vat": {
+    "standard_rate": { "value": 0.20, "source": "VATA 1994 (uk-vat-return, verified block)" },
+    "reduced_rate": { "value": 0.05, "source": "VATA 1994 (uk-vat-return, verified block; domestic fuel and power, etc.)" },
+    "zero_rate": { "value": 0.00, "source": "VATA 1994 (uk-vat-return, verified block; most food, children's clothing, books, exports, etc.)" },
+    "registration_threshold": { "value": 90000, "source": "VATA 1994 Sch.1 (uk-vat-return, verified block; rolling 12-month taxable turnover)" },
+    "deregistration_threshold": { "value": 88000, "source": "VATA 1994 (uk-vat-return, verified block)" },
+    "flat_rate_scheme": {
+      "entry_threshold": { "value": 150000, "source": "FRS Order 2004 (uk-vat-return, verified block; estimated taxable turnover excl. VAT)" },
+      "exit_threshold": { "value": 230000, "source": "FRS Order 2004 (uk-vat-return, verified block; total income incl. VAT)" },
+      "limited_cost_trader_rate": { "value": 0.165, "source": "FRS Order 2004 (uk-vat-return, verified block)" },
+      "sector_rate_computer_and_it_consultancy": { "value": 0.145, "source": "FRS Order 2004 (uk-vat-return, verified block)" },
+      "sector_rate_management_consultancy": { "value": 0.14, "source": "FRS Order 2004 (uk-vat-return, verified block)" },
+      "sector_rate_accountancy_or_bookkeeping": { "value": 0.145, "source": "FRS Order 2004 (uk-vat-return, verified block)" }
+    },
+    "cash_accounting_entry_threshold": { "value": 1350000, "source": "VAT Regs 1995 (uk-vat-return, verified block)" },
+    "cash_accounting_exit_threshold": { "value": 1600000, "source": "VAT Regs 1995 (uk-vat-return, verified block)" },
+    "return_deadline": { "value": "1 month + 7 days after period end", "source": "VATA 1994 (uk-vat-return, verified block)" },
+    "mtd_requirement": { "value": "All VAT-registered businesses must use MTD-compatible software", "source": "MTD (VAT) Regs 2018 (uk-vat-return, verified block)" }
+  },
+  "capital_gains": {
+    "rate_all_assets_basic": { "value": 0.18, "source": "TCGA 1992 s.1H/1I (uk-capital-gains-sa108, verified block)" },
+    "rate_all_assets_higher": { "value": 0.24, "source": "TCGA 1992 (uk-capital-gains-sa108, verified block)" },
+    "badr_rate": { "value": 0.14, "source": "TCGA s.169H (uk-capital-gains-sa108, verified block; 2025-26 step of the Finance Act 2024 two-step uplift)" },
+    "badr_lifetime_limit": { "value": 1000000, "source": "TCGA 1992 (uk-capital-gains-sa108, verified block)" },
+    "investors_relief_rate": { "value": 0.14, "source": "Finance Act 2024 BADR/IR two-step uplift (uk-capital-gains-sa108 §1.1)" },
+    "investors_relief_lifetime_limit": { "value": 1000000, "source": "Finance Act 2024 BADR/IR two-step uplift (uk-capital-gains-sa108 §1.1; dropped from £10m on 30 Oct 2024)" },
+    "carried_interest_rate": { "value": 0.32, "source": "Autumn Budget 2024 (uk-capital-gains-sa108 §1.1; transitional from April 2025, reclassified as trading income from April 2026)" },
+    "annual_exempt_amount_individuals": { "value": 3000, "source": "TCGA 1992 (uk-capital-gains-sa108, verified block)" },
+    "annual_exempt_amount_trustees": { "value": 1500, "source": "TCGA 1992 (uk-capital-gains-sa108, verified block)" },
+    "ppr_final_period_exemption_months": { "value": 9, "source": "TCGA s.222-226 (uk-capital-gains-sa108, verified block)" },
+    "letting_relief_cap": { "value": 40000, "source": "TCGA s.223 (uk-capital-gains-sa108, verified block)" },
+    "ppr_garden_grounds_exempt_hectares": { "value": 0.5, "source": "TCGA s.222 (uk-capital-gains-sa108, verified block)" },
+    "uk_residential_property_reporting_deadline_days": { "value": 60, "source": "TCGA 1992 (uk-capital-gains-sa108, verified block; from completion)" },
+    "late_reporting_penalty_initial": { "value": 100, "source": "TMA 1970 (uk-capital-gains-sa108, verified block)" }
+  },
+  "dividends": {
+    "dividend_allowance": { "value": 500, "source": "ITA 2007 s.13A (uk-dividends, verified block)" },
+    "ordinary_rate_basic_band": { "value": 0.0875, "source": "ITA 2007 (uk-dividends, verified block)" },
+    "upper_rate_higher_band": { "value": 0.3375, "source": "ITA 2007 (uk-dividends, verified block)" },
+    "additional_rate_band": { "value": 0.3935, "source": "ITA 2007 (uk-dividends, verified block)" }
+  },
+  "self_employment": {
+    "trading_allowance": { "value": 1000, "source": "ITTOIA 2005 (uk-self-employment-sa103, verified block)" },
+    "annual_investment_allowance": { "value": 1000000, "source": "CAA 2001 (uk-self-employment-sa103, verified block)" },
+    "sa103s_short_form_turnover_threshold": { "value": 90000, "source": "HMRC guidance (uk-self-employment-sa103, verified block; turnover below £90,000)" },
+    "cash_basis": { "value": "Default from 2024/25, no upper limit", "source": "Finance Act 2024 (uk-self-employment-sa103, verified block)" },
+    "mileage_car_van_first_10000_miles": { "value": 0.45, "source": "ITTOIA s.94A (uk-self-employment-sa103, verified block; per mile)" },
+    "mileage_car_van_over_10000_miles": { "value": 0.25, "source": "ITTOIA s.94A (uk-self-employment-sa103, verified block; per mile)" },
+    "mileage_motorcycle": { "value": 0.24, "source": "ITTOIA s.94A (uk-self-employment-sa103, verified block; per mile)" },
+    "home_office_flat_rate_25_to_50_hrs_month": { "value": 10, "source": "ITTOIA s.94B (uk-self-employment-sa103, verified block; per month)" },
+    "home_office_flat_rate_51_to_100_hrs_month": { "value": 18, "source": "ITTOIA s.94B (uk-self-employment-sa103, verified block; per month)" },
+    "home_office_flat_rate_101_plus_hrs_month": { "value": 26, "source": "ITTOIA s.94B (uk-self-employment-sa103, verified block; per month)" }
+  },
+  "filing_and_payment": {
+    "sa_online_filing_deadline": { "value": "31 January following the tax year (2025/26 return: 31 January 2027)", "source": "TMA 1970 (uk-income-tax-sa100, verified block)" },
+    "sa_paper_filing_deadline": { "value": "31 October following the tax year", "source": "TMA 1970 (uk-income-tax-sa100, verified block)" },
+    "payments_on_account_threshold": { "value": 1000, "source": "TMA 1970 ss 59A-59B (uk-income-tax-sa100 §5.7; POAs required if prior year SA liability > £1,000 and less than 80% deducted at source)" },
+    "payments_on_account_at_source_pct": { "value": 0.80, "source": "TMA 1970 ss 59A-59B (uk-income-tax-sa100 §5.7)" },
+    "sa_late_filing_penalty_initial": { "value": 100, "source": "TMA 1970 (uk-income-tax-sa100 §5.8; then £10/day after 3 months, 5% of tax at 6 and 12 months)" }
+  },
+  "announced_changes_from_2026_04_06": {
+    "_note": "Announced in Autumn Budget 2025; Finance (No. 2) Bill 2024-26 / Finance Bill 2026 pending Royal Assent at time of writing. Savings and property income rate changes were announced but the rates are TBC in the source guides and are therefore not listed here.",
+    "dividend_ordinary_rate_2026_27": { "value": 0.1075, "source": "Finance (No.2) Bill 2024-26 (uk-dividends, verified block; up from 8.75%)" },
+    "dividend_upper_rate_2026_27": { "value": 0.3575, "source": "Finance (No.2) Bill 2024-26 (uk-dividends, verified block; up from 33.75%)" },
+    "dividend_additional_rate_2026_27": { "value": 0.3935, "source": "Finance (No.2) Bill 2024-26 (uk-dividends, verified block; unchanged)" },
+    "badr_rate_2026_27": { "value": 0.18, "source": "Finance Act 2025 (uk-capital-gains-sa108, verified block)" }
+  }
+}


### PR DESCRIPTION
Two follow-ups from the repo overhaul:

**Animated demo.** `assets/demo.svg` is now an animated terminal (staged line reveal, blinking caret, the **✓ Reviewed by** line pops last). GitHub renders CSS-in-SVG animations in READMEs, so this behaves like a demo GIF at ~10KB, crisp at every size, and it honors `prefers-reduced-motion`. Same path, so the README needed no edit.

**UK structured rates (resolves #47).** `packages/uk/rates.2025.json`: **94 figures for 2025/26** across income tax (incl. the Scottish 7-band schedule), NIC classes 1/2/4, VAT, CGT, dividends, self-employment, filing deadlines, and announced 2026-04-06 changes. Extraction rule: **only figures that appear in the repo's accountant-reviewed UK Guide blocks, each carrying its statute citation** (TCGA/VATA/SSCBA/ITA). Anything uncited or marked TBC was deliberately omitted (list in the commit). Mirrors the us-federal schema; UK tax-year metadata included. Second jurisdiction with computable rates — Germany is #48 and open.

Validator: unaffected paths (rates JSON + assets are outside guide validation); CI runs on this PR regardless.