### PR TITLE
Accuracy wave: source-verified corrections across US guides (batch 1 + incoming)

### DIFF
--- a/index.json
+++ b/index.json
@@ -1,5 +1,5 @@
 {
- "generated_at": "2026-07-04T12:40:34+00:00",
+ "generated_at": "2026-07-04T17:22:59+00:00",
  "counts": {
   "guides": 1007,
   "jurisdictions": 187,
@@ -28,7 +28,7 @@
    "verified_by": "pending",
    "reviewed_by": null,
    "tax_year": null,
-   "last_updated": "2025-11-15"
+   "last_updated": "2026-07-04"
   },
   {
    "slug": "us-estate-gift-706-709",
@@ -64,7 +64,7 @@
    "verified_by": "pending",
    "reviewed_by": null,
    "tax_year": null,
-   "last_updated": "2025-11-15"
+   "last_updated": "2026-07-04"
   },
   {
    "slug": "us-foreign-tax-credit-1116",
@@ -76,7 +76,7 @@
    "verified_by": "pending",
    "reviewed_by": null,
    "tax_year": null,
-   "last_updated": "2025-11-15"
+   "last_updated": "2026-07-04"
   },
   {
    "slug": "us-form-1040-individual-return",
@@ -184,7 +184,7 @@
    "verified_by": "pending",
    "reviewed_by": null,
    "tax_year": null,
-   "last_updated": "2025-11-15"
+   "last_updated": "2026-07-04"
   },
   {
    "slug": "us-multi-state-residency-and-allocation",
@@ -892,7 +892,7 @@
    "verified_by": null,
    "reviewed_by": null,
    "tax_year": "2025",
-   "last_updated": "2026-06-12"
+   "last_updated": "2026-07-04"
   },
   {
    "slug": "us-qbi-deduction",
@@ -904,7 +904,7 @@
    "verified_by": null,
    "reviewed_by": null,
    "tax_year": null,
-   "last_updated": "2026-06-12"
+   "last_updated": "2026-07-04"
   },
   {
    "slug": "us-quarterly-estimated-tax",

--- a/packages/us-federal/rates.2025.json
+++ b/packages/us-federal/rates.2025.json
@@ -53,10 +53,11 @@
       ]
     },
     "standard_deduction": {
-      "single": 15000,
-      "mfj": 30000,
-      "mfs": 15000,
-      "hoh": 22500,
+      "single": 15750,
+      "mfj": 31500,
+      "mfs": 15750,
+      "hoh": 23625,
+      "_note_obbba_std_deduction": "OBBBA §70102 raised the 2025 base standard deduction above the Rev. Proc. 2024-40 amounts (15000/30000/22500)",
       "additional_age_or_blind_single": 2000,
       "additional_age_or_blind_mfj": 1600,
       "_note_obbba_senior_bonus": "OBBBA adds a temporary $6,000 senior bonus deduction (age 65+) for tax years 2025-2028; phases out above $75,000 single / $150,000 MFJ AGI"

--- a/packages/us-federal/us-education-credits-8863.md
+++ b/packages/us-federal/us-education-credits-8863.md
@@ -5,7 +5,7 @@ jurisdiction: US
 category: federal-tax
 tier: 2
 verified_by: pending
-last_updated: 2025-11-15
+last_updated: 2026-07-04
 version: 0.1
 ---
 
@@ -230,8 +230,8 @@ A scholarship designated by the donor (or by the institution) for **tuition only
 
 This works when:
 - The scholarship terms permit application to non-tuition expenses (verify in the award letter — if restricted, the planning is unavailable).
-- The student's other income plus the recharacterized scholarship is below the standard deduction ($15,000 single in 2025), so the student pays no actual tax on the "taxable" scholarship.
-- The kiddie tax rules do not push the scholarship into the parent's bracket. Scholarships included in income under §117(c) are treated as **earned income** for purposes of the kiddie-tax standard-deduction calculation under §63(c)(5), per Rev. Rul. 2005-46 and Notice 87-31 — so the student's standard deduction is the full $15,000 (2025), not the $1,300 unearned-income floor.
+- The student's other income plus the recharacterized scholarship is below the standard deduction ($15,750 single in 2025, OBBBA §70102), so the student pays no actual tax on the "taxable" scholarship.
+- The kiddie tax rules do not push the scholarship into the parent's bracket. Scholarships included in income under §117(c) are treated as **earned income** for purposes of the kiddie-tax standard-deduction calculation under §63(c)(5), per Rev. Rul. 2005-46 and Notice 87-31 — so the student's standard deduction is the full $15,750 (2025, OBBBA §70102), not the $1,300 unearned-income floor.
 
 The credit pickup can be substantial: $2,500 of AOTC vs $0 of student-level tax. Document the analysis carefully — this is a planning position the IRS scrutinizes but has explicitly endorsed in Pub. 970 ("Coordination with Pell grants and other scholarships").
 
@@ -474,7 +474,7 @@ Attach the reconciliation worksheet to the return file and retain bursar's state
 *Daniel.* AOTC eligibility: degree-seeking ✓, half-time+ ✓, first 4 years ✓, < 4 prior AOTC ✓, no drug conviction ✓. Qualified expenses = $14,000 + $1,200 + $900 = $16,100. AOTC base capped at $4,000. AOTC = 100% × $2,000 + 25% × $2,000 = $2,500. Phaseout: MFJ $160k-$180k; MAGI $145k is below the floor — no phaseout. Full $2,500.
 
 *Elena.* AOTC eligibility: degree-seeking ✓, half-time+ ✓, first 4 years ✓ (she has not **completed** 4 years yet — this is her 4th year), < 4 prior AOTC ✓ (3 prior claims), no drug conviction ✓. Qualified expenses before scholarship reduction = $32,000 + $2,100 + $1,400 = $35,500. Scholarship is unrestricted — consider recharacterization. If we apply the $8,000 scholarship to room and board (recharacterize as taxable to Elena):
-- Elena reports $8,000 of taxable scholarship income on her own return (Line 8r). Her other 2025 income: $3,200 from summer internship. Total $11,200. Standard deduction $15,000 (single, treated as earned income per §63(c)(5)). Tax = $0.
+- Elena reports $8,000 of taxable scholarship income on her own return (Line 8r). Her other 2025 income: $3,200 from summer internship. Total $11,200. Standard deduction $15,750 (single, treated as earned income per §63(c)(5); OBBBA §70102). Tax = $0.
 - AOTC qualified expenses remain $4,000 capped. AOTC = $2,500.
 - If scholarship had been left applied to tuition, QEE for AOTC would still be $35,500 - $8,000 = $27,500, well above $4,000 cap — so AOTC would still be $2,500. **The recharacterization does not change Elena's AOTC in this case because QEE is so far above the $4,000 cap.** Keep the scholarship applied to tuition; no benefit to recharacterization here. (The recharacterization trick matters only when scholarships push QEE **below** $4,000.)
 
@@ -613,3 +613,9 @@ verified rules together with the name of the accountant who signed them off.
 
 **→ Install the free connector:** <https://www.openaccountants.com/connect>
 **MCP endpoint:** `https://www.openaccountants.com/api/mcp`
+
+---
+
+## Changelog
+
+- **2026-07-04** — Stale figures corrected via cross-guide contradiction check: 2025 standard deduction (single) $15,000 → $15,750 in §6.2 and Example A (OBBBA §70102). Conclusions unchanged — student income stays below the standard deduction, tax = $0.

--- a/packages/us-federal/us-foreign-earned-income-2555.md
+++ b/packages/us-federal/us-foreign-earned-income-2555.md
@@ -5,7 +5,7 @@ jurisdiction: US
 category: federal-tax
 tier: 2
 verified_by: pending
-last_updated: 2025-11-15
+last_updated: 2026-07-04
 version: 0.1
 ---
 
@@ -522,20 +522,20 @@ US citizens abroad still owe quarterly estimated taxes (Form 1040-ES) under §66
 
 **Total exclusion**: $130,000 + $37,600 = $167,600.
 
-**Taxable income**: $264,000 − $167,600 = $96,400 − $14,600 standard deduction (2025 single) = $81,800.
+**Taxable income**: $264,000 − $167,600 = $96,400 − $15,750 standard deduction (2025 single, OBBBA §70102) = $80,650.
 
-**§911(f) stacked tax** (on $81,800 + $167,600 = $249,400 reported "as if"):
-- Tax on $249,400 ≈ $56,872.
-- Tax on $167,600 ≈ $32,460.
-- Net US tax = $56,872 − $32,460 = $24,412.
+**§911(f) stacked tax** (on $80,650 + $167,600 = $248,250 reported "as if"):
+- Tax on $248,250 ≈ $56,503.
+- Tax on $167,600 ≈ $33,071.
+- Net US tax = $56,503 − $33,071 = $23,432.
 
 **Foreign tax credit**: $0 (UAE collected no tax).
 
 **SE tax**: $0 (W-2 employee, not self-employed).
 
-**Net US federal tax owed**: $24,412.
+**Net US federal tax owed**: $23,432.
 
-**Compare without FEIE**: Tax on $204,000 + $60,000 − $14,600 = $249,400 = $56,872. Far worse. §911 saves $32,460.
+**Compare without FEIE**: Tax on $204,000 + $60,000 − $15,750 = $248,250 = $56,503. Far worse. §911 saves $33,071.
 
 ### 15.2 Example B — Freelance US Citizen in Lisbon Using FTC + NHR
 
@@ -548,19 +548,19 @@ US citizens abroad still owe quarterly estimated taxes (Form 1040-ES) under §66
 **§911 path**:
 - FEIE: $130,000.
 - Schedule C taxable in US after FEIE: $50,000.
-- §911(f) stacked tax on $50,000 — $14,600 SD = $35,400: roughly $4,000.
-- FTC on the $50,000 (Portuguese tax allocated: $36,000 × 50/180 = $10,000): FTC = MIN($10,000, $4,000) = $4,000. Net US income tax = $0.
+- §911(f) stacked tax on $50,000 — $15,750 SD = $34,250: roughly $3,900.
+- FTC on the $50,000 (Portuguese tax allocated: $36,000 × 50/180 = $10,000): FTC = MIN($10,000, $3,900) = $3,900. Net US income tax = $0.
 - SE tax: Portugal IS on totalization list. If David has a Certificate of Coverage from Portuguese Segurança Social, SE tax = $0. Otherwise SE tax = $180,000 × 0.9235 × 0.153 = ~$25,447.
 
 **FTC-only path**:
 - Full $180,000 in US gross income.
-- Taxable: $180,000 − $14,600 = $165,400.
-- Tax ≈ $33,000.
-- FTC = MIN($36,000, $33,000) = $33,000. Net US income tax = $0.
-- Excess FTC carryforward: $3,000 (10 years).
+- Taxable: $180,000 − $15,750 = $164,250.
+- Tax ≈ $32,300.
+- FTC = MIN($36,000, $32,300) = $32,300. Net US income tax = $0.
+- Excess FTC carryforward: $3,700 (10 years).
 - SE tax: same as above; not affected by FTC vs §911.
 
-**Recommendation**: For David, FTC-only is slightly better because (a) generates $3,000 of carryforward, (b) preserves Roth IRA / IRA contribution eligibility (compensation is not reduced by §911 exclusion), (c) keeps QBI deduction available on full $180,000 Schedule C net profit (§911 would exclude $130,000 from QBI base), (d) avoids the §911 election lockout if David ever wants to relocate to a high-cost city in the future.
+**Recommendation**: For David, FTC-only is slightly better because (a) generates $3,700 of carryforward, (b) preserves Roth IRA / IRA contribution eligibility (compensation is not reduced by §911 exclusion), (c) keeps QBI deduction available on full $180,000 Schedule C net profit (§911 would exclude $130,000 from QBI base), (d) avoids the §911 election lockout if David ever wants to relocate to a high-cost city in the future.
 
 **Caveat**: David should still file Form 2555 to preserve the §911 election history if he has filed it in prior years. Statement: "FEIE election under §911(e) remains in effect; FEIE not claimed for tax year 2025 due to election to use FTC."
 
@@ -582,20 +582,20 @@ US citizens abroad still owe quarterly estimated taxes (Form 1040-ES) under §66
 
 **Total exclusion**: $130,000 + $69,200 = $199,200.
 
-**Taxable**: $368,000 − $199,200 = $168,800; minus $14,600 SD = $154,200.
+**Taxable**: $368,000 − $199,200 = $168,800; minus $15,750 SD (OBBBA §70102) = $153,050.
 
-**§911(f) stacked tax** (computed on $154,200 + $199,200 = $353,400):
-- Tax on $353,400 (single 2025) — well into the 35% bracket: approximately $89,000.
-- Tax on $199,200: $1,193 + $4,386 + $12,073 + $22,548 + $640 (small piece in 32%) ≈ $40,840.
-- Net US income tax = $89,000 − $40,840 = $48,160.
+**§911(f) stacked tax** (computed on $153,050 + $199,200 = $352,250):
+- Tax on $352,250 (single 2025) — well into the 35% bracket: approximately $92,800.
+- Tax on $199,200: $1,193 + $4,386 + $12,073 + $22,548 + $608 (small piece in 32%) ≈ $40,808.
+- Net US income tax = $92,800 − $40,808 = $51,992.
 
-**FTC on remaining**: Singapore tax of $31,000 allocated to the $130,000 in non-FEIE foreign earned income (it's tricky — the allocation rules under §904 are complex; assume an allocation of $11,000 to the unexcluded portion as a rough approximation, reviewer to verify). FTC = MIN($11,000, $48,160) = $11,000.
+**FTC on remaining**: Singapore tax of $31,000 allocated to the $130,000 in non-FEIE foreign earned income (it's tricky — the allocation rules under §904 are complex; assume an allocation of $11,000 to the unexcluded portion as a rough approximation, reviewer to verify). FTC = MIN($11,000, $51,992) = $11,000.
 
-**Net US tax owed**: $48,160 − $11,000 = $37,160.
+**Net US tax owed**: $51,992 − $11,000 = $40,992.
 
 **SE tax**: $0 (W-2 employee).
 
-**Decision**: §911 + high-cost housing exclusion + partial FTC is the right combination. Pure FTC would not absorb US tax fully because Singapore's effective rate is low; FTC = $31,000 vs full US tax on $368,000 of approximately $95,000. Net US tax under FTC-only ≈ $64,000 — worse than §911 + FTC carve-out by $26,000.
+**Decision**: §911 + high-cost housing exclusion + partial FTC is the right combination. Pure FTC would not absorb US tax fully because Singapore's effective rate is low; FTC = $31,000 vs full US tax on $368,000 of approximately $92,800. Net US tax under FTC-only ≈ $61,800 — worse than §911 + FTC carve-out by $20,800.
 
 ## 16. Self-Checks (Run Before Reviewer Brief)
 
@@ -707,3 +707,9 @@ verified rules together with the name of the accountant who signed them off.
 
 **→ Install the free connector:** <https://www.openaccountants.com/connect>
 **MCP endpoint:** `https://www.openaccountants.com/api/mcp`
+
+---
+
+## Changelog
+
+- **2026-07-04** — Stale figures corrected via cross-guide contradiction check: 2025 standard deduction $14,600 (the 2024 amount) → $15,750 (OBBBA §70102) in Examples A–C; all downstream stacked-tax, FTC, and carryforward figures recomputed against the 2025 single/MFS brackets (Example A net tax $24,412 → $23,432; Example B carryforward $3,000 → $3,700; Example C net tax $37,160 → $40,992 — the prior figure also understated the stacked tax on $353,400).

--- a/packages/us-federal/us-foreign-tax-credit-1116.md
+++ b/packages/us-federal/us-foreign-tax-credit-1116.md
@@ -5,7 +5,7 @@ jurisdiction: US
 category: federal-tax
 tier: 2
 verified_by: pending
-last_updated: 2025-11-15
+last_updated: 2026-07-04
 version: 0.1
 ---
 
@@ -56,7 +56,7 @@ A taxpayer may **either** credit the foreign income tax under §901 (Form 1116, 
 |---|---|---|
 | Effect on tax | Dollar-for-dollar reduction of US tax | Reduction of taxable income at the marginal rate |
 | US tax liability | Any positive US tax | Only useful if itemizing — and even then worth ~22-37 cents per dollar of foreign tax |
-| Standard vs. itemized | Works alongside standard deduction | Requires itemizing (lose standard deduction worth $15,000 single / $30,000 MFJ for 2025) |
+| Standard vs. itemized | Works alongside standard deduction | Requires itemizing (lose standard deduction worth $15,750 single / $31,500 MFJ for 2025, OBBBA §70102) |
 | Excess foreign tax | Carries 1 back / 10 forward | No carry — use it or lose it |
 | Form 1116 complexity | Required (unless de minimis election applies) | No Form 1116 needed |
 
@@ -377,21 +377,21 @@ A §911 election, once revoked, **cannot be re-elected for 5 tax years** without
 - Foreign wages (Germany): €120,000 ≈ **$130,000** at the 2025 average rate.
 - German income tax + solidarity surcharge withheld: **€42,000 ≈ $45,500** (effective rate ~35%).
 - No US-source income.
-- Takes the standard deduction ($15,000 for single).
+- Takes the standard deduction ($15,750 for single, OBBBA §70102).
 - Eligible for §911 (physical presence: 340 days outside US).
 
 **Decision: skip §911, use FTC.**
 
-Reason: German effective rate (35%) > US marginal rate on $130k of taxable income (~22-24% net of standard deduction). §911 excludes only $130,000 (the entire wage, so US tax would be zero under §911 alone — but no carryforward generated). FTC: US tax ≈ $20,000 on $115k taxable, eliminated by ~$45,500 of foreign tax → ~$25,000 of **excess credit carryforward**.
+Reason: German effective rate (35%) > US marginal rate on $130k of taxable income (~22-24% net of standard deduction). §911 excludes only $130,000 (the entire wage, so US tax would be zero under §911 alone — but no carryforward generated). FTC: US tax ≈ $20,000 on ~$114k taxable, eliminated by ~$45,500 of foreign tax → ~$25,000 of **excess credit carryforward**.
 
 **Form 1116 (General basket, box d):**
 - Part I line 1a: $130,000
-- Part I line 3a: standard deduction apportionment: $15,000 × ($130,000 / $130,000) = $15,000
-- Part I line 7: $115,000 (foreign-source taxable income, general basket)
+- Part I line 3a: standard deduction apportionment: $15,750 × ($130,000 / $130,000) = $15,750
+- Part I line 7: $114,250 (foreign-source taxable income, general basket)
 - Part II line 8: $45,500 (foreign tax paid)
-- Part III line 18: $115,000 (total taxable income — entirely foreign)
-- Part III line 19: $115,000 / $115,000 = 1.0000
-- Part III line 20: US tax before FTC ≈ **$20,000** (2025 single brackets on $115k)
+- Part III line 18: $114,250 (total taxable income — entirely foreign)
+- Part III line 19: $114,250 / $114,250 = 1.0000
+- Part III line 20: US tax before FTC ≈ **$20,000** (2025 single brackets on $114,250)
 - Part III line 21: Maximum FTC = 1.0000 × $20,000 = $20,000
 - Part III line 22: lesser of $45,500 or $20,000 = **$20,000 credit**
 - Excess: $45,500 − $20,000 = **$25,500 carryforward** in the General basket
@@ -446,24 +446,24 @@ Reason: no UAE tax to credit on the wages → §911 is the only way to reduce US
 **Form 1116 — General basket (one form with two columns, Germany and Brazil):**
 - Part I line 1a column A (Germany): $60,000; column B (Brazil): $30,000; total $90,000
 - Part I line 2: Schedule C expenses definitely related to the foreign work — assume $9,000 (the foreign-work share of total $27,000 of Schedule C expenses, allocated by gross income ratio: $90k/$180k × $27k = $13,500; refine if any expense is definitely US or definitely foreign). Use $13,500.
-- Part I line 3a: standard deduction apportioned: $15,000 × ($90,000 / $180,000) = $7,500
-- Part I line 6: $90,000 − $13,500 − $7,500 = $69,000 foreign-source taxable income
+- Part I line 3a: standard deduction apportioned: $15,750 × ($90,000 / $180,000) = $7,875
+- Part I line 6: $90,000 − $13,500 − $7,875 = $68,625 foreign-source taxable income
 - Part II line 8: $18,000 (Germany) + $7,500 (Brazil) = $25,500 foreign tax paid
-- Part III line 18: total taxable income from Form 1040 line 15: $180,000 − $13,500 SE-deduction half − $13,500 Schedule C expenses already in line 1a − adjust for the half-SE tax deduction (~$12,700) and QBI deduction (~$33,000 if non-SSTB, see `us-qbi-deduction`) and standard deduction ($15,000) → call it **$105,000** for illustration (worked out by `us-schedule-c-and-se-computation` + `us-qbi-deduction`).
-- Part III line 19: $69,000 / $105,000 = 0.6571
+- Part III line 18: total taxable income from Form 1040 line 15: $180,000 − $13,500 SE-deduction half − $13,500 Schedule C expenses already in line 1a − adjust for the half-SE tax deduction (~$12,700) and QBI deduction (~$33,000 if non-SSTB, see `us-qbi-deduction`) and standard deduction ($15,750, OBBBA §70102) → call it **$105,000** for illustration (worked out by `us-schedule-c-and-se-computation` + `us-qbi-deduction`).
+- Part III line 19: $68,625 / $105,000 = 0.6536
 - Part III line 20: US tax before FTC on $105,000 single ≈ $17,500
-- Part III line 21: max FTC = 0.6571 × $17,500 = **$11,500**
-- Part III line 22: lesser of $25,500 or $11,500 = **$11,500 General-basket credit**
-- Excess: $25,500 − $11,500 = **$14,000 General-basket carryforward**
+- Part III line 21: max FTC = 0.6536 × $17,500 = **$11,438**
+- Part III line 22: lesser of $25,500 or $11,438 = **$11,438 General-basket credit**
+- Excess: $25,500 − $11,438 = **$14,062 General-basket carryforward**
 
 **Form 1116 — Passive basket:**
 - $850 foreign tax, $4,200 foreign dividend income.
 - **De minimis election unavailable** because the taxpayer also has general-basket foreign tax. (The $300 cap is total across all baskets.)
 - Compute the passive-basket Form 1116 in full. With $4,200 of foreign-source qualified dividends (Part I line 1a after qualified-dividend rate adjustment — multiplied by the rate ratio 15%/37% = 0.4054 for QD-rate adjustment if not in de minimis, → ~$1,703 adjusted), the limitation is small (probably absorbs all $850). Confirm with the worksheet.
 
-**Schedule 3 line 1:** ~$12,350 total FTC (General $11,500 + Passive $850).
+**Schedule 3 line 1:** ~$12,288 total FTC (General $11,438 + Passive $850).
 
-**Sanity check.** Brazil and Germany combined effective tax (28.3% on $90k of foreign wages) exceeded the US average rate, generating a $14,000 carryforward. With future foreign work the carryforward will absorb. Document on Schedule B.
+**Sanity check.** Brazil and Germany combined effective tax (28.3% on $90k of foreign wages) exceeded the US average rate, generating a $14,062 carryforward. With future foreign work the carryforward will absorb. Document on Schedule B.
 
 ---
 
@@ -613,3 +613,9 @@ verified rules together with the name of the accountant who signed them off.
 
 **→ Install the free connector:** <https://www.openaccountants.com/connect>
 **MCP endpoint:** `https://www.openaccountants.com/api/mcp`
+
+---
+
+## Changelog
+
+- **2026-07-04** — Stale figures corrected via cross-guide contradiction check: 2025 standard deduction $15,000 single / $30,000 MFJ → $15,750 / $31,500 (OBBBA §70102). Example A recomputed (foreign-source taxable income $115,000 → $114,250; credit unchanged at ~$20,000). Example C recomputed (apportioned deduction $7,500 → $7,875; limitation ratio 0.6571 → 0.6536; General-basket credit $11,500 → $11,438; carryforward $14,000 → $14,062).

--- a/packages/us-federal/us-form-1040-individual-return.md
+++ b/packages/us-federal/us-form-1040-individual-return.md
@@ -1,6 +1,6 @@
 ---
 name: us-form-1040-individual-return
-description: Tier 2 US federal content skill for preparing Form 1040 — the standard individual income tax return for non-freelance taxpayers (W-2 employees, retirees, investors, families). Covers tax year 2025 under OBBBA including the $40k SALT cap, the $15k/$30k/$22,500 standard deduction, capital gains brackets (0/15/20%), the §1411 3.8% NIIT, AMT post-TCJA, Schedule 1/2/3 walkthrough, dependents and filing status, kiddie tax §1(g), and itemized deduction Schedule A. Distinct from us-federal-return-assembly which orchestrates Schedule C freelance returns. Federal only.
+description: Tier 2 US federal content skill for preparing Form 1040 — the standard individual income tax return for non-freelance taxpayers (W-2 employees, retirees, investors, families). Covers tax year 2025 under OBBBA including the $40k SALT cap, the $15,750/$31,500/$23,625 standard deduction, capital gains brackets (0/15/20%), the §1411 3.8% NIIT, AMT post-TCJA, Schedule 1/2/3 walkthrough, dependents and filing status, kiddie tax §1(g), and itemized deduction Schedule A. Distinct from us-federal-return-assembly which orchestrates Schedule C freelance returns. Federal only.
 jurisdiction: US
 category: federal-tax
 tier: 2
@@ -64,11 +64,13 @@ Refuse and refer to a human credentialed preparer when:
 
 | Filing status | 2025 amount |
 |---|---|
-| Single | **$15,000** |
-| Married filing jointly (MFJ) | **$30,000** |
-| Married filing separately (MFS) | $15,000 |
-| Head of household (HoH) | **$22,500** |
-| Qualifying surviving spouse (QSS) | $30,000 |
+| Single | **$15,750** |
+| Married filing jointly (MFJ) | **$31,500** |
+| Married filing separately (MFS) | $15,750 |
+| Head of household (HoH) | **$23,625** |
+| Qualifying surviving spouse (QSS) | $31,500 |
+
+OBBBA §70102 raised the 2025 base amounts above the original Rev. Proc. 2024-40 figures ($15,000 / $30,000 / $22,500).
 
 Additional standard deduction (age 65+ or blind):
 - **MFJ / QSS:** $1,600 per qualifying condition per spouse
@@ -744,7 +746,7 @@ For 2025: excess business loss disallowed when business losses exceed business i
 8. **NIIT** not computed when AGI > $200k/$250k and investment income present.
 9. **Kiddie tax** Form 8615 missed for college student dependents with brokerage 1099-DIV.
 10. **AMT** not run for ISO exercises.
-11. **Standard deduction limitation** when claimed as a dependent — taxpayer used the regular $15k instead of the §63(c)(5) limit ($1,350 or earned income + $450, capped at $15k).
+11. **Standard deduction limitation** when claimed as a dependent — taxpayer used the regular $15,750 instead of the §63(c)(5) limit ($1,350 or earned income + $450, capped at $15,750).
 12. **Wrong filing status** — HoH claimed without a qualifying person; QSS claimed in year 3+ after spouse's death.
 13. **Box 12 W-2 code DD** (employer-sponsored health coverage) mistakenly added to income — informational only.
 14. **Form 1098-T scholarship amount** not added back when in excess of qualified tuition for AOTC.
@@ -779,31 +781,31 @@ For 2025: excess business loss disallowed when business losses exceed business i
 | 9 | Total income | $105,250 |
 | 10 | Adjustments (Sch 1 Line 13 HSA $4,300 + Line 21 SLI $1,800) | $6,100 |
 | 11 | AGI | $99,150 |
-| 12 | Standard deduction | $15,000 |
+| 12 | Standard deduction | $15,750 |
 | 13 | QBI | 0 |
-| 14 | Sum | $15,000 |
-| 15 | Taxable income | $84,150 |
+| 14 | Sum | $15,750 |
+| 15 | Taxable income | $83,400 |
 
 **Tax computation** (Qualified Dividends and Capital Gain Tax Worksheet because LTCG and QDIV present):
-- Ordinary taxable income portion: $84,150 - $5,000 LTCG - $2,800 QDIV = $76,350
+- Ordinary taxable income portion: $83,400 - $5,000 LTCG - $2,800 QDIV = $75,600
 - STCG of $1,200 is in ordinary portion
-- Tax on $76,350 (single, §1(j)): $11,983
+- Tax on $75,600 (single, §1(j)): $11,546
   - 10% × $11,925 = $1,192.50
   - 12% × ($48,475 - $11,925) = $4,386.00
-  - 22% × ($76,350 - $48,475) = $6,132.50
-  - Total = $11,711 (rounded per tax table)
+  - 22% × ($75,600 - $48,475) = $5,967.50
+  - Total = $11,546 (rounded per tax table)
 - Tax on $5,000 + $2,800 = $7,800 LTCG/QDIV at 15% (since ordinary income > $48,350 threshold): $1,170
-- Line 16 tax: ~**$12,881**
+- Line 16 tax: ~**$12,716**
 
 | Line | Item | Amount |
 |---|---|---|
-| 16 | Tax | $12,881 |
-| 22 | Total tax before other | $12,881 |
+| 16 | Tax | $12,716 |
+| 22 | Total tax before other | $12,716 |
 | 23 | Other taxes (Schedule 2) | 0 |
-| 24 | Total tax | $12,881 |
+| 24 | Total tax | $12,716 |
 | 25a | Withholding W-2 | $12,400 |
 | 33 | Total payments | $12,400 |
-| 37 | Amount owed | **$481** |
+| 37 | Amount owed | **$316** |
 
 NIIT check: AGI $99,150 < $200k threshold — **no NIIT**.
 
@@ -850,7 +852,7 @@ NIIT check: AGI $99,150 < $200k threshold — **no NIIT**.
 | 14 | Total charitable | $9,500 |
 | 17 | Total itemized | **$67,300** |
 
-Itemized ($67,300) > standard ($30,000) → itemize.
+Itemized ($67,300) > standard ($31,500) → itemize.
 
 | Line | Item | Amount |
 |---|---|---|
@@ -939,34 +941,34 @@ Itemized ($67,300) > standard ($30,000) → itemize.
 | 11 | AGI | $72,300 |
 
 **Standard deduction** (single, age 65+):
-- Base $15,000 + age 65+ addition $2,000 = **$17,000**
+- Base $15,750 + age 65+ addition $2,000 = **$17,750**
 
 Compare itemized: property tax $4,800 + charitable $1,200 = $6,000 — well below standard. Use standard.
 
 | Line | Item | Amount |
 |---|---|---|
-| 12 | Standard | $17,000 |
-| 15 | Taxable income | $55,300 |
+| 12 | Standard | $17,750 |
+| 15 | Taxable income | $54,550 |
 
 **Tax** (Qualified Dividends and Capital Gain Worksheet):
-- Ordinary portion: $55,300 - $9,000 LTCG - $3,200 QDIV = $43,100
-- Tax on $43,100 single:
+- Ordinary portion: $54,550 - $9,000 LTCG - $3,200 QDIV = $42,350
+- Tax on $42,350 single:
   - 10% × $11,925 = $1,192.50
-  - 12% × ($43,100 - $11,925) = $3,741
-  - Total = $4,934
+  - 12% × ($42,350 - $11,925) = $3,651
+  - Total = $4,844
 - Tax on $9,000 + $3,200 = $12,200 LTCG/QDIV:
-  - $43,100 ordinary + $12,200 = $55,300 total
-  - $48,350 - $43,100 = $5,250 at 0%
-  - $12,200 - $5,250 = $6,950 at 15% = $1,043
-- **Line 16 tax: ~$5,977**
+  - $42,350 ordinary + $12,200 = $54,550 total
+  - $48,350 - $42,350 = $6,000 at 0%
+  - $12,200 - $6,000 = $6,200 at 15% = $930
+- **Line 16 tax: ~$5,774**
 
 | Line | Item | Amount |
 |---|---|---|
-| 16 | Tax | $5,977 |
-| 24 | Total tax | $5,977 |
+| 16 | Tax | $5,774 |
+| 24 | Total tax | $5,774 |
 | 25b | 1099 withholding | $7,000 |
 | 33 | Total payments | $7,000 |
-| 34 | Overpayment | **$1,023 refund** |
+| 34 | Overpayment | **$1,226 refund** |
 
 NIIT check: AGI $72,300 < $200k — none. RMD check: Walter is 73, RMD age (73 under SECURE 2.0 §107 for those born 1951-1959) — confirm full RMD was satisfied. The $10,000 QCD counts toward RMD (§408(d)(8)(B)).
 
@@ -1067,3 +1069,4 @@ verified rules together with the name of the accountant who signed them off.
 ## Changelog
 
 - **2026-07-04** — OBBBA corrections applied from an in-progress review by Christopher Aryee, CPA: SALT §70120 + phase-down, §199A stays 20%, CTC §70104, §25D §70506, tips/overtime/auto §70201–203, 2026 standard deduction, educator expenses uncapped, mortgage insurance deductible, 0.5% charitable floor, state-disaster casualty losses, Pease §70111, §1202 phased exclusion, adoption credit refundable, §461(l) §70601.
+- **2026-07-04** — Stale figures corrected via cross-guide contradiction check: 2025 base standard deduction $15,000/$30,000/$22,500 → $15,750/$31,500/$23,625 (OBBBA §70102); worked examples recomputed — Example A tax $12,881 → $12,716, owed $481 → $316; Example C standard deduction $17,000 → $17,750, tax $5,977 → $5,774, refund $1,023 → $1,226 (Rev. Proc. 2024-40 / OBBBA §70102).

--- a/packages/us-federal/us-irs-collections-and-controversy.md
+++ b/packages/us-federal/us-irs-collections-and-controversy.md
@@ -5,7 +5,7 @@ jurisdiction: US
 category: federal-tax
 tier: 2
 verified_by: pending
-last_updated: 2025-11-15
+last_updated: 2026-07-04
 version: 0.1
 ---
 
@@ -315,7 +315,7 @@ The timeline is approximate. Cases assigned to a Revenue Officer (RO) can move f
 
 Once 30 days have passed since LT11/CP90 with no CDP request and no payment arrangement, the IRS may levy. Common levy targets:
 
-- **Wage levy** (Form 668-W). Continuous on each paycheck. The exempt amount under §6334(d) is computed from the standard deduction and personal exemptions (for 2025, the IRS publishes Publication 1494 tables; the exempt amount for a single filer with no dependents is roughly $14,600 / year divided by pay periods — verify against the most current Publication 1494). Everything above the exempt amount goes to the IRS until released.
+- **Wage levy** (Form 668-W). Continuous on each paycheck. The exempt amount under §6334(d) is computed from the standard deduction and personal exemptions (for 2025, the IRS publishes Publication 1494 tables; the exempt amount for a single filer with no dependents is roughly $15,750 / year — tracking the OBBBA §70102 standard deduction — divided by pay periods; Publication 1494 controls the actual levy tables, so verify against the most current edition). Everything above the exempt amount goes to the IRS until released.
 - **Bank levy** (Form 668-A). One-shot levy on the account balance at the moment the bank receives the levy. The bank holds the funds for **21 days** (§6332(c)) before remitting to the IRS, giving the taxpayer and practitioner a narrow window to negotiate a release.
 - **Accounts receivable levy.** Levies on the taxpayer's customers. Catastrophic for businesses.
 - **Social Security levy** under the Federal Payment Levy Program (FPLP): up to 15% of SS benefits.
@@ -1205,3 +1205,9 @@ verified rules together with the name of the accountant who signed them off.
 
 **→ Install the free connector:** <https://www.openaccountants.com/connect>
 **MCP endpoint:** `https://www.openaccountants.com/api/mcp`
+
+---
+
+## Changelog
+
+- **2026-07-04** — Stale figures corrected via cross-guide contradiction check: §6334(d) wage-levy exempt-amount illustration updated from the 2024 standard deduction ($14,600) to the 2025 amount $15,750 (OBBBA §70102); Publication 1494 controls the actual levy tables.

--- a/skills/federal/us-crypto-tax.md
+++ b/skills/federal/us-crypto-tax.md
@@ -5,7 +5,7 @@ version: 1.0
 jurisdiction: US
 tax_year: 2025
 tier: 2
-last_updated: 2026-06-12
+last_updated: 2026-07-04
 category: federal
 ---
 
@@ -521,7 +521,7 @@ Coinbase, Kraken, Gemini, Binance.US are US-based. Accounts on these exchanges a
 
 - Donor: No taxable event upon gifting
 - Recipient basis: Carryover basis from donor (for gains); FMV at time of gift (for losses, if FMV < donor's basis)
-- Gift tax: Form 709 required if gift exceeds $18,000 annual exclusion (2025) per recipient
+- Gift tax: Form 709 required if gift exceeds $19,000 annual exclusion (2025, Rev. Proc. 2024-40) per recipient
 - Holding period: Tacks (recipient includes donor's holding period) if using carryover basis
 
 ### Charitable donations of crypto
@@ -669,6 +669,10 @@ Received 1,000 ARB tokens via airdrop on March 23, 2025. FMV at receipt: $1.15/t
 ## End of Skill
 
 ---
+
+## Changelog
+
+- **2026-07-04** — Stale figures corrected via cross-guide contradiction check: 2025 gift tax annual exclusion $18,000 → $19,000 ($18,000 was the 2024 figure) (Rev. Proc. 2024-40).
 
 ## Disclaimer
 

--- a/skills/federal/us-qbi-deduction.md
+++ b/skills/federal/us-qbi-deduction.md
@@ -4,7 +4,7 @@ description: Tier 2 content skill for computing the §199A Qualified Business In
 version: 0.2
 jurisdiction: US
 tier: 2
-last_updated: 2026-06-12
+last_updated: 2026-07-04
 ---
 
 # US QBI Deduction Skill v0.2
@@ -459,9 +459,9 @@ QBI:                                  $19,053
 
 **QBI deduction:** 20% × $19,053 = **$3,811**
 
-**Taxable income check:** $62,644 AGI − $4,427 SE tax − $8,400 SE health − $30,764 retirement − $15,000 standard deduction (2025) = ~$4,053 taxable income. Well below $197,300 threshold. QBI deduction limited to lesser of $3,811 or 20% × $4,053 = $811.
+**Taxable income check:** $62,644 AGI − $4,427 SE tax − $8,400 SE health − $30,764 retirement − $15,750 standard deduction (2025, OBBBA §70102) = ~$3,303 taxable income. Well below $197,300 threshold. QBI deduction limited to lesser of $3,811 or 20% × $3,303 = $661.
 
-**Result: QBI deduction = $811** (limited by taxable income cap).
+**Result: QBI deduction = $661** (limited by taxable income cap).
 
 **Form:** 8995 (simplified).
 
@@ -474,7 +474,7 @@ QBI:                                  $19,053
 - Deductible half of SE tax: $10,597
 - SE health insurance: $9,600
 - SEP-IRA contribution: $26,081
-- Standard deduction: $15,000
+- Standard deduction: $15,750
 
 **QBI computation:**
 ```
@@ -488,11 +488,11 @@ QBI:                                  $103,722
 
 **QBI deduction (tentative):** 20% × $103,722 = $20,744
 
-**Taxable income:** $150,000 − $10,597 − $9,600 − $26,081 − $15,000 = $88,722. Below $197,300.
+**Taxable income:** $150,000 − $10,597 − $9,600 − $26,081 − $15,750 = $87,972. Below $197,300.
 
-**Taxable income cap:** 20% × $88,722 = $17,744
+**Taxable income cap:** 20% × $87,972 = $17,594
 
-**Result: QBI deduction = $17,744** (limited by taxable income cap).
+**Result: QBI deduction = $17,594** (limited by taxable income cap).
 
 ### Example 3 — Above threshold, SSTB, within phase-in
 
@@ -553,8 +553,8 @@ Reduction amount phases in the W-2/UBIA limit. Because the W-2/UBIA limit is $0,
 ## Section 14 — Test suite
 
 ### Test 1 — Basic below-threshold computation
-**Input:** Schedule C net profit $80,000; deductible half of SE tax $5,652; SE health insurance $6,000; SEP-IRA $13,470; single; standard deduction $15,000; no capital gains.
-**Expected:** QBI = $80,000 − $5,652 − $6,000 − $13,470 = $54,878. Tentative QBI deduction = 20% × $54,878 = $10,976. Taxable income = $80,000 − $5,652 − $6,000 − $13,470 − $15,000 = $39,878. TI cap = 20% × $39,878 = $7,976. **QBI deduction = $7,976** (TI-limited). Form 8995.
+**Input:** Schedule C net profit $80,000; deductible half of SE tax $5,652; SE health insurance $6,000; SEP-IRA $13,470; single; standard deduction $15,750; no capital gains.
+**Expected:** QBI = $80,000 − $5,652 − $6,000 − $13,470 = $54,878. Tentative QBI deduction = 20% × $54,878 = $10,976. Taxable income = $80,000 − $5,652 − $6,000 − $13,470 − $15,750 = $39,128. TI cap = 20% × $39,128 = $7,826. **QBI deduction = $7,826** (TI-limited). Form 8995.
 
 ### Test 2 — Loss year
 **Input:** Schedule C net loss ($15,000); deductible half of SE tax $0 (no profit); single.
@@ -619,6 +619,10 @@ Reduction amount phases in the W-2/UBIA limit. Because the W-2/UBIA limit is $0,
 | `us-ca-return-assembly` | QBI deduction for CA-resident federal return |
 
 ---
+
+## Changelog
+
+- **2026-07-04** — Stale figures corrected via cross-guide contradiction check: 2025 standard deduction (single) $15,000 → $15,750 in Examples 1–2 and Test 1; taxable income, TI caps, and QBI deduction results recomputed ($811 → $661; $17,744 → $17,594; $7,976 → $7,826) (OBBBA §70102).
 
 ## Disclaimer
 


### PR DESCRIPTION
First shipment of today's accuracy machine — a cross-guide contradiction detector, a 59-agent adversarial adjudication, a 20-agent Fable deep review (150 upheld corrections), and a fetched **truth layer of 189 IRS/SSA figures with verbatim quotes**.

## Batch 1 (this push)
- **Gift annual exclusion 2025: $18,000 → $19,000** (Rev. Proc. 2024-40, and the IRS gift-tax FAQ page fetched today literally shows `2025 | $19,000`)
- **Standard deduction 2025: $15,750 everywhere** (OBBBA §70102) — including `rates.2025.json` which contradicted its own legislative-basis claim, the 1040 guide (see note), education credits, FTC 1116 (worked example fully recomputed), collections, 2555 (examples recomputed; pre-existing arithmetic errors found and fixed), and QBI examples
- Every touched example had its downstream arithmetic recomputed, not just the headline figure

**Note on the 1040 guide:** it's Partner-bound (Chris Aryee's re-approval), but it still carried $15,000 — leaving the flagship wrong while fixing stragglers would recreate the contradiction, so it was fixed with full example recomputation. Flag if you'd rather revert that file.

## Incoming to this branch (agents finishing now)
~130 more skeptic-verified corrections: the **1099-K guide rewritten for the OBBBA §70432 repeal** (IRS's own page, fetched today, confirms $20,000/200), QBI's phantom 23% rate, SALT/§179 stragglers, UK Class 2 SPT £6,845, and per-guide corrections across 1202/1031/retirement/941-940/estate-gift/S-corp/Schedule C/quarterly/crypto.

Parked honestly rather than guessed: [#60](https://github.com/openaccountants/openaccountants/issues/60) (16 items needing current IRS documents). German findings: #55/#59 for the incoming Steuerberater.