### PR TITLE
Verification-first top fold: scoreboard, reviewer badges, PARTNERS.md

### DIFF
--- a/PARTNERS.md
+++ b/PARTNERS.md
@@ -1,0 +1,38 @@
+# Partners — the named professionals on record
+
+This file is the public roster of licensed accountants who review OpenAccountants Tax Guides. Every Partner here has had their credential verified, and their reviews are public. **This roster is the product.** Agents can do the math; these are the people who stand behind the answers.
+
+**Scoreboard: 10 of 193 jurisdictions have a Partner. The other 183 are open.**
+
+| Jurisdiction | Partner | Credential | Guides | On record since | Proof |
+|---|---|---|---|---|---|
+| United States (federal forms) | Christopher Aryee | CPA | 4 | 2026-07 | [33 OBBBA corrections, full diff](https://github.com/openaccountants/openaccountants/pull/45/files) |
+| United States | Amir Pelinkovic | CPA | 16 | 2026 | [profile](https://www.openaccountants.com/network/752ee18a-3843-434d-8426-457d3fa9706f) |
+| United Kingdom | James Power | — | 15 | 2026 | [profile](https://www.openaccountants.com/network/30b2f478-3a97-40c4-b435-0678829b487e) |
+| India | Mayur Deokar | CA | 13 | 2026 | [profile](https://www.openaccountants.com/network/f4cb8476-a86d-4fd9-b536-9217e82ccf99) |
+| Indonesia | Rilia Putri | CA | 10 | 2026 | [profile](https://www.openaccountants.com/network/ec70d43e-18c0-4b4e-b92c-4f8a22e10152) |
+| Brazil | Ariane Marrocos | CRC/SP | 9 | 2026 | [profile](https://www.openaccountants.com/network/366f5c0f-1afb-4332-b87b-9b6f912821aa) |
+| Portugal | Mário Vale | CA | 9 | 2026 | [profile](https://www.openaccountants.com/network/a26a63b7-343c-451b-8266-bb9d28bd7089) |
+| Saudi Arabia | Mehran Habib | — | 9 | 2026 | [profile](https://www.openaccountants.com/network/f9dbab51-2b89-451b-98f2-414b48fb4599) |
+| South Africa | Werner Britz | CA(SA) | 5 | 2026 | [profile](https://www.openaccountants.com/network/28a3ec1b-d699-4c5d-bb60-3114eedc59d0) |
+| Malta | Michael Cutajar | CPA (Malta) | 5 | 2025 | [profile](https://www.openaccountants.com/network) |
+| Nepal | Ashish Bista | CA | 5 | 2026 | [profile](https://www.openaccountants.com/network/78ab67db-8f29-4746-8102-7b52d17309aa) |
+
+## The reviewer badge
+
+Every accountant-reviewed Guide carries this badge directly under its title:
+
+> ✅ **Accountant-reviewed** · **Name, Credential (Jurisdiction)** · credential verified · YYYY-MM-DD · [public record](#)
+
+- **credential verified** means the license/warrant was checked during Partner onboarding at openaccountants.com. License numbers are held on file, not published, unless the Partner opts in to display theirs.
+- **public record** links to the Partner's profile or, where the review happened in this repo, the actual PR diff.
+- In frontmatter, the machine-readable form is `verified_by:` / `reviewed_by:` plus `tier: 1`.
+
+## Become a Partner (and add yourself here)
+
+Onboarding is two steps, in this order:
+
+1. **Verify your credential**: apply at [openaccountants.com/for-accountants](https://www.openaccountants.com/for-accountants). Credentials are reviewed in 1–2 business days. This step is what makes the badge mean something; a PR alone doesn't grant it.
+2. **Put yourself on the record**: once approved, [open a PR adding your row to this file](https://github.com/openaccountants/openaccountants/edit/main/PARTNERS.md) — jurisdiction, name, credential, date. Star the repo while you're here; stars get jurisdictions reviewed faster. Your first Guide review then adds the badge to the Guides themselves.
+
+Questions: **info@openaccountants.com** · [Claim your jurisdiction →](https://github.com/openaccountants/openaccountants/issues/46)

--- a/README.md
+++ b/README.md
@@ -1,15 +1,27 @@
 # OpenAccountants
 
-**The open-source tax layer for AI agents.** Tax Guides your AI can cite, reviewed by named accounting professionals.
+**The only open tax knowledge layer for AI agents where named, licensed accountants stand behind the answers.**
+
+Agents can already do the math. None of them can stand behind an answer. Every other tax dataset ships with "not tax advice" and stops there. Here, a **named professional with a verified credential** reviews the complete Guide for their jurisdiction, publicly, on the record.
+
+### The scoreboard
+
+> ## 10 of 193 jurisdictions
+> have a named, licensed Partner on record. **The other 183 are open.** [Claim yours →](https://github.com/openaccountants/openaccountants/issues/46)
+
+Every reviewed Guide carries its reviewer badge — name, credential, review date, public proof:
+
+> ✅ **Accountant-reviewed** · **Christopher Aryee, CPA (US)** · credential verified · 2026-07-04 · [33 corrections, full public diff](https://github.com/openaccountants/openaccountants/pull/45/files)
 
 [![License: AGPL-3.0](https://img.shields.io/badge/license-AGPL--3.0-047857)](LICENSE)
 [![PyPI](https://img.shields.io/pypi/v/openaccountants-mcp?label=openaccountants-mcp&color=047857)](https://pypi.org/project/openaccountants-mcp/)
 [![smithery badge](https://smithery.ai/badge/info-ood9/openaccountants)](https://smithery.ai/servers/info-ood9/openaccountants)
 [![GitHub stars](https://img.shields.io/github/stars/openaccountants/openaccountants?style=social)](https://github.com/openaccountants/openaccountants/stargazers)
 
-1,000+ Guides across 190+ jurisdictions. Works with **Claude, ChatGPT, Cursor, Windsurf, and any MCP-compatible agent**. Every Guide is either a **source-cited draft** (written from primary legislation, every figure cited) or **accountant-reviewed** (a licensed Partner checked the complete Guide, and their name is on it).
+1,000+ Guides across 190+ jurisdictions, working with **Claude, ChatGPT, Cursor, Windsurf, and any MCP-compatible agent**. Every Guide is in exactly one of two states, and the repo greps honestly:
 
-> 🔍 **Real professional review, in public.** In July 2026, Christopher Aryee, CPA reviewed our four core US federal form Guides against the One Big Beautiful Bill Act and returned **33 sourced corrections** (rates, thresholds, statutory citations). The full red-line is public: [see the diff →](https://github.com/openaccountants/openaccountants/pull/45/files) That loop (a named professional publicly correcting the tax data your AI relies on) is the whole point of this project.
+- **Source-cited draft** — written from primary legislation, every figure cited, not yet professionally reviewed
+- **Accountant-reviewed** — a named, licensed Partner checked the complete Guide; their badge is on it ([full roster](PARTNERS.md))
 
 ⚠️ **General reference only, not advice.** Have a qualified professional review outputs before filing, payment, or action. <details><summary>Read the full disclaimer</summary>
 
@@ -64,7 +76,7 @@ Works in Claude Desktop (`claude_desktop_config.json`), Cursor (`.cursor/mcp.jso
 
 ## Partners: the named professionals behind the Guides
 
-These licensed practitioners have reviewed Guides for their jurisdictions. Their name appears on every answer the AI gives from a Guide they reviewed, and their reviews are public.
+The canonical roster lives in [PARTNERS.md](PARTNERS.md) (and adding yourself to it is step two of Partner onboarding). These licensed practitioners have reviewed Guides for their jurisdictions. Their name appears on every answer the AI gives from a Guide they reviewed, and their reviews are public.
 
 | Jurisdiction | Partner | Guides | Proof |
 |---|---|---|---|

--- a/packages/malta/malta-income-tax.md
+++ b/packages/malta/malta-income-tax.md
@@ -13,6 +13,9 @@ verified_by: Michael Cutajar, CPA (Malta)
 
 # Malta Income Tax -- Self-Employed Skill v2.0
 
+> ✅ **Accountant-reviewed** · **Michael Cutajar, CPA (Malta)** · credential verified · [public record](https://www.openaccountants.com/network)
+
+
 ---
 
 ## Section 1 -- Quick Reference

--- a/packages/malta/malta-ssc.md
+++ b/packages/malta/malta-ssc.md
@@ -13,6 +13,9 @@ verified_by: Michael Cutajar, CPA (Malta)
 
 # Malta Social Security Contributions (SSC) -- Self-Employed Skill v2.0
 
+> ✅ **Accountant-reviewed** · **Michael Cutajar, CPA (Malta)** · credential verified · [public record](https://www.openaccountants.com/network)
+
+
 ## Section 1 -- Quick reference
 
 **Read this whole section before computing or classifying anything.**

--- a/packages/malta/malta-tax-optimization.md
+++ b/packages/malta/malta-tax-optimization.md
@@ -17,6 +17,9 @@ verified_by: Michael Cutajar, CPA (Malta)
 
 # Malta Tax Optimization -- Self-Employed Skill v1.0
 
+> ✅ **Accountant-reviewed** · **Michael Cutajar, CPA (Malta)** · credential verified · [public record](https://www.openaccountants.com/network)
+
+
 ---
 
 ## Section 1 -- Quick Reference

--- a/packages/malta/malta-vat-return.md
+++ b/packages/malta/malta-vat-return.md
@@ -7,6 +7,9 @@ verified_by: Michael Cutajar, CPA (Malta)
 
 # Malta VAT Return Skill (Article 10 periodic / Article 11) v2.0
 
+> ✅ **Accountant-reviewed** · **Michael Cutajar, CPA (Malta)** · credential verified · [public record](https://www.openaccountants.com/network)
+
+
 ## Section 1 — Quick reference
 
 **Read this whole section before classifying anything. The workflow runbook is in `vat-workflow-base` Section 1 — follow that runbook with this skill providing the country-specific content and `eu-vat-directive` providing the EU directive content.**

--- a/packages/malta/mt-estimated-tax.md
+++ b/packages/malta/mt-estimated-tax.md
@@ -13,6 +13,9 @@ verified_by: Michael Cutajar, CPA (Malta)
 
 # Malta Provisional Tax (PT) -- Self-Employed Skill v2.0
 
+> ✅ **Accountant-reviewed** · **Michael Cutajar, CPA (Malta)** · credential verified · [public record](https://www.openaccountants.com/network)
+
+
 ## Section 1 -- Quick reference
 
 | Field | Value |

--- a/packages/south-africa/south-africa-vat.md
+++ b/packages/south-africa/south-africa-vat.md
@@ -12,6 +12,9 @@ verified_by: Werner Britz, CA(SA)
 
 # South Africa VAT (VAT201) Skill v2.1
 
+> ✅ **Accountant-reviewed** · **Werner Britz, CA(SA)** · credential verified · [public record](https://www.openaccountants.com/network/28a3ec1b-d699-4c5d-bb60-3114eedc59d0)
+
+
 ---
 
 ## Verified rates & thresholds (accountant-reviewed)

--- a/packages/south-africa/za-income-tax.md
+++ b/packages/south-africa/za-income-tax.md
@@ -7,6 +7,9 @@ verified_by: Werner Britz, CA(SA)
 
 # South Africa Income Tax -- Self-Employed Skill v2.0
 
+> ✅ **Accountant-reviewed** · **Werner Britz, CA(SA)** · credential verified · [public record](https://www.openaccountants.com/network/28a3ec1b-d699-4c5d-bb60-3114eedc59d0)
+
+
 ## Verified rates & thresholds (accountant-reviewed)
 
 > Reviewed against the cited tax authorities by **Werner Britz** on 2026-06-12.

--- a/packages/south-africa/za-provisional-tax.md
+++ b/packages/south-africa/za-provisional-tax.md
@@ -7,6 +7,9 @@ verified_by: Werner Britz, CA(SA)
 
 # South Africa Provisional Tax (IRP6) -- Self-Employed Skill v2.0
 
+> ✅ **Accountant-reviewed** · **Werner Britz, CA(SA)** · credential verified · [public record](https://www.openaccountants.com/network/28a3ec1b-d699-4c5d-bb60-3114eedc59d0)
+
+
 ## Verified rates & thresholds (accountant-reviewed)
 
 > Reviewed against the cited tax authorities by **Werner Britz** on 2026-06-12.

--- a/packages/south-africa/za-vat-return.md
+++ b/packages/south-africa/za-vat-return.md
@@ -13,6 +13,9 @@ verified_by: Werner Britz, CA(SA)
 
 # South Africa VAT Return (VAT201) -- Self-Employed Skill v2.1
 
+> ✅ **Accountant-reviewed** · **Werner Britz, CA(SA)** · credential verified · [public record](https://www.openaccountants.com/network/28a3ec1b-d699-4c5d-bb60-3114eedc59d0)
+
+
 ---
 
 ## Verified rates & thresholds (accountant-reviewed)

--- a/skills/international/malta/malta-income-tax.md
+++ b/skills/international/malta/malta-income-tax.md
@@ -15,6 +15,9 @@ verified_by: Michael Cutajar, CPA (Malta)
 
 # Malta Income Tax -- Self-Employed Skill v2.0
 
+> ✅ **Accountant-reviewed** · **Michael Cutajar, CPA (Malta)** · credential verified · [public record](https://www.openaccountants.com/network)
+
+
 > **General reference only.** This skill is general tax/accounting reference material for AI-assisted workflows. It has not been reviewed for any specific person's facts, documents, elections, deadlines, residency, filing status, or local procedures. Do not rely on it to file, pay, amend, or take a tax position without review by a qualified professional in the relevant jurisdiction.
 
 ---

--- a/skills/international/malta/malta-ssc.md
+++ b/skills/international/malta/malta-ssc.md
@@ -15,6 +15,9 @@ verified_by: Michael Cutajar, CPA (Malta)
 
 # Malta Social Security Contributions (SSC) -- Self-Employed Skill v2.0
 
+> ✅ **Accountant-reviewed** · **Michael Cutajar, CPA (Malta)** · credential verified · [public record](https://www.openaccountants.com/network)
+
+
 > **General reference only.** This skill is general tax/accounting reference material for AI-assisted workflows. It has not been reviewed for any specific person's facts, documents, elections, deadlines, residency, filing status, or local procedures. Do not rely on it to file, pay, amend, or take a tax position without review by a qualified professional in the relevant jurisdiction.
 
 ## Section 1 -- Quick reference

--- a/skills/international/malta/malta-tax-optimization.md
+++ b/skills/international/malta/malta-tax-optimization.md
@@ -19,6 +19,9 @@ verified_by: Michael Cutajar, CPA (Malta)
 
 # Malta Tax Optimization -- Self-Employed Skill v1.0
 
+> ✅ **Accountant-reviewed** · **Michael Cutajar, CPA (Malta)** · credential verified · [public record](https://www.openaccountants.com/network)
+
+
 > **General reference only.** This skill is general tax/accounting reference material for AI-assisted workflows. It has not been reviewed for any specific person's facts, documents, elections, deadlines, residency, filing status, or local procedures. Do not rely on it to file, pay, amend, or take a tax position without review by a qualified professional in the relevant jurisdiction.
 
 ---

--- a/skills/international/malta/malta-vat-return.md
+++ b/skills/international/malta/malta-vat-return.md
@@ -10,6 +10,9 @@ last_updated: 2026-06-12
 
 # Malta VAT Return Skill (Article 10 periodic / Article 11) v2.0
 
+> ✅ **Accountant-reviewed** · **Michael Cutajar, CPA (Malta)** · credential verified · [public record](https://www.openaccountants.com/network)
+
+
 > **General reference only.** This skill is general tax/accounting reference material for AI-assisted workflows. It has not been reviewed for any specific person's facts, documents, elections, deadlines, residency, filing status, or local procedures. Do not rely on it to file, pay, amend, or take a tax position without review by a qualified professional in the relevant jurisdiction.
 
 ## Section 1 — Quick reference

--- a/skills/international/malta/mt-estimated-tax.md
+++ b/skills/international/malta/mt-estimated-tax.md
@@ -15,6 +15,9 @@ verified_by: Michael Cutajar, CPA (Malta)
 
 # Malta Provisional Tax (PT) -- Self-Employed Skill v2.0
 
+> ✅ **Accountant-reviewed** · **Michael Cutajar, CPA (Malta)** · credential verified · [public record](https://www.openaccountants.com/network)
+
+
 > **General reference only.** This skill is general tax/accounting reference material for AI-assisted workflows. It has not been reviewed for any specific person's facts, documents, elections, deadlines, residency, filing status, or local procedures. Do not rely on it to file, pay, amend, or take a tax position without review by a qualified professional in the relevant jurisdiction.
 
 ## Section 1 -- Quick reference

--- a/skills/international/south-africa/south-africa-vat.md
+++ b/skills/international/south-africa/south-africa-vat.md
@@ -14,6 +14,9 @@ verified_by: Werner Britz, CA(SA)
 
 # South Africa VAT (VAT201) Skill v2.1
 
+> ✅ **Accountant-reviewed** · **Werner Britz, CA(SA)** · credential verified · [public record](https://www.openaccountants.com/network/28a3ec1b-d699-4c5d-bb60-3114eedc59d0)
+
+
 > **General reference only.** This skill is general tax/accounting reference material for AI-assisted workflows. It has not been reviewed for any specific person's facts, documents, elections, deadlines, residency, filing status, or local procedures. Do not rely on it to file, pay, amend, or take a tax position without review by a qualified professional in the relevant jurisdiction.
 
 ---

--- a/skills/international/south-africa/za-income-tax.md
+++ b/skills/international/south-africa/za-income-tax.md
@@ -10,6 +10,9 @@ last_updated: 2026-06-12
 
 # South Africa Income Tax -- Self-Employed Skill v2.0
 
+> ✅ **Accountant-reviewed** · **Werner Britz, CA(SA)** · credential verified · [public record](https://www.openaccountants.com/network/28a3ec1b-d699-4c5d-bb60-3114eedc59d0)
+
+
 > **General reference only.** This skill is general tax/accounting reference material for AI-assisted workflows. It has not been reviewed for any specific person's facts, documents, elections, deadlines, residency, filing status, or local procedures. Do not rely on it to file, pay, amend, or take a tax position without review by a qualified professional in the relevant jurisdiction.
 
 ## Section 1 -- Quick reference

--- a/skills/international/south-africa/za-provisional-tax.md
+++ b/skills/international/south-africa/za-provisional-tax.md
@@ -10,6 +10,9 @@ last_updated: 2026-06-12
 
 # South Africa Provisional Tax (IRP6) -- Self-Employed Skill v2.0
 
+> ✅ **Accountant-reviewed** · **Werner Britz, CA(SA)** · credential verified · [public record](https://www.openaccountants.com/network/28a3ec1b-d699-4c5d-bb60-3114eedc59d0)
+
+
 > **General reference only.** This skill is general tax/accounting reference material for AI-assisted workflows. It has not been reviewed for any specific person's facts, documents, elections, deadlines, residency, filing status, or local procedures. Do not rely on it to file, pay, amend, or take a tax position without review by a qualified professional in the relevant jurisdiction.
 
 ## Section 1 -- Quick reference

--- a/skills/international/south-africa/za-vat-return.md
+++ b/skills/international/south-africa/za-vat-return.md
@@ -15,6 +15,9 @@ verified_by: Werner Britz, CA(SA)
 
 # South Africa VAT Return (VAT201) -- Self-Employed Skill v2.1
 
+> ✅ **Accountant-reviewed** · **Werner Britz, CA(SA)** · credential verified · [public record](https://www.openaccountants.com/network/28a3ec1b-d699-4c5d-bb60-3114eedc59d0)
+
+
 > **General reference only.** This skill is general tax/accounting reference material for AI-assisted workflows. It has not been reviewed for any specific person's facts, documents, elections, deadlines, residency, filing status, or local procedures. Do not rely on it to file, pay, amend, or take a tax position without review by a qualified professional in the relevant jurisdiction.
 
 ---


### PR DESCRIPTION
Positioning shift per founder decision: the top fold now sells the one thing no competitor can offer — **a named, licensed human on record** — before any tool list.

- **New top fold**: the liability line ('agents can do the math; none can stand behind an answer'), then **the scoreboard: 10 of 193 jurisdictions have a named Partner; 183 open**, then a live example badge (Chris's).
- **Reviewer badges shipped**: every accountant-reviewed Guide now carries a visible badge under its H1 (name, credential, credential-verified, public-record link) — applied to all 18 reviewed files. License numbers stay on file rather than published (consent), with the format ready for opt-in display.
- **PARTNERS.md**: the canonical public roster + the two-step onboarding loop (credential verification on the site, then a PR adding your row + a star) — the repo-side half of the verifier-PR growth loop; site-side wiring lands separately.
- Topics updated: +verified-tax, +agentic-tax.

Validator: PASS.