### PR TITLE
Worked-example arithmetic pass across US federal guides

### DIFF
--- a/index.json
+++ b/index.json
@@ -1,5 +1,5 @@
 {
- "generated_at": "2026-07-06T09:05:27+00:00",
+ "generated_at": "2026-07-06T09:07:21+00:00",
  "counts": {
   "guides": 1007,
   "jurisdictions": 187,
@@ -160,7 +160,7 @@
    "verified_by": "pending",
    "reviewed_by": null,
    "tax_year": null,
-   "last_updated": "2026-07-05"
+   "last_updated": "2026-07-06"
   },
   {
    "slug": "us-gilti-fdii-beat",

--- a/index.json
+++ b/index.json
@@ -1,5 +1,5 @@
 {
- "generated_at": "2026-07-06T09:07:21+00:00",
+ "generated_at": "2026-07-06T09:10:01+00:00",
  "counts": {
   "guides": 1007,
   "jurisdictions": 187,
@@ -952,7 +952,7 @@
    "verified_by": null,
    "reviewed_by": null,
    "tax_year": null,
-   "last_updated": "2026-07-04"
+   "last_updated": "2026-07-06"
   },
   {
    "slug": "us-self-employed-health-insurance",

--- a/index.json
+++ b/index.json
@@ -1,5 +1,5 @@
 {
- "generated_at": "2026-07-06T09:10:01+00:00",
+ "generated_at": "2026-07-06T09:15:19+00:00",
  "counts": {
   "guides": 1007,
   "jurisdictions": 187,
@@ -40,7 +40,7 @@
    "verified_by": "pending",
    "reviewed_by": null,
    "tax_year": null,
-   "last_updated": "2025-11-15"
+   "last_updated": "2026-07-06"
   },
   {
    "slug": "us-fbar-and-fatca-8938",

--- a/index.json
+++ b/index.json
@@ -1,5 +1,5 @@
 {
- "generated_at": "2026-07-06T08:59:26+00:00",
+ "generated_at": "2026-07-06T09:04:39+00:00",
  "counts": {
   "guides": 1007,
   "jurisdictions": 187,
@@ -256,7 +256,7 @@
    "verified_by": "pending",
    "reviewed_by": null,
    "tax_year": null,
-   "last_updated": "2026-07-05"
+   "last_updated": "2026-07-06"
   },
   {
    "slug": "us-section-1202-qsbs",

--- a/index.json
+++ b/index.json
@@ -1,5 +1,5 @@
 {
- "generated_at": "2026-07-05T17:41:06+00:00",
+ "generated_at": "2026-07-06T08:56:03+00:00",
  "counts": {
   "guides": 1007,
   "jurisdictions": 187,
@@ -976,7 +976,7 @@
    "verified_by": null,
    "reviewed_by": null,
    "tax_year": null,
-   "last_updated": "2026-07-05"
+   "last_updated": "2026-07-06"
   },
   {
    "slug": "us-sole-prop-bookkeeping",

--- a/index.json
+++ b/index.json
@@ -1,5 +1,5 @@
 {
- "generated_at": "2026-07-06T08:56:03+00:00",
+ "generated_at": "2026-07-06T08:59:26+00:00",
  "counts": {
   "guides": 1007,
   "jurisdictions": 187,
@@ -268,7 +268,7 @@
    "verified_by": "pending",
    "reviewed_by": null,
    "tax_year": null,
-   "last_updated": "2026-07-05"
+   "last_updated": "2026-07-06"
   },
   {
    "slug": "us-secure-2-and-retirement-updates",

--- a/index.json
+++ b/index.json
@@ -1,5 +1,5 @@
 {
- "generated_at": "2026-07-06T09:04:39+00:00",
+ "generated_at": "2026-07-06T09:05:27+00:00",
  "counts": {
   "guides": 1007,
   "jurisdictions": 187,

--- a/packages/us-federal/us-estate-gift-706-709.md
+++ b/packages/us-federal/us-estate-gift-706-709.md
@@ -5,7 +5,7 @@ jurisdiction: US
 category: federal-tax
 tier: 2
 verified_by: pending
-last_updated: 2025-11-15
+last_updated: 2026-07-06
 version: 0.1
 ---
 
@@ -95,7 +95,7 @@ The **applicable credit amount** under §2010(c)(2) for 2025 is the tentative ta
 AEA  =  BEA  +  DSUE  +  Restored exclusion amount (rarely applicable)
 ```
 
-For a single decedent or unmarried donor in 2025, AEA = BEA = **$13,990,000**, producing an applicable credit amount of **$5,389,800** (the tentative tax on $13,990,000 under §2001(c)).
+For a single decedent or unmarried donor in 2025, AEA = BEA = **$13,990,000**, producing an applicable credit amount of **$5,541,800** (the tentative tax on $13,990,000 under §2001(c): $345,800 on the first $1,000,000 plus 40% of the remaining $12,990,000 = $5,196,000). Note: $5,389,800 is the *2024* credit (on the 2024 BEA of $13,610,000) — do not carry it into 2025.
 
 ### 2.4 The "Form 706 Method" — interaction of lifetime gifts and the estate
 
@@ -781,13 +781,13 @@ S's AEA after the election: $13,990,000 (S's own BEA in 2025) + $13,990,000 (DSU
 
 | Asset | Value |
 |---|---|
-| Primary residence (jointly held with S) | $3,000,000 |
+| Primary residence (spousal JTWROS, FMV $3,000,000) — only ½ includible under §2040(b) | $1,500,000 |
 | Brokerage account (D's separate) | $9,000,000 |
 | IRA (S is sole beneficiary) | $4,000,000 |
 | Life insurance (proceeds payable to D's estate) | $2,000,000 |
 | Personal effects, autos | $500,000 |
 | 50% interest in family LLC (closely held real estate) | $1,500,000 |
-| **Total gross estate** | **$20,000,000** |
+| **Total gross estate** | **$18,500,000** |
 
 D's will: $13,990,000 to a credit shelter (bypass) trust for the benefit of S during life with remainder to the children; residue outright to S.
 
@@ -797,23 +797,25 @@ Prior gifts: D used $500,000 of BEA in 2018 on a gift to children.
 
 | Line | Amount |
 |---|---|
-| Gross estate | $20,000,000 |
+| Gross estate (residence at the §2040(b) ½ = $1.5M) | $18,500,000 |
 | Schedule J — funeral & admin | ($200,000) |
 | Schedule K — debts (residential mortgage $400k) | ($400,000) |
-| Schedule M — marital deduction (residue + 1/2 JTWROS + IRA = $1.5M + $4M + remaining residue) | ($5,910,000) |
+| Schedule M — marital deduction (½ JTWROS residence $1.5M + IRA $4M + probate residue to S) | ($5,910,000) |
 | Schedule M — bypass trust is NOT marital because it terminates at S's death without QTIP | $0 |
-| Taxable estate | $13,490,000 |
+| Taxable estate | $11,990,000 |
 | Adjusted taxable gifts (post-1976 gifts not in gross estate) | $500,000 |
-| Tentative tax base | $13,990,000 |
-| Tentative tax (§2001(c) at 40% top rate) | $5,389,800 |
+| Tentative tax base | $12,490,000 |
+| Tentative tax (§2001(c): $345,800 + 40% × $11,490,000) | $4,941,800 |
 | Less gift tax payable on adjusted taxable gifts at DOD rates | $0 (within BEA) |
-| Net tentative tax | $5,389,800 |
-| Less applicable credit amount (AEA = BEA only, no DSUE) | ($5,389,800) |
+| Net tentative tax | $4,941,800 |
+| Less applicable credit amount (2025, AEA = BEA only, no DSUE) | ($5,541,800) |
 | **Net federal estate tax** | **$0** |
 
 **Notes:**
 
-- D's BEA is fully consumed: $13,490,000 to the bypass trust at death + $500,000 prior gifts = $13,990,000. Exactly matches 2025 BEA.
+- Under **§2040(b)**, a qualified joint interest held with a U.S.-citizen spouse is included at exactly one-half regardless of who contributed, so only $1,500,000 of the $3,000,000 residence is in D's gross estate; the survivor's half was never D's to tax. That includible $1.5M half passes to S by survivorship and is the Schedule M item (net effect on the taxable estate: $0). (The earlier version double-counted by including the full $3M and then deducting only half.)
+- The applicable exclusion is **not** fully consumed: the $12,490,000 base is $1,500,000 below the 2025 BEA, so ~$1,500,000 of exclusion (plus any DSUE) remains — a further reason to file Form 706 for portability.
+- **Reviewer note:** the bypass-trust "$13,990,000 to the credit-shelter trust" clause is an illustrative formula; the probate assets available to fund it (brokerage, life insurance, personal effects, LLC = ~$13M, less debts/expenses) are less than $13,990,000, and the mortgage may need proportioning to the ½ residence interest under §2040(b). Confirm the funding formula and debt apportionment against the actual instrument before relying.
 - IRA passing to S qualifies for marital deduction even though it is IRD — S will pay income tax on distributions; estate tax avoidance is preserved.
 - Life insurance payable to the estate is fully included under §2042 — note the planning miss; an ILIT would have kept the $2M outside the estate.
 - The 50% LLC interest may qualify for valuation discounts (minority interest + lack of marketability) — typically 25-40% combined. Requires appraisal. Not reflected in this example.
@@ -825,8 +827,8 @@ Prior gifts: D used $500,000 of BEA in 2018 on a gift to children.
 
 **Portability:**
 
-- D used the full BEA — DSUE = $0. No portability benefit to S.
-- However, S now holds substantial assets ($5.91M from D's estate + S's own pre-existing assets). S should engage in pre-sunset planning of his/her own — see Example 14.3.
+- With the §2040(b) correction, D's tentative tax base is $12,490,000 — **below** the $13,990,000 BEA — so **DSUE = $13,990,000 − $12,490,000 = $1,500,000** is portable to S if the executor files Form 706 and makes the portability election. (Under the pre-correction $20M/full-BEA version this showed DSUE = $0; the corrected figures leave $1.5M of exclusion to port.)
+- S now holds substantial assets ($5.91M from D's estate + S's own pre-existing assets) plus the $1.5M DSUE. S should still engage in pre-sunset planning of his/her own — see Example 14.3.
 
 ---
 
@@ -860,8 +862,8 @@ W establishes an irrevocable trust (SLAT-2) for the benefit of H and descendants
 | Net taxable gift | $13,000,000 |
 | Cumulative prior gifts | $0 |
 | Cumulative gifts | $13,000,000 |
-| Applicable credit on $13,000,000 | $4,989,800 (tax on $13M at the §2001(c) rates) |
-| Applicable credit available (2025 = $5,389,800) | $5,389,800 |
+| Tentative tax on $13,000,000 (§2001(c)) | $5,145,800 ($345,800 + 40% × $12,000,000) |
+| Applicable credit available (2025) | $5,541,800 |
 | Net gift tax due | $0 |
 
 Each spouse uses $13,000,000 of the $13,990,000 BEA. Remaining BEA per spouse for end-of-2025 = $990,000.
@@ -1096,3 +1098,7 @@ verified rules together with the name of the accountant who signed them off.
 
 **→ Install the free connector:** <https://www.openaccountants.com/connect>
 **MCP endpoint:** `https://www.openaccountants.com/api/mcp`
+
+## Changelog
+
+- **2026-07-06** - Worked-example arithmetic fixes (Fable review). Corrected the 2025 applicable credit amount to **$5,541,800** ($345,800 + 40% × $12,990,000) throughout — the guide had carried the 2024 figure ($5,389,800, on the 2024 BEA of $13,610,000). Example 14.2: applied **§2040(b)** so only one-half ($1,500,000) of the spousal-JTWROS residence is in the gross estate (total $20,000,000 -> $18,500,000); the includible half is the Schedule M item, net $0 to the taxable estate; recomputed the base ($12,490,000), tentative tax ($4,941,800) and DSUE ($0 -> $1,500,000), and flagged the illustrative bypass-trust funding + mortgage apportionment. Example 14.3: §2001(c) tentative tax on $13,000,000 corrected to **$5,145,800** (was $4,989,800, which was the tax on $12,610,000) and the available 2025 credit to $5,541,800. Net tax/gift-tax conclusions ($0) unchanged.

--- a/packages/us-federal/us-form-941-940-payroll.md
+++ b/packages/us-federal/us-form-941-940-payroll.md
@@ -5,7 +5,7 @@ jurisdiction: US
 category: federal-tax
 tier: 2
 verified_by: pending
-last_updated: 2026-07-05
+last_updated: 2026-07-06
 version: 0.1
 ---
 
@@ -788,12 +788,12 @@ Assuming relatively even payroll across the year and the wage base concentration
 |---|---|---|
 | Total wages (Line 2) | $1,800,000 (illustrative) | Box 1 = $1,800,000 |
 | Federal income tax withheld (Line 3) | $360,000 | Box 2 = $360,000 |
-| SS wages (Line 5a Col 1) | $1,408,800 (Carol capped at $176,100 + 7 others at full wages) | Box 3 = $1,408,800 |
-| SS tax (Line 5a Col 2) | $174,691.20 | Box 4 = $87,345.60 (employee half only) |
+| SS wages (Line 5a Col 1) | $1,408,800 (Carol capped at $176,100; her actual wages are $567,300, so the 7 others total $1,232,700, each ≤ the $176,100 wage base) | Box 3 = $1,408,800 |
+| SS tax (Line 5a Col 2) | $174,691.20 (12.4% × $1,408,800) | Box 4 = $87,345.60 (employee half only) |
 | Medicare wages (Line 5c Col 1) | $1,800,000 (uncapped) | Box 5 = $1,800,000 |
-| Medicare tax (Line 5c Col 2 + 5d Col 2) | $53,100 (Medicare) + $900 (Add'l Med) = $54,000 (employer + employee combined for Medicare; Add'l is employee only) | Box 6 = $27,000 (employee Medicare half) + $900 (employee Add'l Medicare) = $27,900 |
+| Medicare tax (Line 5c Col 2 + 5d Col 2) | Regular Medicare 2.9% × $1,800,000 = **$52,200**; Additional Medicare 0.9% × $367,300 (only Carol's wages over $200,000) = **$3,305.70**; total $55,505.70 | Box 6 = employee regular half $26,100 (1.45% × $1,800,000) + Additional Medicare $3,305.70 = **$29,405.70** |
 
-**Note on Box 4 / Box 6 vs 941**: Box 4 and Box 6 on W-2/W-3 are the EMPLOYEE half only. Form 941 Lines 5a Col 2 and 5c Col 2 report the COMBINED employer + employee. Divide the 941 amount by 2 (for SS) and by 2 (for regular Medicare, then add the Additional Medicare which is 100% employee).
+**Note on Box 4 / Box 6 vs 941**: Box 4 and Box 6 on W-2/W-3 are the EMPLOYEE half only. Form 941 Line 5a Col 2 (SS) and Line 5c Col 2 (regular Medicare) report the COMBINED employer + employee, so halve them for the W-2 boxes; Line 5d Col 2 (Additional Medicare) is 100% employee, so it is added to Box 6 in full, not halved. Additional Medicare applies only to the portion of an individual employee's wages above $200,000 — here only Carol crosses that threshold.
 
 If W-3 totals don't match the four 941s, the SSA sends a CAWR discrepancy notice. The employer typically has 45 days to respond with reconciliation.
 
@@ -923,4 +923,5 @@ verified rules together with the name of the accountant who signed them off.
 **MCP endpoint:** `https://www.openaccountants.com/api/mcp`
 
 ## Changelog
+- **2026-07-06** — Worked-example arithmetic pass (completes the §12.4 item flagged 2026-07-05). Example 4 reconciliation: corrected the Medicare figures — regular Medicare is 2.9% × $1,800,000 = $52,200 (was $53,100), and Additional Medicare is 0.9% only on the portion of an individual's wages above $200,000 (here only Carol, whose $567,300 gives 0.9% × $367,300 = $3,305.70, not a flat $900); Box 6 employee Medicare is $26,100 + $3,305.70 = $29,405.70 (was $27,900). Made Carol's $567,300 wages explicit so the reconciliation is followable. The HSA/§125 FICA-exclusion table remains flagged for a separate pass.
 - **2026-07-05** — Payroll corrections (Fable review, verified against IRS i940/i941 + 2025 SS/FUTA figures): T.D. 9972 dated Feb 2023 (not "2024 IRS final regs"); the $2,500 de-minimis deposit test is disjunctive (current OR prior quarter); backup-withholding drafting residue cleaned to a flat 24% for 2025 (§3406; TCJA rates made permanent by OBBBA §70101); FUTA successor wage-base credit cited to §3306(b)(1) not §3306(c)(8); Form 941-X interest-free-adjustment timing tied to when the error is ascertained; reasonable-cause standard split between §6656(a) (deposits) and §6724(a) (info returns). FLAGGED: §12.4 Example 4 reconciliation arithmetic and the HSA/§125 FICA-exclusion table need a follow-up pass.

--- a/packages/us-federal/us-section-1031-like-kind-exchange.md
+++ b/packages/us-federal/us-section-1031-like-kind-exchange.md
@@ -78,7 +78,7 @@ The Tax Cuts and Jobs Act of 2017 (P.L. 115-97), effective for exchanges complet
 6. **Mineral, oil, and gas interests** — perpetual royalty interests qualify; production payments do not
 7. **Easements** (permanent) and **conservation easements**
 8. **Air rights** and **transferable development rights (TDRs)**
-9. **Stock in cooperative housing corporations** (§1031(i)) — limited carve-out for co-op shares
+9. **Stock in a mutual ditch, reservoir, or irrigation company** (§1031(i)) — treated as real property for §1031 where, at the time of the exchange, the shares are recognized as real property by the highest court or a statute of the State of organization (this is the §1031(i) carve-out; it is NOT a cooperative-housing provision)
 
 **Not real property even though physically attached:**
 - Machinery installed for an industrial process, not the building itself
@@ -737,7 +737,7 @@ Before the relinquished property closes, confirm:
 - IRC §1031(d) — basis carryover
 - IRC §1031(f) — related-party 2-year rule
 - IRC §1031(h) — US-for-foreign disallowance
-- IRC §1031(i) — cooperative housing carve-out
+- IRC §1031(i) — mutual ditch, reservoir, or irrigation company stock carve-out
 - IRC §121(d)(10) — §1031 + §121 sequential rules
 - IRC §168(i)(7) — depreciation treatment of exchanged-basis property
 - IRC §1223(1) — holding-period tacking

--- a/packages/us-federal/us-section-1031-like-kind-exchange.md
+++ b/packages/us-federal/us-section-1031-like-kind-exchange.md
@@ -5,7 +5,7 @@ jurisdiction: US
 category: federal-tax
 tier: 2
 verified_by: pending
-last_updated: 2026-07-05
+last_updated: 2026-07-06
 version: 0.1
 ---
 
@@ -546,9 +546,9 @@ California's most distinctive §1031 rule: California Revenue & Taxation Code §
 **Facts:**
 - Taxpayer: California resident, individual, calendar year
 - Relinquished: 12-unit apartment building in San Diego, CA
-  - Original cost (2010): $1,800,000
-  - Cumulative depreciation through 2025: $654,545 (over 15 years on 27.5-year schedule)
-  - Adjusted basis: $1,145,455
+  - Original cost (2010): $1,800,000 ($600,000 land + $1,200,000 building)
+  - Cumulative depreciation through 2025: $654,545 (building $1,200,000 ÷ 27.5-year residential schedule = $43,636/yr × 15 years; land is not depreciable)
+  - Adjusted basis: $1,145,455 ($1,800,000 − $654,545)
   - Mortgage: $900,000 (paid off at closing)
   - Sale price: $3,200,000 (closed June 1, 2025)
   - Selling costs (commission, title, escrow): $192,000
@@ -585,43 +585,40 @@ Deferred gain: $1,862,545
 ```
 
 **Step 4 — Basis in replacement:**
+
+The authoritative identity for a fully deferred exchange is **basis of replacement = its cost (FMV) − deferred gain**:
 ```
-Basis = Adjusted basis relinquished + cash paid + new mortgage + recognized gain − cash received − mortgage relieved
-     = $1,145,455 + $2,100,000 + $1,400,000 + $0 − $0 − $900,000
-     = $3,745,455
-Cross-check: FMV $3,500,000 − deferred gain $1,862,545 = $1,637,455? — discrepancy
+Basis = FMV replacement $3,500,000 − deferred gain $1,862,545 = $1,637,455
 ```
 
-The discrepancy is the boot-paid offset against selling costs. Reconciliation:
+The "carryover + adjustments" formula must reach the **same** $1,637,455. The common error is to add the $2,100,000 of QI cash as "cash paid" — but that cash is the taxpayer's OWN relinquished-sale proceeds (already embedded in the carryover basis and the deferred gain), so counting it again overstates basis. Correct:
 ```
-FMV replacement received: $3,500,000
-Less: deferred gain: $1,862,545
-Basis: $1,637,455
-
-Alternative Treas. Reg. computation:
-Adjusted basis $1,145,455 (carryover)
-+ $1,400,000 debt assumed (treated as cash paid)
-− $900,000 debt relieved (treated as cash received)
-+ $200,000 net additional cash paid out of pocket (the $192,000 selling costs absorb most of the gross sale; net analysis)
-= $1,845,455
+Basis = Adjusted basis relinquished ($1,145,455)
+        + net new consideration paid (net debt assumed $500,000, net of
+          the exchange-expense mechanics)          =  +$492,000
+        + recognized gain ($0)  −  boot received ($0)
+      = $1,637,455
 ```
+(The earlier "$3,745,455" double-counted the $2,100,000 QI proceeds.)
 
-In practice, the reviewer should walk through Form 8824 lines methodically. The depreciation schedule for the replacement post-exchange uses the $1,145,455 carryover basis on the relinquished's residual 12.5-year remaining schedule, plus the $500,000 net debt addition + cash paid out of pocket as new-acquisition basis on a fresh 39-year industrial schedule.
+The post-exchange depreciation schedule splits: the $1,145,455 carryover basis continues on the relinquished's residual residential schedule, and the excess basis ($1,637,455 − $1,145,455 = $492,000, plus any out-of-pocket closing costs) starts a fresh 39-year nonresidential schedule.
 
 **Form 8824 reporting (key lines):**
 - Line 7: Related party? No
-- Line 15: Cash and other property received: $0
+- Line 15: Cash and other (non-like-kind) property received: $0
 - Line 16: FMV of like-kind property received: $3,500,000
-- Line 18: Adjusted basis of relinquished + costs: $1,145,455 + $192,000 + net debt $500,000 = $1,837,455
-- Line 19: Realized gain: $1,862,545
-- Line 20: Recognized gain: $0
-- Line 25: Basis in replacement: $1,637,455
+- Line 17: Line 15 + line 16: $3,500,000
+- Line 18: Adjusted basis of relinquished + net amounts paid + unused exchange expenses: **$1,637,455** (the balancing figure; equals line 25)
+- Line 19: Realized gain = line 17 − line 18 = $3,500,000 − $1,637,455 = **$1,862,545** (ties to Step 1)
+- Line 23: Recognized gain: $0
+- Line 24: Deferred gain = line 19 − line 23: $1,862,545
+- Line 25: Basis in replacement = line 18 + line 23 − line 15 = **$1,637,455** (ties to Step 4)
 
 **California reporting:**
 - Form 3840 filed with 2025 CA return because replacement is in Arizona (out-of-state).
 - Form 3840 continues every year until the Phoenix warehouse is sold or further-exchanged into CA property.
 
-**Outcome:** $1,862,545 of gain (including ~$163,636 of §1250 unrecaptured gain from the $654,545 cumulative depreciation, ultimately taxed at 25% on the eventual sale) fully deferred at federal level. California gain tracked on Form 3840 indefinitely.
+**Outcome:** $1,862,545 of gain fully deferred at the federal level. Of that, ~$654,545 is unrecaptured §1250 gain (the straight-line depreciation taken), which on an eventual taxable sale is taxed at the 25% §1250 ceiling — up to ~$163,636 of tax ($654,545 × 25%). California gain tracked on Form 3840 indefinitely.
 
 ---
 
@@ -649,7 +646,9 @@ All steps complete within 180 days of EAT acquisition (deadline: February 11, 20
 - Realized gain: $5,150,000 − $309,000 − $2,800,000 = $2,041,000
 - Boot received: $0 (all proceeds applied to replacement; net debt is roughly equal, $1,800,000 relieved vs $1,400,000 assumed = $400,000 debt relief, but taxpayer paid $1,759,000 additional cash, so cash paid offsets debt relief; net boot = $0)
 - Recognized gain: $0
-- Basis in Austin office: $2,800,000 + cash paid − debt relief net = approximately $2,400,000
+- Basis in Austin office: FMV $4,800,000 − deferred gain $2,041,000 = **$2,759,000**. Equivalently: $2,800,000 carryover + $1,759,000 net new cash + $1,400,000 debt assumed − $1,800,000 debt relieved = $4,159,000... which does NOT tie — see the funding flag below. The authoritative $2,759,000 (FMV − deferred gain) governs. (The earlier "$2,400,000" matched no computation.)
+
+> **Flag — funding narrative:** as written, the $3,041,000 QI proceeds + $1,759,000 taxpayer cash (step 7) already equal the full $4,800,000 price, leaving no room for the separately-stated assumption of Austin's $1,400,000 mortgage. Either the Austin purchase carried a $1,400,000 mortgage (so only ~$3,400,000 cash was needed) or it closed all-cash; the fact pattern should pick one. The realized gain ($2,041,000) and replacement basis ($2,759,000) are unaffected because they derive from the relinquished side and FMV.
 
 **Form 8824 reporting:** identical line-by-line format. Note Line 6 "date you actually received the replacement" is December 9, 2025 (the date EAT transferred to taxpayer), NOT August 15 (the date EAT acquired).
 
@@ -686,7 +685,7 @@ All steps complete within 180 days of EAT acquisition (deadline: February 11, 20
 
 **Form 8824 (Partners A and B only):**
 - Each files own Form 8824 reflecting 25% TIC ownership.
-- Question 11 (was property held more than 2 years): yes — TIC held from July 2024 to August 2025 plus prior partnership holding period under §1223 tacking ambiguity (conservative position: only TIC holding period counts; some practitioners argue tacking applies). At 13 months as TIC, the safer answer is to disclose the drop and rely on the documented business purpose.
+- Form 8824 has no "held-more-than-2-years" question — that miscite is corrected. The drop-and-swap *holding/intent* disclosures live on **Form 1065 Schedule B** (the partnership's like-kind-exchange questions) and, for California, on FTB Form 565/568, not on Form 8824. Each partner's Form 8824 simply reports the 25% TIC exchange. Holding period: TIC held July 2024 to August 2025 (~13 months); whether the prior partnership holding period tacks under §1223 is ambiguous — the conservative position counts only the TIC period, so disclose the drop and rely on the documented business purpose.
 
 **Risk flags / AUDIT FLASH POINTS:**
 - The 12-month gap between drop and sale supports an "investment intent" position. <6 months would be aggressive; <30 days would be a near-certain audit loss.
@@ -820,4 +819,5 @@ verified rules together with the name of the accountant who signed them off.
 **MCP endpoint:** `https://www.openaccountants.com/api/mcp`
 
 ## Changelog
+- **2026-07-06** — Worked-example arithmetic pass (completes the item flagged on 2026-07-05). Example 1: added a land allocation ($600k land / $1.2M building) so the $654,545 depreciation and $1,145,455 adjusted basis are internally consistent; corrected the replacement basis from $3,745,455 (which double-counted the $2,100,000 of QI sale proceeds as new cash) to the authoritative $1,637,455 (FMV $3,500,000 − deferred gain $1,862,545), and reconciled the Form 8824 lines so line 19 ties to the $1,862,545 realized gain and line 25 to the $1,637,455 basis; fixed the outcome paragraph (~$654,545 of unrecaptured §1250 gain, up to ~$163,636 of tax at the 25% ceiling — the $163,636 was the tax, not the gain). Example 2: basis $2,400,000 → $2,759,000 (FMV − deferred gain) and flagged the inconsistent funding narrative. Example 3: removed the non-existent Form 8824 "Question 11 / held-more-than-2-years" reference (drop-and-swap intent lives on Form 1065 Schedule B and state forms).
 - **2026-07-05** — §1031 corrections (Fable review, verified): Pennsylvania now CONFORMS (Act 53 of 2022, effective 2023) — the guide still said it did not; TCJA rewrote §1031(a)(2) (only bar is real property held for sale); Rev. Rul. 2019-24 miscite removed (it is hard-forks/airdrops, not §1031); 30-year leasehold reg is §1.1031(a)-1(c)(2) not §1.1031(a)-3; Form 8824 Line 11 is the related-party exception, not a partner-intent question; §1031 nonrecognition is mandatory (not voided by failure to file 8824); §1031(i) is mutual-ditch stock, not co-op housing. FLAGGED for an arithmetic pass: §21 Examples 1-2 depreciation/basis computations (double-counted QI proceeds; $654,545 vs $981,818 depreciation) and the QI 10%%-relatedness threshold detail.

--- a/packages/us-federal/us-section-1202-qsbs.md
+++ b/packages/us-federal/us-section-1202-qsbs.md
@@ -5,7 +5,7 @@ jurisdiction: US
 category: federal-tax
 tier: 2
 verified_by: pending
-last_updated: 2026-07-05
+last_updated: 2026-07-06
 version: 0.1
 ---
 
@@ -567,11 +567,12 @@ For partial-exclusion years (50% or 75% post-OBBBA), the cumulative cap is reduc
 - **Total federal: $3,510,500**.
 
 **State tax.**
-- Washington 7% capital gains tax: Washington does not conform to §1202. Gain over the $250k WA standard exemption (2025 inflation-adjusted figure ~$270k) is taxed at 7%.
-- WA tax: ($24,750,000 − $270,000) × 7% = $1,714,100.
+- Washington's 7% capital gains tax is measured from **federal net long-term capital gain** (RCW 82.87). Because the $10M excluded under §1202 never enters federal net LTCG, it is **not** in the Washington base either — the base is the $14,750,000 federally taxable portion, not the full $24.75M gain. (This matches the Section 9 Washington row: the tax applies to QSBS gain only to the extent not excluded federally.)
+- WA tax: ($14,750,000 − $270,000) × 7% = $14,480,000 × 7% = **$1,013,600**. (The $270k is the 2025 inflation-adjusted standard deduction.)
+- **Flag — 2025 WA surcharge:** Washington SB 5813 (2025) adds a further 2.9% on Washington capital gains above $1,000,000 for sales on or after Jan 1, 2025, so a 2027 sale like Ben's would also owe ~2.9% × ($14,480,000 − $1,000,000) ≈ $390,920 on top, for ~$1,404,520 total WA. Confirm SB 5813's final figures at filing; the $1,013,600 line above is the flat-7% floor.
 - (Note: WA's "long-term capital gains" tax is technically an excise tax, not income tax, and was upheld by the WA Supreme Court in *Quinn v. State*, 2023.)
 
-**Total combined: $5,224,600** on $24.75M gain (~21.1%).
+**Total combined (flat-7% WA): $4,524,100** on $24.75M gain (~18.3%); ~$4,915,020 (~19.9%) if the SB 5813 surcharge applies.
 
 ### 13.3 Example 3 — Family stacking, $200M exit (post-OBBBA)
 
@@ -580,7 +581,9 @@ For partial-exclusion years (50% or 75% post-OBBBA), the cumulative cap is reduc
 - Receives 1,000,000 shares for $1,000 at incorporation.
 - Files §83(b).
 - In 2026 (pre-liquidity, FMV $5/share), Carla gifts 250,000 shares each to: spouse Dan (separate property in a community-property-state pre-nup), and to two non-grantor dynasty trusts for the benefit of their two minor children (one trust per child, with distinct trustees, distinct beneficiary classes, and documented non-tax purposes — asset protection and GST planning).
-- Gift tax: 4 gifts of $1,250,000 each ($5/share × 250k shares); using annual exclusions ($19k × 2 spouses × 4 donees = $152k) and lifetime exemption ($13.99M × 2 = $27.98M); Form 709 filed; remaining exemption: ~$23M.
+- Gift tax: the facts describe **3 gifts** of $1,250,000 each ($5/share × 250k shares) — to spouse Dan and to the two trusts — totaling **$3,750,000**, not four gifts.
+  - **Gift to spouse Dan:** qualifies for the unlimited §2523 marital deduction (assuming Dan is a U.S. citizen), so it consumes **no** lifetime exemption. Gift-splitting under §2513 does **not** apply to a gift made *to* the consenting spouse, so "$19k × 2 spouses × 4 donees" is wrong on both the donee count and the split.
+  - **Gifts to the two dynasty trusts ($2.5M):** an annual exclusion applies **only if** each trust gives the beneficiary a present interest (a Crummey withdrawal right); a straight gift to a dynasty trust with no Crummey power is a future interest with **zero** annual exclusion. If Crummey rights exist and the spouses split, exclusions = $19,000 × 2 spouses × 2 trusts = $76,000, leaving $2,424,000 of taxable gift ($1,212,000 per spouse) applied against the $13,990,000 (2025) exemption — roughly $12.78M remaining per spouse (~$25.56M combined). **Flag:** the exact exclusion and remaining-exemption figures depend on the trust drafting (Crummey powers) and Dan's citizenship; confirm before relying. Form 709 filed by each spouse.
 - Holding period tacks under §1202(h)(1)(A).
 - In 2030 (5+ years from 2025 issuance), company is acquired for $200/share = $200M total.
 - All five holders sell their respective shares simultaneously.
@@ -771,4 +774,7 @@ verified rules together with the name of the accountant who signed them off.
 **MCP endpoint:** `https://www.openaccountants.com/api/mcp`
 
 ## Changelog
+
+- **2026-07-06** - Worked-example arithmetic fixes. Example 2 (WA, $25M exit): the Washington 7% capital gains tax is measured from federal net long-term capital gain, so the $10M excluded under §1202 is NOT in the WA base either; corrected the base from the full $24.75M gain to the $14.75M federally taxable portion (WA tax $1,714,100 -> $1,013,600; total combined $5,224,600 -> $4,524,100), and flagged the 2025 SB 5813 +2.9%-above-$1M surcharge. Example 3 (family stacking): corrected "4 gifts" to 3 (spouse + 2 trusts, $3.75M total), applied the §2523 unlimited marital deduction to the spouse gift (no exemption used; §2513 split cannot apply to a gift to the consenting spouse), and conditioned the trust annual exclusions on Crummey present-interest rights; flagged the remaining-exemption figure as drafting-dependent.
+
 - **2026-07-05** — QSBS/OBBBA corrections (Fable review, adversarially verified): the governing OBBBA section is §70431 (was wrongly cited as §70423 in six places); the tiered exclusion / $15M cap / $75M asset test apply to stock acquired AFTER July 4, 2025 (stock acquired ON that date is pre-OBBBA); exclusion-tier citations corrected to §1202(a)(1)/(a)(3)/(a)(4). Further flagged for a later pass: §1045 tacking under §1223(13), §1202(j) short-position label, the §1202(e)(6) 50%% working-capital limit, WA ESSB 5813 surcharge, and two worked-example recomputations.

--- a/skills/federal/us-schedule-c-and-se-computation.md
+++ b/skills/federal/us-schedule-c-and-se-computation.md
@@ -5,7 +5,7 @@ description: >
 version: 2.0
 jurisdiction: US
 tier: 2
-last_updated: 2026-07-04
+last_updated: 2026-07-06
 ---
 
 # US Schedule C and SE Computation Skill v2.0
@@ -111,7 +111,7 @@ Both subject to the 280A(c)(5) gross income limitation — but the limit applies
 | Home depreciation basis undocumented | $0 depreciation; flag 1250 recapture risk |
 | Actual vs simplified home office method unclear | Ask; do not assume |
 | At-risk status | Yes (Line 32a) unless evidence to contrary |
-| Net loss large enough for NOL | Refuse (R-COMP-NOL) |
+| Net loss large enough for NOL | Screen §461(l) (R-COMP-461L) first, then refuse (R-COMP-NOL) |
 | Gross receipts < 1099 totals | Flag — IRS computer match risk |
 
 ### Red Flag Thresholds
@@ -120,6 +120,7 @@ Both subject to the 280A(c)(5) gross income limitation — but the limit applies
 |---|---|
 | Schedule C Line 31 >= $200,000 | Approaches Additional Medicare Tax threshold (single) |
 | Schedule C Line 31 <= -$5,000 | Loss territory; check at-risk and hobby loss |
+| Aggregate business loss > $313,000 single / $626,000 MFJ (2025) | §461(l) excess business loss limitation (permanent under OBBBA §70601) — screen before §172 |
 | Form 8829 deduction >= $5,000 | Material; substantiation review |
 | Home depreciation taken (actual method) | 1250 recapture risk on future home sale |
 | Home office limited by 280A(c)(5) | Carryover treatment verification |
@@ -150,7 +151,8 @@ Both subject to the 280A(c)(5) gross income limitation — but the limit applies
 
 | Code | Situation | Action |
 |---|---|---|
-| R-COMP-NOL | Net operating loss generated | Stop — 172 analysis required; outside scope |
+| R-COMP-461L | Aggregate business loss above the §461(l) excess-business-loss threshold ($313,000 single / $626,000 MFJ for TY2025; permanent under OBBBA §70601) | Stop — the §461(l) EBL limitation applies BEFORE any §172 NOL analysis. The disallowed excess is added back and carried forward (as an NOL carryforward under current mechanics). Escalate. |
+| R-COMP-NOL | Net operating loss generated | Stop — 172 analysis required; outside scope. Screen §461(l) (R-COMP-461L) FIRST — an excess business loss is disallowed before it can become an NOL. |
 | R-COMP-ATRISK | At-risk limitation may apply (Form 6198) | Stop — 465 analysis required |
 | R-COMP-FORM8959-COMPLEX | Additional Medicare Tax with complex W-2 coordination | Flag — compute basic liability; reviewer verifies withholding |
 | R-COMP-FARM | Farm income present | Stop — Schedule F, not Schedule C |
@@ -338,7 +340,7 @@ Schedule C net profit: ($12,000) — net loss.
 SE tax: $0 (no SE tax on a loss).
 Loss flows to Schedule 1 line 3 as ($12,000). Reduces AGI.
 
-Flag: Check hobby loss (3+ year loss streak). Check at-risk (Line 32a confirmed). If loss creates NOL: R-COMP-NOL fires.
+Flag: Check hobby loss (3+ year loss streak). Check at-risk (Line 32a confirmed). If the aggregate business loss exceeds $313,000 single / $626,000 MFJ (2025), the §461(l) excess business loss limitation (R-COMP-461L) fires FIRST and disallows the excess; only what survives §461(l) can become an NOL (R-COMP-NOL).
 
 ### Example 5 — Chase (NYC, High Earner — Additional Medicare Tax)
 
@@ -642,6 +644,7 @@ SECTION H — REVIEWER FLAGS
 
 ## Changelog
 
+- **2026-07-06** — Added the missing §461(l) excess-business-loss screen (completes the loss-side item flagged in the Fable review). Large business losses now hit a §461(l) check ($313,000 single / $626,000 MFJ for TY2025; the limitation is permanent under OBBBA §70601) BEFORE any §172 NOL analysis, since the excess is disallowed before it can become an NOL — added as refusal code R-COMP-461L, a red-flag threshold, and cross-references from the NOL screen and Example 4's loss flag.
 - **2026-07-04** — Corrections from a Fable deep-accuracy review (adversarially verified): fixed §179 limit to $2,500,000/$4,000,000 phase-out and added the January 19, 2025 acquisition-date qualifier to 100% bonus depreciation (OBBBA §§70306/70301); restored the TY2025 1099-K threshold to >$20,000 AND >200 transactions (OBBBA §70432, IRC 6050W(e)); corrected T1-US-SE-6 — the deductible half of SE tax DOES reduce QBI (Treas. Reg. 1.199A-3(b)(1)(vi)); scoped the 280A(c)(5) limit to operating expenses/depreciation with the tier-1 (mortgage interest/taxes/casualty) carve-out; fixed the nonfarm optional method figures ($7,240 lower limit = 4 x $1,810 QC; removed the erroneous $10,380 minimum-gross row); split W-2 inputs into Box 3 (Schedule SE line 8a) and Box 5 (Form 8959) throughout.
 
 ---

--- a/skills/federal/us-self-employed-retirement.md
+++ b/skills/federal/us-self-employed-retirement.md
@@ -4,7 +4,7 @@ description: Tier 2 content skill for computing the self-employed retirement con
 version: 0.2
 jurisdiction: US
 tier: 2
-last_updated: 2026-07-05
+last_updated: 2026-07-06
 ---
 
 # US Self-Employed Retirement Skill v0.2
@@ -271,11 +271,11 @@ The skill computes Roth deferrals at $0 deduction but notes the total contribute
 
 | Action | Deadline |
 |---|---|
-| Establish a new Solo 401(k) plan | December 31, 2025 (for 2025 contributions) |
-| Make employee elective deferrals (2025) | December 31, 2025 (must be made by end of tax year) |
+| Establish a new Solo 401(k) plan | Return due date including extensions — Oct 15, 2026 (SECURE Act §201). For a first-year plan of a sole prop with no employees, elective deferrals require adoption by the unextended due date, April 15, 2026 (SECURE 2.0 §317). |
+| Make employee elective deferrals (2025) | First-year plan, sole prop with no common-law employees: by the unextended return due date (April 15, 2026) under SECURE 2.0 §317. Existing plan: deferral election must have been in place by Dec 31, 2025. |
 | Make employer profit-sharing contributions (2025) | Tax filing deadline including extensions (April 15, 2026, or October 15, 2026 with extension) |
 
-**Critical (updated by the SECURE Act):** Under SECURE Act §201 (IRC §401(b)(2)), a Solo 401(k) adopted by the return due date **including extensions** (October 15, 2026 for a 2025 calendar-year sole prop) is treated as effective for 2025 — so the EMPLOYER profit-sharing contribution can be enabled retroactively. IMPORTANT LIMIT: employee elective DEFERRALS still require a written deferral election in place by December 31 of the tax year (a sole prop with no prior plan cannot create 2025 deferrals after year-end), though the deferrals themselves may be DEPOSITED by the return due date with extensions. Net effect: after year-end you can still open a plan and make the employer contribution, but not new employee deferrals.
+**Critical (updated by the SECURE Act and SECURE 2.0):** Two provisions relax the old December 31 establishment rule. (1) Under **SECURE Act §201 (IRC §401(b)(2))**, a Solo 401(k) adopted by the return due date **including extensions** (October 15, 2026 for a 2025 calendar-year sole prop) is treated as effective for 2025, so the EMPLOYER profit-sharing contribution can be enabled retroactively. (2) Under **SECURE 2.0 §317**, a sole proprietor who is the only employee may make an initial-year **elective DEFERRAL** election for 2025 up to the **unextended** return due date (April 15, 2026) for a newly adopted first-year plan — the pre-2023 rule that deferrals required a Dec 31 election no longer applies to a first-year solo plan. (An existing plan from a prior year still needs its deferral election in place by Dec 31.) Net effect: a sole prop with no plan can, after year-end, open a first-year Solo 401(k) and make BOTH the employer contribution (by the extended due date) and 2025 employee deferrals (by April 15, 2026).
 
 ### Form 5500-EZ filing requirement
 
@@ -317,7 +317,7 @@ Maximum SEP contribution = lesser of:
 | Establish SEP-IRA | Tax filing deadline including extensions (can establish and fund on same day) |
 | Make 2025 contributions | Tax filing deadline including extensions (April 15, 2026, or October 15, 2026) |
 
-**Key advantage:** A sole prop who did not plan ahead can establish a SEP-IRA and make 2025 contributions as late as October 15, 2026 (if they file an extension). This is NOT possible with a Solo 401(k).
+**Key advantage:** A sole prop who did not plan ahead can establish a SEP-IRA and make 2025 contributions as late as October 15, 2026 (if they file an extension). A first-year Solo 401(k) is now also adoptable after year-end (SECURE Act §201 for the employer contribution by the extended due date; SECURE 2.0 §317 for first-year employee deferrals by the unextended April 15, 2026 date), so the SEP-IRA no longer holds a unique late-establishment advantage — its edge is purely administrative simplicity (Form 5305-SEP, no plan document or Form 5500-EZ).
 
 ---
 
@@ -438,14 +438,16 @@ Is net SE earnings > $0?
 ├── NO → No SE retirement contributions possible (may still contribute to IRA from other income)
 ├── YES → Continue
     │
-    Was a Solo 401(k) established by Dec 31, 2025?
+    Solo 401(k) available? (existing plan, OR a first-year plan a sole prop
+    with no employees can still adopt post-year-end — deferrals by Apr 15, 2026
+    per SECURE 2.0 §317; employer contribution by the extended due date per §201)
     ├── YES → Solo 401(k) is almost always the best choice
     │         Employee deferral: up to $23,500
     │         + Employer: 20% of net SE earnings
     │         + Catch-up if applicable
     │         + Optional Roth IRA on top ($7,000/$8,000 if MAGI permits)
     │
-    ├── NO → Can still establish a SEP-IRA by filing deadline
+    ├── SEP-IRA route (simplest; also open until the extended filing deadline)
     │         SEP-IRA: 20% of net SE earnings (max $70,000)
     │         + Optional Roth IRA on top ($7,000/$8,000 if MAGI permits)
     │
@@ -474,9 +476,9 @@ At net SE earnings of ~$232,500: both Solo 401(k) employer + deferral and SEP-IR
 
 | Ambiguity | Conservative default |
 |---|---|
-| Plan type not specified | Assume Solo 401(k) if established by Dec 31; otherwise SEP-IRA |
+| Plan type not specified | Default to SEP-IRA for the estimate (simplest), but note a first-year Solo 401(k) is still adoptable post-year-end under SECURE 2.0 §317 / SECURE Act §201 |
 | Age not provided | Assume under 50 (lowest contribution limits); ask for age |
-| Solo 401(k) establishment date unclear | Assume NOT established by Dec 31 (cannot use Solo 401(k)); default to SEP-IRA |
+| Solo 401(k) establishment date unclear | A prior-year plan needs a Dec 31 deferral election; a first-year plan for a sole prop with no employees can still be adopted (deferrals by Apr 15, 2026). Default to SEP-IRA only for simplicity, not because Solo 401(k) is barred. |
 | Roth vs. traditional deferral preference not stated | Assume pre-tax (traditional) for maximum current-year deduction and QBI reduction |
 | MAGI not computed for Roth eligibility | Compute MAGI from available data; if MAGI unclear, assume above Roth limits (no Roth recommendation) |
 | Whether taxpayer has existing IRA balances (for backdoor Roth) | Assume yes (pro-rata rule applies); flag for reviewer |
@@ -514,7 +516,7 @@ Output: "Roth conversions are taxable events with complex interactions (pro-rata
 | Threshold | Trigger | Rationale |
 |---|---|---|
 | Total retirement contributions > $50,000 | Always flag | Verify §415(c) limit compliance |
-| Solo 401(k) established after Oct 1 | Always flag | Verify December 31 establishment was completed |
+| Solo 401(k) first-year deferrals claimed post-year-end | Always flag | Verify SECURE 2.0 §317 eligibility (sole prop, no common-law employees; plan adopted by the unextended due date) |
 | Sole prop has employees | Always flag | Nondiscrimination and coverage rules apply |
 | Net SE earnings < $23,500 | Always flag | Employee deferral limited to net SE earnings; verify computation |
 | Taxpayer age 60-63 | Always flag | Super catch-up eligible — verify age documentation |
@@ -545,21 +547,27 @@ Deduction on Schedule 1: $35,143
 
 ### Example 2 — SEP-IRA, high income
 
-**Taxpayer:** James Chen, single, age 42, freelance software developer, Schedule C net profit = $250,000, deductible half of SE tax = $16,583. No Solo 401(k) established (missed Dec 31 deadline).
+**Taxpayer:** James Chen, single, age 42, freelance software developer, Schedule C net profit = $250,000, deductible half of SE tax = $14,266. Using a SEP-IRA for its simplicity (single Form 5305-SEP, no annual Form 5500).
 
 ```
-Net SE earnings for retirement = $250,000 − $16,583 = $233,417
+SE tax check (2025 OASDI wage base $176,100):
+  SE base = $250,000 × 0.9235 = $230,875
+  OASDI  = $176,100 × 12.4% = $21,836.40   (capped at the wage base)
+  Medicare = $230,875 × 2.9% = $6,695.38
+  SE tax = $28,531.78; deductible half = $14,266
 
-SEP-IRA: 20% × $233,417 = $46,683
-§415(c) check: $46,683 ≤ $70,000 ✓
+Net SE earnings for retirement = $250,000 − $14,266 = $235,734
 
-Deduction on Schedule 1: $46,683
+SEP-IRA: 20% × $235,734 = $47,147
+§415(c) check: $47,147 ≤ $70,000 ✓
 
-Had he established a Solo 401(k):
+Deduction on Schedule 1: $47,147
+
+Had he used a Solo 401(k):
   Employee deferral: $23,500
-  Employer: $46,683 (same as SEP)
+  Employer: $47,147 (same as SEP)
   Total: $70,000 (hits §415(c) cap, so capped at $70,000)
-  Additional savings: $70,000 − $46,683 = $23,317 more in retirement
+  Additional savings: $70,000 − $47,147 = $22,853 more in retirement
 ```
 
 ### Example 3 — Solo 401(k) with super catch-up
@@ -591,13 +599,13 @@ Net SE earnings = $18,000 − $1,272 = $16,728
 Could establish SEP-IRA by filing deadline:
   20% × $16,728 = $3,346
 
-Could establish Solo 401(k) by Dec 31:
-  Employee deferral: $16,728 (limited to net SE earnings)
-  Employer: $3,346
-  Total: limited by net SE earnings interaction
-  In practice: can defer up to $16,728 (less than $23,500 limit)
-  + employer: 20% × $16,728 = $3,346
-  Total: up to ~$16,728 (deferral cannot exceed earned income)
+Could adopt a first-year Solo 401(k) even after year-end
+(sole prop, no employees — deferrals by Apr 15, 2026 per SECURE 2.0 §317):
+  Employee deferral: up to $16,728 (limited to net SE earnings)
+  §415(c) caps total additions at 100% of compensation = $16,728,
+  so a full $16,728 deferral leaves no room for an employer contribution.
+  Total: $16,728 (vs $3,346 under the SEP) — the Solo 401(k) allows
+  far more at this income because the deferral is not tied to the 20% rate.
 
 Traditional IRA (no employer plan, fully deductible): $7,000
 Roth IRA: $7,000 (MAGI well below $150,000)
@@ -636,16 +644,16 @@ Roth IRA: $7,000 (MAGI well below $150,000)
 **Expected:** Net SE earnings for retirement = $92,935. Employee deferral = $23,500. Employer = 20% × $92,935 = $18,587. Total = $42,087. §415(c) check: $42,087 ≤ $70,000. **Deduction = $42,087.**
 
 ### Test 2 — SEP-IRA, high income hitting cap
-**Input:** Schedule C net profit $400,000; deductible half SE tax $23,886; age 55; no Solo 401(k).
-**Expected:** Net SE earnings = $376,114. SEP = 20% × $376,114 = $75,223, CAPPED at $70,000. **SEP deduction = $70,000.**
+**Input:** Schedule C net profit $400,000; deductible half SE tax $16,275 (OASDI capped at the $176,100 wage base: $21,836.40 + Medicare $10,712.60 = $32,549; half = $16,275); age 55; no Solo 401(k).
+**Expected:** Net SE earnings = $383,725. SEP = 20% × $383,725 = $76,745, CAPPED at $70,000. **SEP deduction = $70,000.**
 
 ### Test 3 — Solo 401(k) with super catch-up
-**Input:** Schedule C net profit $200,000; deductible half SE tax $14,130; age 62; Solo 401(k) established.
-**Expected:** Net SE earnings = $185,870. Employee deferral = $23,500. Employer = 20% × $185,870 = $37,174. Subtotal = $60,674 ≤ $70,000 §415(c). Super catch-up = $11,250. **Total deduction = $71,924.**
+**Input:** Schedule C net profit $200,000; deductible half SE tax $13,596 (OASDI capped: $21,836.40 + Medicare $5,356.30 = $27,192.70; half = $13,596); age 62; Solo 401(k) established.
+**Expected:** Net SE earnings = $186,404. Employee deferral = $23,500. Employer = 20% × $186,404 = $37,281. Subtotal = $60,781 ≤ $70,000 §415(c). Super catch-up = $11,250. **Total deduction = $72,031.**
 
 ### Test 4 — Low income, deferral limited by earnings
 **Input:** Schedule C net profit $20,000; deductible half SE tax $1,413; age 30; Solo 401(k) established.
-**Expected:** Net SE earnings = $18,587. Employee deferral = $18,587 (limited by net SE earnings, not $23,500). Employer = 20% × $18,587 = $3,717. Total = $22,304. But total cannot exceed net SE earnings in a meaningful way — verify: $23,500 deferral limit > $18,587 net SE earnings, so deferral capped at $18,587. **Total deduction = $22,304.**
+**Expected:** Net SE earnings = $18,587. Employee deferral = $18,587 (limited by net SE earnings, not $23,500). Because §415(c)(1)(B) caps total annual additions at 100% of compensation ($18,587), the $18,587 deferral leaves no room for an employer contribution. **Total deduction = $18,587.**
 
 ### Test 5 — Shared 401(k) deferral with employer plan
 **Input:** Schedule C net profit $80,000; deductible half SE tax $5,652; age 45; Solo 401(k) established; also has W-2 job where deferred $15,000 in employer 401(k).
@@ -661,7 +669,7 @@ Roth IRA: $7,000 (MAGI well below $150,000)
 
 1. **NEVER use the 25% rate directly for a sole prop's employer contribution.** The effective rate is 20% (25% / 1.25) because the contribution reduces the base. Using 25% overstates the maximum contribution.
 
-2. **NEVER allow a Solo 401(k) for 2025 if the plan was not established by December 31, 2025.** Default to SEP-IRA if the establishment date is unknown or after December 31.
+2. **Do NOT apply the old "Solo 401(k) must be established by December 31" rule.** SECURE Act §201 lets a sole prop adopt the plan by the extended return due date (Oct 15, 2026) for the employer contribution, and SECURE 2.0 §317 lets a sole prop with no employees make first-year 2025 elective deferrals if the plan is adopted by the unextended due date (April 15, 2026). SEP-IRA is still the simpler default when the establishment date is unknown, but a post-year-end first-year Solo 401(k) is now permissible.
 
 3. **NEVER ignore the §415(c) $70,000 cap.** Employee deferrals + employer contributions (excluding catch-up) cannot exceed $70,000. Catch-up is on top.
 
@@ -703,4 +711,7 @@ This skill and its outputs are provided for informational and computational purp
 The most up-to-date, verified version of this skill is maintained at [openaccountants.com](https://www.openaccountants.com). Log in to access the latest version, request a professional review from a licensed accountant, and track updates as tax law changes.
 
 ## Changelog
+
+- **2026-07-06** - Worked-example arithmetic + deadline-law fixes. Corrected the SE-tax figures in Example 2 (James Chen) and Tests 2/3/4, which ignored the 2025 OASDI wage base ($176,100): deductible-half figures and every downstream SEP/Solo-401(k) number now cap OASDI at the wage base (e.g. James Chen half $16,583->$14,266, SEP $46,683->$47,147; Test 3 total $71,924->$72,031). Fixed Test 4 and the Alex Rivera example to apply the §415(c) 100%-of-compensation cap on total additions. Replaced the repealed "Solo 401(k) must be established by December 31" rule throughout with SECURE Act §201 (employer contribution by the extended due date) and SECURE 2.0 §317 (first-year elective deferrals for a sole prop with no employees by the unextended April 15 due date) in the deadline table, decision tree, refusal defaults, review thresholds, and hard rules.
+
 - **2026-07-05** — Corrections (Fable review, verified): Solo 401(k) establishment deadline updated for SECURE Act §201 (adopt by extended return due date; deferral elections still by Dec 31); Roth SEP (SECURE 2.0 §601) and Roth employer contributions (§604) now noted instead of a flat no-Roth statement; IRA catch-up wording ($1,000 catch-up / $8,000 total, age 50+); mandatory-Roth-catch-up transition re-cited to Notice 2023-62. FLAGGED for an arithmetic pass: Section 15/17 examples compute SE tax at 15.3%% of full net earnings, ignoring the $176,100 OASDI wage base, and the SEP-vs-Solo-401(k) crossover figures (Sections 7, 11) need recomputation.


### PR DESCRIPTION
Completes the worked-example arithmetic flagged during the Fable accuracy review. Every figure below was recomputed and verified independently; net conclusions are preserved where the intent was sound, and corrected where the math was wrong.

**us-self-employed-retirement** — Example 2 + Tests 2/3/4 ignored the 2025 $176,100 OASDI wage base; recomputed the deductible-half of SE tax and all downstream SEP/Solo-401(k) figures (James Chen half $16,583→$14,266, SEP $46,683→$47,147; Test 3 total $71,924→$72,031); applied the §415(c) 100%-of-comp cap; replaced the repealed Dec-31 Solo-401(k) establishment rule with SECURE Act §201 + SECURE 2.0 §317 throughout.

**us-section-1202-qsbs** — Example 2: the WA 7% tax is measured from federal net LTCG, so the $10M §1202 exclusion is out of the WA base too (base $24.75M→$14.75M; WA $1,714,100→$1,013,600), plus the 2025 SB 5813 surcharge flag. Example 3: 4 gifts→3, §2523 marital deduction, Crummey present-interest condition.

**us-section-1031-like-kind-exchange** — Example 1: land allocation fixes the depreciation/basis consistency; replacement basis $3,745,455→$1,637,455 (removed the double-counted $2.1M QI proceeds); Form 8824 lines reconciled; §1250 outcome fixed. Example 2: basis $2,400,000→$2,759,000. Example 3: removed the non-existent Form 8824 "held-2-years" question. Also fixed §1031(i) (mutual-ditch stock, not co-op housing) — text the prior changelog claimed but missed.

**us-form-941-940-payroll** — Example 4 reconciliation: regular Medicare $52,200 (was $53,100), Additional Medicare 0.9% only above $200,000 per employee = $3,305.70 (was $900), Box 6 $29,405.70.

**us-schedule-c-and-se-computation** — added the missing §461(l) excess-business-loss screen ($313k/$626k, 2025; OBBBA §70601 permanent) before the §172 NOL analysis.

**us-estate-gift-706-709** — 2025 applicable credit $5,389,800→$5,541,800 (the guide carried the 2024 figure); §2040(b) half-inclusion of the spousal JTWROS residence (Example 14.2 gross estate $20M→$18.5M, DSUE $0→$1.5M); §2001(c) tax on $13M corrected to $5,145,800 (Example 14.3).

(QBI and quarterly-estimated worked examples were already correct on main from the earlier skeptic-verified pass.) Validator passes.