### PR TITLE
Docs coherence: one frontmatter spec, honest quality-state language, community health

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,11 @@
+blank_issues_enabled: true
+contact_links:
+  - name: 🌍 Become a Partner (licensed accountants)
+    url: https://www.openaccountants.com/for-accountants
+    about: Review Tax Guides for your jurisdiction — your name goes on every answer. 130+ jurisdictions open. No GitHub needed.
+  - name: 💬 Ask a question
+    url: https://github.com/openaccountants/openaccountants/discussions
+    about: Usage questions, jurisdiction requests, and general discussion.
+  - name: 🔒 Report a security issue
+    url: https://github.com/openaccountants/openaccountants/blob/main/SECURITY.md
+    about: Please report security vulnerabilities privately — see the security policy.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -25,20 +25,7 @@ This is the open-source skills repository (AGPL-3.0 + attribution + commercial d
 
 ## Skill file conventions
 
-Every skill is a single Markdown file with YAML frontmatter:
-
-```yaml
----
-name: <slug>
-description: <80-100 word description trigger phrase for AI agents>
-jurisdiction: <ISO 2-letter for countries, US-XX for US states, CA + sub_region for Canadian provinces, GLOBAL/INTL for cross-border>
-category: <state-tax|federal-tax|vat|income-tax|payroll|formation|...>
-tier: 2  # 1 = accountant-verified (named accountant signed off); 2 = research-verified (awaiting sign-off)
-verified_by: pending  # or a real name + credential string like "Michael Cutajar, CPA (Malta)"
-last_updated: YYYY-MM-DD
-version: 0.1
----
-```
+Every skill is a single Markdown file with YAML frontmatter. **The canonical frontmatter spec — required keys (`name`, `description`, `jurisdiction`, `category`, `tax_year`, `tier`, `last_updated`), optional keys (`tax_year_notes`, `verified_by`, `reviewed_by`, `depends_on`, `version`), formats, and the category vocabulary — is [docs/skill-template.md](docs/skill-template.md).** Do not restate or improvise variants; CI enforces the spec via `scripts/validate-guides.py`. Tier labels: `1` = accountant-reviewed, `2` = source-cited draft.
 
 After the frontmatter, the skill body is structured as numbered sections covering Scope, Topic-specific rules, Worked examples, Provenance, and a Circular 230 §10.37 disclosure for US skills.
 

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,33 @@
+# Code of Conduct
+
+## Our commitment
+
+OpenAccountants brings together developers and licensed accounting professionals from 190+ jurisdictions. We are committed to a harassment-free, professional experience for everyone, regardless of background, identity, credential, or country.
+
+## Standards
+
+**Expected:**
+
+- Be professional. Many contributors here stake their real name and license on their work.
+- Argue about tax law with citations, not volume. "HMRC says X, here's the link" beats any amount of insistence.
+- Respect jurisdictional differences. A rule that sounds absurd in your country may be exactly right in another.
+- Welcome newcomers, including accountants who have never used GitHub before. Point them to the no-GitHub contribution paths rather than gatekeeping.
+- Accept corrections gracefully. Being publicly corrected by a professional is the system working, not an attack.
+
+**Unacceptable:**
+
+- Harassment, personal attacks, or discriminatory language
+- Publishing others' private information
+- Misrepresenting credentials or claiming a license you don't hold
+- Deliberately submitting tax figures you know to be wrong
+- Spam, self-promotion unrelated to the project, or AI-generated bulk submissions without review
+
+## Enforcement
+
+Report conduct issues to **info@openaccountants.com**. Reports are reviewed confidentially. Maintainers may edit, remove, or reject contributions, comments, issues, and PRs that violate this code, and may temporarily or permanently ban contributors for behavior they deem inappropriate.
+
+Misrepresenting professional credentials is treated as the most serious violation, since named professional review is the trust backbone of this project.
+
+## Attribution
+
+Adapted from the [Contributor Covenant](https://www.contributor-covenant.org/version/2/1/code_of_conduct/), version 2.1, with project-specific additions for professional-credential integrity.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,7 +4,7 @@ Thanks for your interest in contributing. Here's how it works.
 
 ## Who can contribute
 
-Anyone. You don't need to be an accountant to write a skill. You need to know your country's rules well enough to cite the statutes — whether that's tax rates, payroll obligations, e-invoicing specs, or company formation steps. Accountants then verify what you wrote.
+Anyone. You don't need to be an accountant to write a skill. You need to know your country's rules well enough to cite the statutes — whether that's tax rates, payroll obligations, e-invoicing specs, or company formation steps. Partners — licensed accountants — then review what you wrote.
 
 ## How to contribute a skill
 
@@ -13,7 +13,7 @@ Anyone. You don't need to be an accountant to write a skill. You need to know yo
 1. Go to [openaccountants.com](https://www.openaccountants.com)
 2. Sign up for an account
 3. Use the submission form to upload your skill
-4. It goes live immediately as "unverified"
+4. It goes live immediately as a **source-cited draft**
 
 ### Option 2: Via GitHub PR
 
@@ -40,38 +40,11 @@ Every skill in `skills/` that should appear on [openaccountants.com](https://www
 
 Full details: [docs/WEBSITE-SYNC.md](docs/WEBSITE-SYNC.md)
 
-## Skill structure
+## Skill structure and frontmatter
 
-Every skill follows the same structure:
+**The canonical spec for skill files — required/optional frontmatter keys, formats, the `category` vocabulary, and the body section order — is [docs/skill-template.md](docs/skill-template.md).** Don't restate it; follow it. CI enforces it via `scripts/validate-guides.py`.
 
-- **Frontmatter** — name, description, version, jurisdiction, category, dependencies
-- **Scope statement** — what it covers, what it doesn't
-- **Filing requirements** — who needs to file, thresholds, deadlines
-- **Rates and thresholds** — every number with a statute citation
-- **Computation rules** — step-by-step logic Claude can execute
-- **Edge cases** — exceptions, elections, safe harbors
-- **Self-checks** — verification items for the reviewer
-- **Disclaimer** — not tax advice
-
-### Skill categories
-
-The `category` field in YAML frontmatter tells the system what domain a skill covers:
-
-| Category | What it means | Example |
-|----------|---------------|---------|
-| `international` | Tax computation (VAT, income tax, SSC) | `malta-income-tax.md` |
-| `bookkeeping` | Chart of accounts, P&L, balance sheet | `germany-bookkeeping.md` |
-| `invoicing` | E-invoicing format, validation, transmission | `italy-einvoice.md` |
-| `payroll` | Withholding, social security, payslips | `uk-payroll.md` |
-| `formation` | Entity types, registration, compliance | `singapore-formation.md` |
-| `financial-statements` | Annual accounts, reporting, audit | `france-financial-statements.md` |
-| `transfer-pricing` | TP documentation, arm's length, CbCR | `india-transfer-pricing.md` |
-| `tax-optimization` | Legal tax reduction strategies, timing, deductions | `malta-tax-optimization.md` |
-| `crypto` | Cryptocurrency and digital asset taxation | `uk-crypto-tax.md` |
-| `cross-border` | Multi-jurisdiction coordination, treaties, WHT | `eu-social-security-coordination.md` |
-| `vertical` | Industry-specific accounting patterns | `freelance-developer.md` |
-| `integration` | Platform export formats, column mappings | `stripe-integration.md` |
-| `foundation` | Universal workflow base (domain-agnostic) | `payroll-workflow-base.md` |
+One-line summary: YAML frontmatter (`name`, `description`, `jurisdiction`, `category`, `tax_year`, `tier`, `last_updated`, plus optional keys), then a body that runs scope → filing requirements → rates with citations → step-by-step computation rules → edge cases → self-checks → disclaimer.
 
 All domain skills for a country live in the same directory (e.g., `skills/international/germany/` contains tax, bookkeeping, payroll, formation, financial statements, transfer pricing, tax optimization, and e-invoicing). The build script detects them by filename suffix and bundles the appropriate workflow base automatically.
 
@@ -127,9 +100,9 @@ After editing, run `python3 scripts/build-packages.py` to regenerate all package
 
 If you add a `references.md` to a country's source directory, it will be included in the generated package automatically.
 
-## Verification
+## Review
 
-After you submit, licensed accountants review each section of your skill on [openaccountants.com](https://www.openaccountants.com). When every section is approved, the skill gets a green "verified" badge. Your name stays on it as the author.
+After you submit, Partners — licensed accountants — review your skill on [openaccountants.com](https://www.openaccountants.com). When the full review is approved, the skill becomes **accountant-reviewed** (Tier 1). Your name stays on it as the author.
 
 ## Contributor License Agreement (CLA)
 
@@ -145,5 +118,5 @@ If anything in [CLA.md](CLA.md) is unclear, ask before contributing.
 
 - Your name on the skill, linked to your contributor profile
 - Public contributor profile showing all your contributions
-- Accountant verification — real professionals review your work
+- Accountant review — real professionals review your work
 - The knowledge that thousands of freelancers and small businesses are using your skill to manage their accounting

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,27 @@
+# Security Policy
+
+## Reporting a vulnerability
+
+If you find a security issue in the MCP server (`mcp/`), the build/CI scripts, or the hosted service at openaccountants.com, please **do not open a public issue**.
+
+Email **info@openaccountants.com** with:
+
+- What you found and where (file, endpoint, or tool name)
+- Steps to reproduce
+- Impact as you understand it
+
+You'll get an acknowledgment within 2 business days. We'll keep you informed as we triage and fix, and we're happy to credit you publicly once resolved (or keep you anonymous — your call).
+
+## Reporting wrong tax data
+
+A wrong rate or threshold is not a "vulnerability" in the security sense, but it can do real harm. Report it in the open instead — that's the point of this repo:
+
+- [Open a rate-correction issue](https://github.com/openaccountants/openaccountants/issues/new?template=rate-correction.md), or
+- Email **info@openaccountants.com** if you prefer
+
+If you're a licensed accountant, corrections you submit are credited to you by name. See [CONTRIBUTING.md](CONTRIBUTING.md).
+
+## Scope notes
+
+- The Guides are reference material with a prominent disclaimer; they are not executable code.
+- The MCP server runs read-only over bundled markdown and, in hosted mode, calls openaccountants.com APIs. It does not execute Guide content.

--- a/START-HERE.md
+++ b/START-HERE.md
@@ -8,7 +8,7 @@ If you only read one file in this repo, this is the one.
 
 ## What is this?
 
-OpenAccountants is a library of **research-verified or accountant-verified** AI skills that you upload to Claude, ChatGPT, or any LLM. Give the AI your bank statement and the right files, and you get a working paper your accountant can sign off in minutes.
+OpenAccountants is a library of AI skills — **source-cited drafts, with accountant-reviewed versions** — that you upload to Claude, ChatGPT, or any LLM. Give the AI your bank statement and the right files, and you get a working paper your accountant can sign off in minutes.
 
 It is **not** tax advice. It is a pre-meeting working paper.
 
@@ -37,7 +37,7 @@ It is **not** tax advice. It is a pre-meeting working paper.
 | **A startup planning an S-corp election (US)** | [`packages/us-<state>/us-s-corp-election-decision.md`](packages/) | Federal + state files including the S-corp skill | "Should I become an S-corp? My net profit is [$X], state is [Y]." |
 | **A property buyer figuring out stamp duty / SDLT / ABSD** | [`skills/cross-border/property-transfer-tax-matrix.md`](skills/cross-border/property-transfer-tax-matrix.md) | The RETT matrix | "I'm buying property in [country] for [amount], status [resident/non-resident/foreign]. How much is the transfer tax?" |
 | **Handling an estate / inheritance** | [`skills/cross-border/inheritance-estate-gift-matrix.md`](skills/cross-border/inheritance-estate-gift-matrix.md) + relevant country packages | All of the above | "[Decedent] died in [country] holding [assets in countries]. Help with the estate." |
-| **An accountant who wants to verify a jurisdiction** | [`docs/QUALITY-TIERS.md`](docs/QUALITY-TIERS.md) + your jurisdiction's source files in `skills/` | None to upload — you're a reviewer | "I want to verify the skills for [jurisdiction]. What's the process?" |
+| **An accountant who wants to review a jurisdiction** | [`docs/QUALITY-TIERS.md`](docs/QUALITY-TIERS.md) + your jurisdiction's source files in `skills/` | None to upload — you're reviewing | "I want to review the skills for [jurisdiction]. What's the process?" |
 
 ---
 
@@ -100,8 +100,8 @@ See the main [README.md](README.md) for MCP installation details.
 
 Every skill is one of two tiers:
 
-- **Accountant-verified** — a licensed practitioner has signed off. (Currently: Malta full suite, Germany VAT, US federal bookkeeping + SE.)
-- **Research-verified** — drafted from authoritative sources (tax-authority publications and primary legislation), awaiting credentialed sign-off.
+- **Accountant-reviewed** (Tier 1) — a licensed practitioner has reviewed and signed off. (Currently: Malta full suite, Germany VAT, US federal bookkeeping + SE.)
+- **Source-cited draft** (Tier 2) — drafted from authoritative sources (tax-authority publications and primary legislation), awaiting accountant review.
 
 Every output goes to your accountant. We do not file anything on your behalf, and we are not a substitute for a credentialed reviewer.
 

--- a/docs/ACCURACY-METHODOLOGY.md
+++ b/docs/ACCURACY-METHODOLOGY.md
@@ -1,21 +1,21 @@
 # Accuracy methodology
 
-How OpenAccountants skills are built, verified, and corrected — and, just as importantly, what "verified" does **not** mean.
+How OpenAccountants skills are built, reviewed, and corrected — and, just as importantly, what "reviewed" does **not** mean.
 
 ## The problem we're solving
 
 General-purpose LLMs hallucinate tax law: they invent rates, misremember thresholds, cite forms that don't exist, and apply last year's rules to this year. OpenAccountants skills replace the model's guesswork with content drafted from authoritative sources and, where possible, signed off by a licensed practitioner.
 
-## Two verification tiers
+## Two quality tiers
 
 See [QUALITY-TIERS.md](QUALITY-TIERS.md) for the full definitions. In short:
 
 | Tier | Standard | Who |
 |---|---|---|
-| **Research-verified** (Tier 2) | Every rate, threshold, form, and deadline drafted from authoritative sources (tax-authority publications and primary legislation) | Drafted + cross-checked, awaiting credentialed sign-off |
-| **Accountant-verified** (Tier 1) | A licensed practitioner has reviewed the skill, tested it against representative data, and put their name + credential on it | Named CPA / CA / EA / Steuerberater / local equivalent |
+| **Source-cited draft** (Tier 2) | Every rate, threshold, form, and deadline drafted from authoritative sources (tax-authority publications and primary legislation) | Drafted + cross-checked, awaiting a full accountant review |
+| **Accountant-reviewed** (Tier 1) | A licensed practitioner has reviewed the skill, tested it against representative data, and put their name + credential on it | Named CPA / CA / EA / Steuerberater / local equivalent |
 
-The honest headline is **"research-verified here, accountant-verified via MCP"** — never a blanket "verified by accountants." Most skills in this repo are Tier 2. See [COVERAGE.md](COVERAGE.md) for the exact split.
+The honest headline is **"source-cited drafts here, accountant-reviewed via MCP"** — never a blanket "reviewed by accountants." Most skills in this repo are Tier 2. See [COVERAGE.md](COVERAGE.md) for the exact split.
 
 ## Sources
 
@@ -35,13 +35,13 @@ When the correct treatment is genuinely uncertain, skills are written to **assum
 Accuracy improves in the open. When a skill produces something wrong:
 1. Anyone can open an issue or PR with the correct figure and a source, or email a correction (see [CORRECTION-FEEDBACK-LOOP-SPEC.md](CORRECTION-FEEDBACK-LOOP-SPEC.md)).
 2. The fix is applied and the contributor gets public credit.
-3. With credentialed sign-off, the skill moves from research-verified to accountant-verified.
+3. With a credentialed practitioner's full review and sign-off, the skill moves from source-cited draft to accountant-reviewed.
 
-## What "verified" does NOT mean
+## What "reviewed" does NOT mean
 
 - It is **not** tax advice and **not** a filed return — every output is a **working paper** for a human to check.
-- A research-verified skill has **not** been signed off by a credentialed practitioner.
-- Verification reflects the rules **as of the skill's stated date**; tax law changes — check the date.
+- A source-cited draft has **not** been reviewed by a credentialed practitioner.
+- A review reflects the rules **as of the skill's stated date**; tax law changes — check the date.
 - Coverage of a jurisdiction does not imply coverage of every edge case within it.
 
 The product is designed around this honesty: the AI produces a working paper and routes you to a real accountant for sign-off via `request_accountant_review`.

--- a/docs/COVERAGE.md
+++ b/docs/COVERAGE.md
@@ -14,16 +14,16 @@ _Last updated: 2026-06-07 · source: production database (skills served via the 
 
 > When a headline needs round numbers, use **"1,000+ skills"** and **"192 jurisdictions"** (or **"130+ countries plus every US state"**). Do not invent other figures.
 
-## Verification split
+## Quality-state split
 
-OpenAccountants has two verification tiers (see [QUALITY-TIERS.md](QUALITY-TIERS.md)). The distinction matters and should never be collapsed into a blanket "accountant-verified":
+OpenAccountants has two quality tiers (see [QUALITY-TIERS.md](QUALITY-TIERS.md)). The distinction matters and should never be collapsed into a blanket "accountant-reviewed":
 
 | Tier | What it means | Count | Where it lives |
 |---|---|---|---|
-| **Accountant-verified** (Tier 1) | A licensed practitioner has signed off; name + credential on every output | **85** | **MCP server only** (not in this repo) |
-| **Research-verified** (Tier 2) | Every rate/threshold/form drafted from authoritative sources, awaiting credentialed sign-off | **1,013** | **This repo** |
+| **Accountant-reviewed** (Tier 1) | A licensed practitioner has reviewed and signed off; name + credential on every output | **85** | **MCP server only** (not in this repo) |
+| **Source-cited draft** (Tier 2) | Every rate/threshold/form drafted from authoritative sources, awaiting a full accountant review | **1,013** | **This repo** |
 
-**Correct headline phrasing:** _"Research-verified in this repo. Accountant-verified via the MCP connector."_
+**Correct headline phrasing:** _"Source-cited drafts in this repo. Accountant-reviewed via the MCP connector."_
 
 ## Jurisdiction breakdown
 

--- a/docs/EXAMPLE-WORKING-PAPERS.md
+++ b/docs/EXAMPLE-WORKING-PAPERS.md
@@ -2,7 +2,7 @@
 
 What an OpenAccountants skill actually produces. The output is a **working paper** — a structured, sourced computation for a human to check — not a filed return and not tax advice.
 
-> ⚠️ The example below is **illustrative**, with round invented numbers, to show the *format*. It is not a real computation and the figures are not authoritative. Real output uses the live rates and thresholds in the skill, dated, with the verifier's name attached.
+> ⚠️ The example below is **illustrative**, with round invented numbers, to show the *format*. It is not a real computation and the figures are not authoritative. Real output uses the live rates and thresholds in the skill, dated, with the reviewing Partner's name attached.
 
 ## Anatomy of a working paper
 
@@ -11,7 +11,7 @@ Every working paper has the same bones:
 1. **Inputs** — the facts the user provided, restated so they can confirm them
 2. **Computation** — each line derived from a specific rule in the skill, not from model recall
 3. **Audit flash points** — the spots a real practitioner must check before filing
-4. **Provenance footer** — skill, jurisdiction, date, and (for Tier 1) the named verifier
+4. **Provenance footer** — skill, jurisdiction, date, and (for Tier 1) the named reviewing Partner
 5. **Handoff** — a route to a licensed accountant for sign-off
 
 ## Illustrative example — UK sole trader (SA103)
@@ -41,8 +41,8 @@ Every working paper has the same bones:
 - Student loan / High Income Child Benefit Charge interactions if other income exists.
 
 **Provenance footer:**
-> Computed with `uk-self-employment-sa103` · 2025/26 rules · research-verified.
-> _For accountant-verified output with a named UK CPA on the result, use the [MCP connector](https://www.openaccountants.com/connect)._
+> Computed with `uk-self-employment-sa103` · 2025/26 rules · source-cited draft.
+> _For accountant-reviewed output with a named UK CPA on the result, use the [MCP connector](https://www.openaccountants.com/connect)._
 
 **Handoff:** the AI then offers to route the working paper to a licensed accountant via `request_accountant_review`.
 
@@ -50,6 +50,6 @@ Every working paper has the same bones:
 
 Don't copy figures from this page. To produce a real working paper:
 - **Upload** the relevant package from [`packages/`](../packages/) to your LLM and give it your facts, or
-- **Connect via [MCP](https://www.openaccountants.com/connect)** and ask your question — the AI loads the authoritative skill automatically and attaches a verifier's name where one exists.
+- **Connect via [MCP](https://www.openaccountants.com/connect)** and ask your question — the AI loads the authoritative skill automatically and attaches the reviewing Partner's name where one exists.
 
 Always have a credentialed professional review before filing.

--- a/docs/QUALITY-TIERS.md
+++ b/docs/QUALITY-TIERS.md
@@ -8,27 +8,29 @@ We use **two tiers**. No drafts, no stubs — every published skill is one of th
 
 ## The two tiers
 
-| Tier | Label | What it means | Badge |
-|------|-------|--------------|-------|
-| **Accountant-verified** | A licensed practitioner has reviewed the skill, run it against real (or representative) data, and signed off. Errors found during use have been corrected. The skill is current with the latest tax-year rates and filing forms. | `accountant-verified` |
-| **Research-verified** | Every rate, threshold, form number, and deadline has been drafted from authoritative sources — tax-authority publications and the relevant statutes. Format matches the accountant-verified standard. Awaiting a credentialed sign-off. | `research-verified` |
+| Tier | Label | What it means | Legacy identifier |
+|------|-------|--------------|-------------------|
+| **1** | **Accountant-reviewed** | A licensed practitioner has reviewed the skill, run it against real (or representative) data, and signed off. Errors found during use have been corrected. The skill is current with the latest tax-year rates and filing forms. | `accountant-verified` |
+| **2** | **Source-cited draft** | Every rate, threshold, form number, and deadline has been drafted from authoritative sources — tax-authority publications and the relevant statutes. Format matches the accountant-reviewed standard. Awaiting a full review by an accountant. | `research-verified` |
 
 That's it. If a skill is published, it is one of those two.
+
+> **Display label vs. stored identifier.** The machine identifiers do not change: frontmatter still uses `tier: 1|2` and `verified_by:`, and legacy badges/enums still say `accountant-verified` / `research-verified`. What changed is the **display language**: Tier 1 is written as **"accountant-reviewed"** and Tier 2 as **"source-cited draft"** everywhere a human reads it. This doc is the mapping between the two.
 
 ---
 
 ## What each tier guarantees
 
-### Accountant-verified
+### Accountant-reviewed (Tier 1)
 
 - A real licensed practitioner (CPA, EA, CA, Steuerberater, expert-comptable, commercialista, asesor fiscal, or equivalent for the jurisdiction) has put their name and license number on it.
 - The skill has been used against real client data and refined through filing cycles.
 - The contributor is publicly credited on the skill and at [openaccountants.com](https://www.openaccountants.com).
 - The skill is reviewed at least annually for rate / threshold / form changes.
 
-### Research-verified
+### Source-cited draft (Tier 2)
 
-- The skill follows the accountant-verified format (Step 0 onboarding → Step N output).
+- The skill follows the accountant-reviewed format (Step 0 onboarding → Step N output).
 - Every figure carries a primary-source citation (statute, regulation, tax authority notice).
 - Deep research against the tax authority's published guidance has been completed.
 - It is **not** a substitute for accountant review of an actual filing. The reviewer brief always says so.
@@ -73,9 +75,9 @@ Key rules:
 
 ## Current inventory
 
-### Accountant-verified
+### Accountant-reviewed (Tier 1)
 
-| Skill | Jurisdiction | Verified by |
+| Skill | Jurisdiction | Reviewed by |
 |-------|-------------|-------------|
 | `malta-vat-return` | Malta | Michael Cutajar, CPA |
 | `malta-income-tax` | Malta | Michael Cutajar, CPA |
@@ -91,9 +93,9 @@ Key rules:
 | `us-schedule-c-and-se-computation` | US Federal | Pending publication of practitioner registry |
 | `us-ca-freelance-intake` | US-CA | Pending publication of practitioner registry |
 
-This list is auto-derived from each skill's `verified_by` frontmatter by `scripts/build-skills-manifest.py`. To add a new accountant-verified skill, set its `verified_by:` field to the reviewer's name and credential, then re-run the script. Every accountant-verified skill carries the reviewer's name and license number on the skill page at openaccountants.com.
+This list is auto-derived from each skill's `verified_by` frontmatter by `scripts/build-skills-manifest.py` (the field name is a stored identifier and stays `verified_by`). To add a new accountant-reviewed skill, set its `verified_by:` field to the reviewer's name and credential, then re-run the script. Every accountant-reviewed skill carries the reviewer's name and license number on the skill page at openaccountants.com.
 
-### Research-verified
+### Source-cited drafts (Tier 2)
 
 Everything else in this repo. ~700+ skills covering 134 countries and 51 US states. Each one's frontmatter shows the research date and the authoritative sources cross-checked.
 
@@ -104,34 +106,34 @@ Everything else in this repo. ~700+ skills covering 134 countries and 51 US stat
 ```
 ┌─────────────────────────────────────────────┐
 │  Malta VAT Return v1.0                      │
-│  ████████████ ACCOUNTANT-VERIFIED           │
+│  ████████████ ACCOUNTANT-REVIEWED           │
 │                                             │
-│  Verified by: [Practitioner name + license] │
+│  Reviewed by: [Practitioner name + license] │
 │  Tested against: Real client data           │
 │  Last updated: [Date]                       │
 └─────────────────────────────────────────────┘
 
 ┌─────────────────────────────────────────────┐
 │  France VAT Return (CA3) v0.1               │
-│  ▓▓▓▓▓▓▓▓░░░░ RESEARCH-VERIFIED             │
+│  ▓▓▓▓▓▓▓▓░░░░ SOURCE-CITED DRAFT            │
 │                                             │
 │  Sources: impots.gouv.fr, PWC, EU TEDB      │
 │  Research date: April 2026                  │
-│  Awaiting accountant sign-off               │
-│  Help verify: openaccountants.com/verify    │
+│  Awaiting accountant review                 │
+│  Help review: openaccountants.com/verify    │
 └─────────────────────────────────────────────┘
 ```
 
 ---
 
-## How a skill moves from research-verified to accountant-verified
+## How a skill moves from source-cited draft to accountant-reviewed
 
 1. A credentialed practitioner in the jurisdiction picks up the skill.
 2. They review the rates, thresholds, forms, and deadlines against current law.
 3. They run the skill against representative or real client data.
 4. They submit corrections (web form at openaccountants.com or GitHub PR).
 5. A skill maintainer merges the corrections; the skill is tagged with the practitioner's name and license number.
-6. The skill is bumped to **accountant-verified** in the next release.
+6. The skill is bumped to **accountant-reviewed** in the next release.
 
 The practitioner is credited publicly. Their profile lists all the skills they've signed off.
 
@@ -139,7 +141,7 @@ The practitioner is credited publicly. Their profile lists all the skills they'v
 
 ## Authoritative research sources
 
-These are the sources used during research verification. The same sources are recommended to practitioners verifying their jurisdiction.
+These are the sources a source-cited draft must be drafted and cross-checked against. The same sources are recommended to practitioners reviewing their jurisdiction.
 
 ### Global / multi-jurisdiction
 
@@ -203,4 +205,4 @@ Each state has an online portal. Search "[State] department of revenue" for the 
 
 ## Disclaimer
 
-Quality tiers describe the verification status of a skill, not a guarantee that any specific output is correct. LLMs hallucinate, tax law changes, and individual circumstances vary. Every output must be reviewed by a qualified professional before filing.
+Quality tiers describe the review status of a skill, not a guarantee that any specific output is correct. LLMs hallucinate, tax law changes, and individual circumstances vary. Every output must be reviewed by a qualified professional before filing.

--- a/docs/TEST-PLAN.md
+++ b/docs/TEST-PLAN.md
@@ -1,6 +1,6 @@
 # OpenAccountants — Test Plan
 
-> **Note:** Predates the two-tier quality model. References to "Q4 stub" should be read as "skill not yet research-verified" — current quality model in [QUALITY-TIERS.md](QUALITY-TIERS.md).
+> **Note:** Predates the two-tier quality model. References to "Q4 stub" should be read as "skill not yet at source-cited-draft standard" — current quality model in [QUALITY-TIERS.md](QUALITY-TIERS.md).
 
 15 real-world test cases across different countries, business types, and complexity levels. Each simulates a real user who cloned the repo into Claude Code and starts a conversation.
 

--- a/docs/VERIFIERS.md
+++ b/docs/VERIFIERS.md
@@ -1,10 +1,10 @@
-# Verifiers
+# Partners — accountant reviewers
 
-These are the licensed practitioners who have signed off on **accountant-verified (Tier 1)** skills. Tier 1 skills are served via the [MCP connector](https://www.openaccountants.com/connect) with the verifier's name and credential on every output.
+These are the licensed practitioners who have reviewed and signed off **accountant-reviewed (Tier 1)** skills. Tier 1 skills are served via the [MCP connector](https://www.openaccountants.com/connect) with the reviewing Partner's name and credential on every output.
 
 _Last updated: 2026-06-07. The authoritative, live list is the network directory at [openaccountants.com](https://www.openaccountants.com)._
 
-| Jurisdiction | Verifier | Credential |
+| Jurisdiction | Partner | Credential |
 |---|---|---|
 | 🇧🇷 Brazil | Ariane Marrocos | CRC SP 312052/O-1 |
 | 🇮🇳 India | Mayur Deokar | 615638 |
@@ -18,14 +18,14 @@ _Last updated: 2026-06-07. The authoritative, live list is the network directory
 | 🇬🇧 United Kingdom | James Power | — |
 | 🇺🇸 United States (federal + Illinois) | Amir Pelinkovic | 065.061971 |
 
-**11 credentialed practitioners across 13 jurisdiction assignments.** Most jurisdictions in this repo are still **research-verified** and awaiting a credentialed reviewer.
+**11 credentialed practitioners across 13 jurisdiction assignments.** Most jurisdictions in this repo are still **source-cited drafts** awaiting a credentialed reviewer.
 
-## Become a verifier
+## Become a Partner
 
-If you're a licensed CPA / CA / EA / Steuerberater (or local equivalent) and want to be the named verifier for your jurisdiction:
+If you're a licensed CPA / CA / EA / Steuerberater (or local equivalent) and want to be the named reviewer for your jurisdiction:
 
 - See the open [reviewer-wanted issues](https://github.com/openaccountants/openaccountants/issues)
 - Read [CONTRIBUTING.md](../CONTRIBUTING.md) and [QUALITY-TIERS.md](QUALITY-TIERS.md)
 - Apply at [openaccountants.com](https://www.openaccountants.com)
 
-Your sign-off moves a jurisdiction's skills from research-verified to accountant-verified, with your name on every answer the AI gives.
+Your full review moves a jurisdiction's skills from source-cited draft to accountant-reviewed, with your name on every answer the AI gives.

--- a/docs/skill-template.md
+++ b/docs/skill-template.md
@@ -1,16 +1,76 @@
+# Frontmatter spec — the canonical reference
+
+**This section is THE frontmatter spec for every skill/Guide file in this repo.** Other docs (`CLAUDE.md`, `CONTRIBUTING.md`) link here rather than restating it. CI enforces it: `scripts/validate-guides.py` hard-fails on malformed frontmatter, a missing `name`/`description`, a non-integer `tax_year`, a missing or invalid `tier` (must be 1 or 2), a missing or malformed `last_updated` (YYYY-MM-DD), and a missing `jurisdiction` (except in a small allowlist of jurisdiction-agnostic directories, where it warns).
+
+## Required keys
+
+| Key | Format | Notes |
+|-----|--------|-------|
+| `name` | slug, `[country-or-topic]-[domain]` | e.g. `malta-income-tax` |
+| `description` | 80-100 words | What it covers, entity types, jurisdiction, tax year, plus trigger phrases the AI should match |
+| `jurisdiction` | ISO code | `MT`, `GB`, `DE`, `US`, `US-CA`, `GLOBAL`, `INTL`, `EU-27`. Required even when the folder path implies it |
+| `category` | one of the vocabulary below | Domain the skill covers |
+| `tax_year` | **bare integer**, e.g. `2025` | The **coverage start year**. Ranges, fiscal calendars, and qualifiers ("2025-26", "YA 2026", "2567 (2024)") go in `tax_year_notes`, never here. CI errors on anything that is not an integer 2015-2035 |
+| `tier` | `1` or `2` | `1` = **accountant-reviewed** (a named licensed accountant fully reviewed and signed off); `2` = **source-cited draft** (drafted from primary sources, awaiting review). These are the only two quality states |
+| `last_updated` | `YYYY-MM-DD` | Date the content was last checked/edited |
+
+## Optional keys
+
+| Key | Format | Notes |
+|-----|--------|-------|
+| `tax_year_notes` | quoted string | The human-readable tax-year label when a bare year can't express it: `"2025-26"`, `"FY 2026-27 (AY 2027-28)"`, `"2025 (with confirmed 2026 figures noted)"` |
+| `verified_by` | `pending` or `Name, Credential` | e.g. `Michael Cutajar, CPA (Malta)`. Stored identifier — the field name stays `verified_by` even though the display language is "reviewed". A real name here implies `tier: 1` |
+| `reviewed_by` | `Name, Credential` | Used on the hand-authored `packages/us-federal/` guides (e.g. `Christopher Aryee, CPA`) |
+| `depends_on` | YAML list of slugs | Workflow base or country skill this loads on top of |
+| `version` | e.g. `0.1` | Content version, bumped on substantive change |
+
+## Category vocabulary (the real one)
+
+This is the vocabulary actually in use across the repo's guides (by count), not an aspirational list. Use these for new files:
+
+| Category | What it means | Approx. usage |
+|----------|---------------|---------------|
+| `international` | Country-level tax computation (income tax, VAT, SSC) | ~757 |
+| `foundation` | Universal workflow base (domain-agnostic) | ~198 |
+| `orchestrator` | Router / intake / assembly files | ~110 |
+| `federal` | US federal tax | ~104 |
+| `payroll` | Withholding, social security, payslips | ~82 |
+| `tax-optimization` | Legal tax reduction strategies, timing, deductions | ~64 |
+| `cross-border` | Multi-jurisdiction coordination, treaties, WHT | ~54 |
+| `transfer-pricing` | TP documentation, arm's length, CbCR | ~43 |
+| `state-tax` | US state tax | ~40 |
+| `formation` | Entity types, registration, compliance | ~39 |
+| `financial-statements` | Annual accounts, reporting, audit | ~39 |
+| `bookkeeping` | Chart of accounts, P&L, balance sheet | ~39 |
+| `invoicing` | E-invoicing format, validation, transmission | ~30 |
+| `crypto` | Cryptocurrency and digital asset taxation | ~30 |
+| `vertical` | Industry-specific accounting patterns | ~28 |
+| `integration` | Platform export formats, column mappings | ~20 |
+
+Legacy synonyms still present in older files — do **not** use for new files: `federal-tax` (use `federal`), `state` / `us-states` (use `state-tax`), `financial-reporting` (use `financial-statements`), plus stragglers `template`, `pattern(s)`, `intelligence`.
+
+## Template
+
+---
+
+```yaml
 ---
 name: [country-or-topic]-[domain]
 description: >
   [One paragraph: what this skill covers, entity types, jurisdiction, tax year.
   Include trigger phrases the AI should match. Be specific about scope.]
-version: 0.1
 jurisdiction: XX   # REQUIRED — MT, GB, DE, US, US-CA, GLOBAL, INTL, EU-27, etc.
-tax_year: 2025
-category: international   # international | crypto | bookkeeping | payroll | formation | cross-border | vertical | integration | foundation | orchestrator | federal | state
+category: international   # see the category vocabulary above
+tax_year: 2025             # bare integer = coverage start year
+tax_year_notes: "2025-26"  # optional — only when a bare year can't express it
+tier: 2                    # 1 = accountant-reviewed | 2 = source-cited draft
+last_updated: 2026-07-04   # YYYY-MM-DD
+version: 0.1
 depends_on:
   - [workflow-base-or-country-skill]
-verified_by: pending
+verified_by: pending       # or "Name, Credential" — stored field name stays verified_by
 ---
+```
 
 # [Skill Name] v0.1
 

--- a/mcp/README.md
+++ b/mcp/README.md
@@ -4,7 +4,7 @@
 
 A read-only [Model Context Protocol](https://modelcontextprotocol.io/) server that gives Claude, Cursor, and any MCP client **on-demand access** to 134 countries + 51 US state packages + 13 Canadian provinces/territories of open-source accounting skills across 10 domains (tax, bookkeeping, payroll, e-invoicing, formation, financial statements, transfer pricing, tax optimization, cross-border, and more) — no manual file uploads.
 
-> **Two MCPs, different surfaces.** This **self-hosted server** reads the open-source markdown in your local checkout. The **hosted server** at `https://www.openaccountants.com/api/mcp` reads the production database and exposes a larger surface that includes the **accountant-verified** tier, the `request_accountant_review` handoff (routes to a named licensed CPA/CA/EA with your working paper attached), `get_rates`, `list_verifiers`, `compare_jurisdictions`, and `plan_cross_border`. The hosted server is the product; this self-hosted one is the open research base.
+> **Two MCPs, different surfaces.** This **self-hosted server** reads the open-source markdown bundled with the package (or in your local checkout). The **hosted server** at `https://www.openaccountants.com/api/mcp` reads the production database and exposes a larger surface that includes the **accountant-reviewed** tier, the `request_accountant_review` handoff (routes to a named licensed CPA/CA/EA with your working paper attached), `get_rates`, `list_verifiers`, `compare_jurisdictions`, and `plan_cross_border`. The hosted server is the product; this self-hosted one is the open research base.
 
 ## Why this exists
 
@@ -48,7 +48,7 @@ The self-hosted server exposes 6 read-only tools below. The hosted server at `ht
 | Tool | Description |
 |------|-------------|
 | `start` | **Front door.** Call first whenever a user asks for tax/accounting help. Takes optional `intent` (free text — e.g. `"taxes"`, `"VAT return"`, `"set up a company"`) and `jurisdiction` (e.g. `"MT"`, `"GB"`, `"US-CA"`). Returns either a clarification question or a ready-to-execute plan (`skills_to_load`, `expectations`, `next_action`, `guardrails`). |
-| `list_skills` | List published skills with quality tier and verifier. Optional `jurisdiction` (ISO code, e.g. `MT`, `GB`, `US-CA`) and `category` filters. |
+| `list_skills` | List published skills with quality tier and reviewing accountant. Optional `jurisdiction` (ISO code, e.g. `MT`, `GB`, `US-CA`) and `category` filters. |
 | `get_skill` | Given a skill `slug`, returns the full markdown plus a provenance/attribution footer. |
 | `get_skill_sections` | Given a `slug`, returns the skill parsed into sections (`heading`, `content`, `level`) for step-by-step application. |
 | `search_skills` | Keyword search across skill markdown (`query`, optional `jurisdiction`). Returns the matched section heading and a snippet. |
@@ -91,15 +91,43 @@ Guided workflows that turn the skills into a tax engine, not just a library:
 | `skill-feedback` | `skill_slug`, `country` | Collect structured feedback on a skill after use. |
 | `skill-review` | `skillSlug`, `scenario` | Load a skill's sections and apply them to one scenario. |
 
-> Note: the on-disk server reads the open-source markdown in `packages/`. Most skill files don't carry a `jurisdiction` field, so it's inherited from the package directory (the folder name for `us-XX`/`ca-XX`, otherwise the code its siblings declare). Quality tier is derived from whether a file names a verifier.
+> Note: the on-disk server reads the open-source markdown in `packages/`. Most skill files don't carry a `jurisdiction` field, so it's inherited from the package directory (the folder name for `us-XX`/`ca-XX`, otherwise the code its siblings declare). Quality tier is derived from whether a file's `verified_by` frontmatter names a reviewing accountant.
 
-> **Canadian users — important:** the `ca-XX/` provincial packages (`ca-on`, `ca-qc`, `ca-bc`, …) are **generated**, not checked in. After cloning, run `python3 scripts/build-packages.py` once to materialise them. Until you do, the MCP won't return Canadian provincial skills via `list_skills(jurisdiction="CA-ON")` — only the federal Canadian files visible under `packages/canada/`.
+> **Canadian users on a development (clone) install — important:** the `ca-XX/` provincial packages (`ca-on`, `ca-qc`, `ca-bc`, …) are **generated**, not checked in. After cloning, run `python3 scripts/build-packages.py` once to materialise them. Until you do, the MCP won't return Canadian provincial skills via `list_skills(jurisdiction="CA-ON")` — only the federal Canadian files visible under `packages/canada/`. (The PyPI wheel ships with the packages already built.)
 
 ## Quick start
 
-### 1. Clone and install
+Three ways to install, easiest first.
 
-Requires **Python 3.10+**.
+### Option 1 — Hosted endpoint (1 step, nothing to install)
+
+Point any remote-capable MCP client at:
+
+```
+https://www.openaccountants.com/api/mcp
+```
+
+That's it. The hosted server is the full product surface (live database, accountant-reviewed tier, `request_accountant_review`, `get_rates`, and more — see the note at the top).
+
+### Option 2 — Install from PyPI (no clone needed)
+
+Requires **Python 3.10+**. The wheel bundles all skill packages — you do not need a checkout of this repo:
+
+```bash
+pip install openaccountants-mcp
+```
+
+Or run it directly with `uvx`:
+
+```bash
+uvx openaccountants-mcp
+```
+
+Then connect your AI client (next section) using the `openaccountants-mcp` command.
+
+### Development install (clone the repo)
+
+For contributors, or if you want the server to read your local, editable checkout:
 
 ```bash
 git clone https://github.com/openaccountants/openaccountants.git
@@ -107,13 +135,15 @@ cd openaccountants
 pip install ./mcp
 ```
 
-Or with `uv` (recommended):
+Or with `uv`:
 
 ```bash
 uv pip install ./mcp
 ```
 
-### 2. Connect to your AI client
+The server reads `packages/` from the repo root (override with `OPENACCOUNTANTS_ROOT`, see environment variables below).
+
+### Connect to your AI client
 
 Pick **one** of the following.
 
@@ -162,7 +192,7 @@ Add to `.cursor/mcp.json` in the project (or via Cursor Settings > MCP):
 
 Run `openaccountants-mcp` (or `python -m openaccountants_mcp`) as a **stdio** transport server.
 
-### 3. Start chatting
+### Start chatting
 
 > Help me with my 2025 taxes. Here's my bank statement.
 
@@ -225,4 +255,4 @@ All checks should pass (path safety, tool outputs, jurisdiction count, US state 
 
 ## Disclaimer
 
-All skills and outputs are for informational and computational purposes only. Not tax, legal, or financial advice. Not a replacement for professional judgment. Every skill is in one of [two tiers](../docs/QUALITY-TIERS.md) — **accountant-verified** (a licensed practitioner signed off) or **research-verified** (drafted from authoritative sources, awaiting sign-off). Most skills are research-verified. Always have a qualified professional review before filing or acting upon.
+All skills and outputs are for informational and computational purposes only. Not tax, legal, or financial advice. Not a replacement for professional judgment. Every skill is in one of [two tiers](../docs/QUALITY-TIERS.md) — **accountant-reviewed** (a licensed practitioner reviewed and signed off) or a **source-cited draft** (drafted from authoritative sources, awaiting review). Most skills are source-cited drafts. Always have a qualified professional review before filing or acting upon.


### PR DESCRIPTION
Three things:

**Language sweep (9 docs).** Display copy now says **source-cited draft** / **accountant-reviewed** and **Partners** everywhere; stored identifiers (`verified_by`, tier enums) kept verbatim, with QUALITY-TIERS.md explicitly mapping display label ↔ stored identifier.

**One canonical frontmatter spec.** `docs/skill-template.md` is now THE spec (required/optional keys, formats, CI enforcement) — documenting the category vocabulary the guides *actually* use (both old spec lists contained categories with zero real usage). CLAUDE.md and CONTRIBUTING.md link to it instead of restating conflicting variants. mcp/README.md now leads with the 1-step hosted endpoint, then the no-clone PyPI install.

**Community health → ~100%.** SECURITY.md (private vuln channel + a public wrong-tax-data flow, which is on-brand), CODE_OF_CONDUCT.md (Contributor Covenant + a professional-credential-integrity clause), and issue-template `config.yml` routing accountants to Become a Partner.