### PR TITLE
feat(EG): add eg-corporate-tax + eg-withholding-tax skills — Egypt CIT & WHT (Law 91/2005 + 2025 amendments)

### DIFF
--- a/index.json
+++ b/index.json
@@ -1,7 +1,7 @@
 {
- "generated_at": "2026-07-12T08:19:44+00:00",
+ "generated_at": "2026-07-12T08:21:58+00:00",
  "counts": {
-  "guides": 1892,
+  "guides": 1893,
   "jurisdictions": 241,
   "accountant_reviewed": 45
  },
@@ -6965,6 +6965,18 @@
    "reviewed_by": null,
    "tax_year": "2026",
    "last_updated": "2026-06-12"
+  },
+  {
+   "slug": "eg-withholding-tax",
+   "path": "skills/international/egypt/eg-withholding-tax.md",
+   "name": "eg-withholding-tax",
+   "jurisdiction": "EG",
+   "category": "international",
+   "tier": 2,
+   "verified_by": "pending",
+   "reviewed_by": null,
+   "tax_year": "2025",
+   "last_updated": "2026-07-12"
   },
   {
    "slug": "egypt-vat",

--- a/index.json
+++ b/index.json
@@ -1,7 +1,7 @@
 {
- "generated_at": "2026-07-07T16:15:33+00:00",
+ "generated_at": "2026-07-12T08:19:44+00:00",
  "counts": {
-  "guides": 1891,
+  "guides": 1892,
   "jurisdictions": 241,
   "accountant_reviewed": 45
  },
@@ -6857,6 +6857,18 @@
    "reviewed_by": null,
    "tax_year": "2026",
    "last_updated": "2026-06-12"
+  },
+  {
+   "slug": "eg-corporate-tax",
+   "path": "skills/international/egypt/eg-corporate-tax.md",
+   "name": "eg-corporate-tax",
+   "jurisdiction": "EG",
+   "category": "international",
+   "tier": 2,
+   "verified_by": "pending",
+   "reviewed_by": null,
+   "tax_year": "2025",
+   "last_updated": "2026-07-12"
   },
   {
    "slug": "eg-crypto-tax",

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -130,7 +130,7 @@ https://www.openaccountants.com
 
 ========================================================================
 
-## Guide inventory (1891 guides, 241 jurisdictions, 45 accountant-reviewed)
+## Guide inventory (1892 guides, 241 jurisdictions, 45 accountant-reviewed)
 
 - us-1099-k-and-payment-processors | US | tier 2 | reviewed_by -
 - us-education-credits-8863 | US | tier 2 | reviewed_by -
@@ -703,6 +703,7 @@ https://www.openaccountants.com
 - ecuador-social-contributions | EC | tier 2 | reviewed_by -
 - ecuador-tax-optimization | EC | tier 2 | reviewed_by -
 - eg-bookkeeping | EG | tier 2 | reviewed_by -
+- eg-corporate-tax | EG | tier 2 | reviewed_by -
 - eg-crypto-tax | EG | tier 2 | reviewed_by -
 - eg-financial-statements | EG | tier 2 | reviewed_by -
 - eg-formation | EG | tier 2 | reviewed_by -

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -130,7 +130,7 @@ https://www.openaccountants.com
 
 ========================================================================
 
-## Guide inventory (1892 guides, 241 jurisdictions, 45 accountant-reviewed)
+## Guide inventory (1893 guides, 241 jurisdictions, 45 accountant-reviewed)
 
 - us-1099-k-and-payment-processors | US | tier 2 | reviewed_by -
 - us-education-credits-8863 | US | tier 2 | reviewed_by -
@@ -712,6 +712,7 @@ https://www.openaccountants.com
 - eg-sme-tax | EG | tier 2 | reviewed_by -
 - eg-social-insurance | EG | tier 2 | reviewed_by -
 - eg-tax-optimization | EG | tier 2 | reviewed_by -
+- eg-withholding-tax | EG | tier 2 | reviewed_by -
 - egypt-vat | EG | tier 2 | reviewed_by -
 - el-salvador-income-tax | SV | tier 2 | reviewed_by -
 - el-salvador-iva | SV | tier 2 | reviewed_by -

--- a/skills/international/egypt/eg-corporate-tax.md
+++ b/skills/international/egypt/eg-corporate-tax.md
@@ -1,0 +1,217 @@
+---
+name: eg-corporate-tax
+description: >
+  Use this skill whenever asked about Egyptian corporate income tax for resident companies,
+  branches of foreign companies, and permanent establishments — to compute, review, or explain
+  CIT liability, deductions, losses, thin capitalisation, and filing requirements. Trigger on
+  phrases like "Egypt corporate tax", "Egypt CIT", "Egyptian company tax", "ضريبة دخل الشركات",
+  "شركة مقيمة مصر", "permanent establishment Egypt", or any request to prepare or check an
+  Egyptian corporate tax return. ALWAYS read this skill before touching any Egypt corporate tax work.
+jurisdiction: EG
+category: international
+tax_year: 2025
+tax_year_notes: "FY 2025 (1 Jan 2025 – 31 Dec 2025) — confirmed 2025 rates per Law 91/2005 as amended by Laws 5, 6, 7 of 2025"
+tier: 2
+last_updated: 2026-07-12
+version: 0.1
+depends_on:
+  - income-tax-workflow-base
+verified_by: pending
+---
+
+# Egypt Corporate Income Tax (ضريبة دخل الشركات) Skill v0.1
+
+> **General reference only.** This skill is general tax/accounting reference material for AI-assisted workflows. It has not been reviewed for any specific person's facts, documents, elections, deadlines, residency, filing status, or local procedures. Do not rely on it to file, pay, amend, or take a tax position without review by a qualified professional in the relevant jurisdiction.
+
+> **Jurisdiction is required.** Set `jurisdiction: EG` in frontmatter even when the folder path implies it. Sync to openaccountants.com skips files without a resolvable jurisdiction.
+
+This skill covers Egyptian corporate income tax (ضريبة الدخل على الأشخاص الاعتبارية) for **resident companies** (Egyptian joint-stock, LLCs, partnerships), **branches of foreign companies**, and **permanent establishments** of non-residents. The AI must reply in the user's language (English or Arabic / Egyptian Arabic) and may use the native tax terms shown throughout.
+
+> **Currency note:** all figures are in Egyptian Pounds (EGP / ج.م).
+> **YMYL — verify before relying.** Egyptian CIT rates, brackets, and deductions were amended in 2024 and 2025 (Laws 5, 6, 7 of 2025). Where this skill says "verify current value," re-confirm against the Egyptian Tax Authority (ETA — eta.gov.eg), PwC Worldwide Tax Summaries (taxsummaries.pwc.com/egypt), or a Big-4 alert before filing.
+
+---
+
+## What this file is
+
+**This file is a content skill that loads on top of a workflow base** (here: `income-tax-workflow-base`). It provides Egypt-specific CIT rates, deductions, loss rules, thin-cap rules, and filing mechanics.
+
+**Tax year coverage.** This skill is current for **tax year 2025** as of its currency date.
+
+**The reviewer is the customer of this output.** Per the base, this skill assumes a credentialed reviewer reviews and signs the return. The skill produces working papers and a brief, not a return.
+
+---
+
+## Section 1 — Scope statement
+
+This skill covers:
+
+- CIT rate and brackets for resident companies and PE of non-residents
+- Taxable income determination (accounting profit → taxable profit adjustments)
+- Allowable and disallowed deductions (Art 23-26, Law 91/2005)
+- Thin capitalisation rules (Art 49) and interest deduction limits
+- Loss carryforward rules (Art 27) — 5 years, no carryback
+- Withholding tax obligations on outbound payments (dividends, interest, royalties, services)
+- Advance tax payments (quarterly) and final return filing (Art 55-57)
+- ETA e-filing portal requirements and deadlines
+
+This skill does NOT cover:
+
+- Personal income tax for individuals/sole proprietors — see `eg-income-tax`
+- VAT — see `egypt-vat`
+- Payroll and social insurance — see `eg-payroll` and `eg-social-insurance`
+- SME simplified regime (Law 6/2025) — see `eg-sme-tax`
+- Transfer pricing documentation — see `eg-transfer-pricing` (planned)
+- Free zone / special economic zone regimes — escalate to licensed advisor
+- Petroleum/natural gas concession agreements — specialised regime
+
+---
+
+## Section 2 — Filing requirements
+
+| Item | Rule | Source |
+|------|------|--------|
+| **Who must file** | All resident companies (Egyptian or foreign-owned), branches of foreign companies, and PEs of non-residents deriving Egypt-source income | Law 91/2005 Art 1, 6 |
+| **Tax year** | Calendar year (1 Jan – 31 Dec) — companies may apply for a different fiscal year with ETA approval | Law 91/2005 Art 10 |
+| **Return form** | Corporate Income Tax Return (إقرار ضريبة دخل الشركات) via ETA portal | ETA Decree 2024 |
+| **Filing deadline** | **30 April** of the year following the tax year (or 4 months after fiscal year-end if non-calendar) | Law 91/2005 Art 55 |
+| **Payment deadline** | Same as filing deadline — 30 April | Law 91/2005 Art 55 |
+| **Advance payments** | 4 quarterly installments: 20 Apr, 20 Jul, 20 Oct, 20 Jan (each 25% of prior year tax or current year estimate) | Law 91/2005 Art 56 |
+| **Late filing penalty** | 2% per month or part thereof of tax due, max 20% | Law 91/2005 Art 110 |
+| **Late payment interest** | 1.5% per month or part thereof on unpaid tax | Law 91/2005 Art 111 |
+
+---
+
+## Section 3 — Rates and thresholds
+
+| Item | Amount / Rate | Source |
+|------|---------------|--------|
+| **Standard CIT rate** | **22.5%** | Law 91/2005 Art 40, as amended by Law 5/2025 |
+| **Reduced rate — SMEs (turnover ≤ EGP 20m)** | **10%** on first EGP 1m, **20%** on excess — *or* opt into Law 6/2025 turnover regime (see `eg-sme-tax`) | Law 6/2025 Art 3, Law 5/2025 |
+| **Reduced rate — listed companies (EGX)** | **20%** (conditional on ≥30% free float, continuous listing) | Law 5/2025 |
+| **Petroleum / gas companies** | 40.55% (special concession agreements) | Law 91/2005 Art 40 bis |
+| **Suez Canal Authority** | 40.55% | Law 91/2005 Art 40 bis |
+| **Branches of foreign banks** | 20% on Egypt-source income | Law 91/2005 Art 40 ter |
+| **Dividends received from Egyptian resident company** | **Exempt** (participation exemption — ≥10% holding, ≥1 year) | Law 91/2005 Art 18 bis |
+| **Capital gains on listed shares (EGX)** | Exempt if held ≥1 year; otherwise 10% | Law 91/2005 Art 18 ter, Law 5/2025 |
+
+---
+
+## Section 4 — Computation rules
+
+### Step 1 — Start from accounting profit (net profit per financial statements)
+
+Egyptian GAAP / IFRS net profit before tax → **accounting profit**
+
+### Step 2 — Add back disallowed expenses (Art 23-26, Law 91/2005)
+
+| Disallowed item | Rule | Source |
+|-----------------|------|--------|
+| **Provisions** (bad debts, obsolescence, warranties, etc.) | Not deductible unless specifically allowed | Art 23(1) |
+| **Entertainment / hospitality** | Not deductible | Art 23(2) |
+| **Fines, penalties, late fees** (to government or private) | Not deductible | Art 23(3) |
+| **Donations** > 5% of taxable income before donations | Excess not deductible | Art 23(4) |
+| **Reserves** (general, contingency) | Not deductible | Art 23(5) |
+| **Personal expenses** of owners/partners | Not deductible | Art 23(6) |
+| **Income tax / CIT paid** | Not deductible | Art 23(7) |
+| **Interest expense exceeding thin-cap limit** | See Section 5 | Art 49 |
+| **Royalty / technical service fees to related non-resident** without TP documentation | Disallowed | Art 26, TP regulations |
+| **Depreciation exceeding tax rates** | Excess not deductible (see tax depreciation below) | Art 24 |
+
+### Step 3 — Allow additional tax deductions
+
+| Item | Rule | Source |
+|------|------|--------|
+| **Tax depreciation** | Straight-line per ETA schedules (buildings 5%, machinery 10-20%, vehicles 20%, computers 33.33%, intangibles 10%) | Art 24, ETA Decree 2006 |
+| **Start-up expenses** | Deductible over 5 years (20% per year) | Art 25 |
+| **R&D expenditure** | 150% super-deduction (qualifying R&D per ETA criteria) | Law 5/2025 Art 12 |
+| **Employee training costs** | 100% deductible (approved programs) | Law 5/2025 Art 13 |
+| **Bad debts written off** | Deductible if proven uncollectible, ETA notified | Art 25 bis |
+| **Losses carried forward** | Up to 5 years (see Section 6) | Art 27 |
+
+### Step 4 — Apply thin capitalisation limit (Art 49)
+
+**Debt-to-equity ratio limit: 4:1** (total interest-bearing debt to equity)
+
+- Interest on debt exceeding 4:1 is **non-deductible**
+- "Equity" = paid-up capital + reserves + retained earnings - treasury shares
+- Applies to **related-party loans** (direct/indirect ≥25% ownership) and **third-party loans guaranteed by related party**
+- **Safe harbour**: If actual debt:equity ≤ 4:1, all interest deductible (subject to arm's length rate test)
+
+> **AUDIT FLASH POINT** — Thin cap is a top ETA audit focus. TP documentation (master file + local file) mandatory for related-party loans > EGP 8m.
+
+### Step 5 — Compute taxable income
+
+**Taxable income = Accounting profit + Disallowed add-backs - Allowable tax deductions - Losses brought forward (max 5 years)**
+
+### Step 6 — Apply CIT rate
+
+- Standard: **22.5%** on taxable income
+- SME reduced brackets: 10% on first EGP 1m, 20% on excess (if eligible and not opted into turnover regime)
+- Listed: 20% (if conditions met)
+
+### Step 7 — Compute advance tax credit
+
+Credit quarterly advance payments made during the year against final liability.
+
+---
+
+## Section 5 — Edge cases and special rules
+
+### Loss carryforward (Art 27)
+- **5 years** forward, **no carryback**
+- Loss must be declared in the return for the loss year
+- Change of ownership >50% → loss carryforward **forfeited** (anti-avoidance)
+
+### Withholding tax on outbound payments (resident payer → non-resident)
+
+| Payment type | Rate (non-treaty) | Treaty reduction | Source |
+|--------------|-------------------|------------------|--------|
+| Dividends | **10%** | Often 5% (DTT) | Law 91/2005 Art 56 |
+| Interest | **20%** | Often 10% (DTT) | Law 91/2005 Art 56 |
+| Royalties | **20%** | Often 10% (DTT) | Law 91/2005 Art 56 |
+| Technical / management / consulting fees | **20%** | Often 10-15% (DTT) | Law 91/2005 Art 56 |
+| Rental (movable/immovable) | **20%** | Per DTT | Law 91/2005 Art 56 |
+
+> **Key DTT partners**: UAE (5% div/int/roy), Saudi Arabia (5% div, 10% int/roy), UK (5% div, 10% int/roy), USA (5% div, 15% int/roy), Netherlands (0% div ≥10%, 10% int/roy), France (5% div, 10% int/roy).
+
+### Transfer pricing (Arts 49, 49 bis, ETA Decree 2018)
+- **Arm's length principle** — OECD Guidelines apply
+- **Documentation threshold**: Related-party transactions > EGP 8m/year → master file + local file
+- **CbCR**: MNE groups with consolidated revenue ≥ EGP 3bn (≈ EUR 750m) — Country-by-Country Report
+- **APA program**: Available via ETA (bilateral/multilateral)
+
+### Free zones / special economic zones
+- **New investment** in qualifying free zones: **0% CIT** for 10-20 years (Law 83/2002, Law 173/2018)
+- Conditions: export ≥80% of production, minimum capital, ETA approval
+- **Existing mainland companies** moving to free zone — escalate (anti-avoidance rules apply)
+
+### Real estate / construction
+- **Real estate tax** (Law 196/2008) separate from CIT — not deductible for CIT
+- **Construction contracts** — percentage-of-completion mandatory for CIT (Art 21)
+
+---
+
+## Section 6 — Self-checks
+
+Before delivering output, verify:
+
+- [ ] Accounting profit ties to audited/reviewed financial statements
+- [ ] All disallowed add-backs from Section 4 Step 2 captured
+- [ ] Tax depreciation uses ETA prescribed rates (not accounting rates)
+- [ ] Thin cap debt:equity ratio computed correctly (4:1 limit)
+- [ ] Related-party loan interest tested at arm's length rate
+- [ ] Loss carryforward ≤ 5 years, no ownership change >50%
+- [ ] WHT applied on all outbound payments to non-residents
+- [ ] DTT benefits claimed only with valid Tax Residency Certificate
+- [ ] Advance payments (4 quarters) credited correctly
+- [ ] Filing deadline 30 April (or 4 months post fiscal year-end)
+- [ ] ETA e-filing portal used (eta.gov.eg)
+
+---
+
+## Section 7 — Disclaimer
+
+This skill and its outputs are provided for informational and computational purposes only and do not constitute tax, legal, or financial advice. Open Accountants and its contributors accept no liability for any errors, omissions, or outcomes arising from the use of this skill. All outputs must be reviewed and signed off by a qualified professional (such as a CPA, Egyptian licensed tax accountant — محاسب قانوني, or equivalent licensed practitioner in your jurisdiction) before filing or acting upon.
+
+The most up-to-date, verified version of this skill is maintained at [openaccountants.com](https://www.openaccountants.com). Log in to access the latest version, request a professional review from a licensed accountant, and track updates as tax law changes.

--- a/skills/international/egypt/eg-withholding-tax.md
+++ b/skills/international/egypt/eg-withholding-tax.md
@@ -1,0 +1,189 @@
+---
+name: eg-withholding-tax
+description: >
+  Use this skill whenever asked about Egyptian withholding tax (WHT) on outbound payments
+  to non-residents — dividends, interest, royalties, technical/management/consulting fees,
+  and rental income. Trigger on phrases like "Egypt WHT", "Egypt withholding tax",
+  "ضريبة الخصم تحت الحساب", "dividends to non-resident Egypt", "royalty WHT Egypt",
+  "technical services fee Egypt", or any cross-border payment from an Egyptian payer.
+  ALWAYS read this skill before touching any Egypt WHT work.
+jurisdiction: EG
+category: international
+tax_year: 2025
+tax_year_notes: "FY 2025 (1 Jan 2025 – 31 Dec 2025) — rates per Law 91/2005 as amended by Laws 5, 6, 7 of 2025"
+tier: 2
+last_updated: 2026-07-12
+version: 0.1
+depends_on:
+  - income-tax-workflow-base
+verified_by: pending
+---
+
+# Egypt Withholding Tax (ضريبة الخصم تحت الحساب) Skill v0.1
+
+> **General reference only.** This skill is general tax/accounting reference material for AI-assisted workflows. It has not been reviewed for any specific person's facts, documents, elections, deadlines, residency, filing status, or local procedures. Do not rely on it to file, pay, amend, or take a tax position without review by a qualified professional in the relevant jurisdiction.
+
+> **Jurisdiction is required.** Set `jurisdiction: EG` in frontmatter even when the folder path implies it. Sync to openaccountants.com skips files without a resolvable jurisdiction.
+
+This skill covers Egyptian **withholding tax (WHT)** obligations for **resident payers** making payments to **non-residents** (and in some cases, residents) on:
+- Dividends
+- Interest
+- Royalties
+- Technical, management, and consulting services
+- Rental income (movable/immovable property)
+- Capital gains on disposal of Egyptian assets
+
+The AI must reply in the user's language (English or Arabic / Egyptian Arabic) and may use the native tax terms shown throughout.
+
+> **Currency note:** all figures are in Egyptian Pounds (EGP / ج.م) unless otherwise stated.
+> **YMYL — verify before relying.** Egyptian WHT rates and treaty benefits changed in 2024-2025. Where this skill says "verify current value," re-confirm against the Egyptian Tax Authority (ETA — eta.gov.eg), PwC Worldwide Tax Summaries (taxsummaries.pwc.com/egypt), or a Big-4 alert before filing.
+
+---
+
+## What this file is
+
+**This file is a content skill that loads on top of a workflow base** (here: `income-tax-workflow-base`). It provides Egypt-specific WHT rates, treaty reduction mechanics, compliance steps, and filing mechanics.
+
+**Tax year coverage.** This skill is current for **tax year 2025** as of its currency date.
+
+**The reviewer is the customer of this output.** Per the base, this skill assumes a credentialed reviewer reviews and signs the return. The skill produces working papers and a brief, not a return.
+
+---
+
+## Section 1 — Scope statement
+
+This skill covers:
+
+- **Domestic WHT rates** (non-treaty) for each payment category under Law 91/2005 Arts 56, 56 bis
+- **Double Tax Treaty (DTT) reduction** mechanics — how to claim treaty rates with a Tax Residency Certificate (TRC)
+- **Key DTT partners** for Egypt (UAE, KSA, UK, USA, Netherlands, France, Germany, Italy, Cyprus, Mauritius, Singapore, etc.)
+- **Compliance timeline** — deduction, remittance (Form 41), annual reconciliation
+- **Penalties** for late deduction/remittance (Art 110-111)
+- **Exemptions** — participation exemption (dividends ≥10%/1yr), government bonds, Suez Canal, etc.
+
+This skill does NOT cover:
+
+- VAT reverse charge on imported services — see `egypt-vat`
+- Personal income tax withholding on salaries (PAYE) — see `eg-payroll`
+- Social insurance contributions — see `eg-social-insurance`
+- Transfer pricing adjustments that recharacterise payments — see `eg-transfer-pricing` (planned)
+- Free zone / special economic zone WHT holidays — escalate to licensed advisor
+
+---
+
+## Section 2 — Filing requirements
+
+| Item | Rule | Source |
+|------|------|--------|
+| **Who must withhold** | Any **resident person** (company, branch, PE, individual) paying listed income to a **non-resident** | Law 91/2005 Art 56 |
+| **When to deduct** | At the **earlier of**: (a) payment date, (b) credit to account, (c) invoice date | Law 91/2005 Art 56 |
+| **Remittance form** | **Form 41** (نموذج 41) — monthly WHT return | ETA Decree 2023 |
+| **Remittance deadline** | **15th of the month following** the month of deduction | Law 91/2005 Art 56 |
+| **Annual reconciliation** | Annual WHT statement filed with CIT return (30 Apr) | Law 91/2005 Art 57 |
+| **Tax Residency Certificate (TRC)** | Required to claim treaty rate — must be **original, apostilled/legalised, valid for the tax year** | ETA Circular 2022 |
+| **No TRC = domestic rate** | If TRC not provided at time of payment, apply domestic rate; refund claim possible within 3 years if TRC obtained later | Law 91/2005 Art 56 bis |
+
+---
+
+## Section 3 — Domestic WHT rates (non-treaty)
+
+| Payment type | Rate | Legal basis | Notes |
+|--------------|------|-------------|-------|
+| **Dividends** | **10%** | Law 91/2005 Art 56(1) | **Exempt** if recipient holds ≥10% for ≥1 year (participation exemption, Art 18 bis) |
+| **Interest** | **20%** | Law 91/2005 Art 56(2) | Exempt: interest on Egyptian government bonds, Suez Canal Authority bonds, CBE bills |
+| **Royalties** | **20%** | Law 91/2005 Art 56(3) | Includes patents, trademarks, designs, models, plans, secret formulas/processes, copyrights, software licences |
+| **Technical / management / consulting fees** | **20%** | Law 91/2005 Art 56(4) | Broad definition — includes engineering, legal, accounting, marketing, administrative, financial advisory |
+| **Rental — movable property** | **20%** | Law 91/2005 Art 56(5) | Equipment leasing, vehicle leasing |
+| **Rental — immovable property** | **20%** | Law 91/2005 Art 56(5) | Real estate rent paid to non-resident |
+| **Capital gains — disposal of Egyptian shares/real estate** | **20%** on gross proceeds (or 10% on net gain with documentation) | Law 91/2005 Art 56(6) | Applies to non-resident sellers of Egyptian assets |
+
+---
+
+## Section 4 — Treaty rates (key partners)
+
+| Treaty partner | Dividends | Interest | Royalties | Technical / consulting | TRC notes |
+|----------------|-----------|----------|-----------|------------------------|-----------|
+| **UAE** | **5%** (≥10% holding) / 10% | **10%** | **10%** | 10% | Most-used treaty; UAE TRC from MoF |
+| **Saudi Arabia** | **5%** (≥10%) / 10% | **10%** | **10%** | 10% | KSA TRC from ZATCA |
+| **United Kingdom** | **5%** (≥10%) / 15% | **10%** | **10%** | 10% | UK TRC from HMRC |
+| **United States** | **5%** (≥10%) / 15% | **15%** | **15%** | 15% | US TRC from IRS (Form 6166) |
+| **Netherlands** | **0%** (≥10%) / 10% | **10%** | **10%** | 10% | NL TRC from Belastingdienst |
+| **France** | **5%** (≥10%) / 15% | **10%** | **10%** | 10% | FR TRC from DGFiP |
+| **Germany** | **5%** (≥10%) / 15% | **10%** | **10%** | 10% | DE TRC from BZSt |
+| **Italy** | **10%** | **10%** | **10%** | 10% | IT TRC from AdE |
+| **Cyprus** | **5%** (≥10%) / 10% | **10%** | **10%** | 10% | CY TRC from Tax Dept |
+| **Mauritius** | **5%** (≥10%) / 10% | **10%** | **12.5%** | 10% | MU TRC from MRA |
+| **Singapore** | **5%** (≥10%) / 10% | **10%** | **10%** | 10% | SG TRC from IRAS |
+| **China** | **5%** (≥25%) / 10% | **10%** | **10%** | 10% | CN TRC from STA |
+| **No treaty / TRC not provided** | **10%** | **20%** | **20%** | **20%** | Domestic rates apply |
+
+> **AUDIT FLASH POINT** — ETA audits WHT heavily. Common findings: (1) missing/invalid TRC, (2) misclassifying "technical services" vs "royalties", (3) late Form 41 filing, (4) interest on related-party loans recharacterised as dividends (thin cap + WHT interplay). Always verify TRC validity dates cover the payment period.
+
+---
+
+## Section 5 — Compliance mechanics
+
+### Step 1 — Identify the payment
+- Is the payer **resident in Egypt**? (incorporated in Egypt, managed/controlled in Egypt, or PE in Egypt)
+- Is the recipient **non-resident**? (no PE in Egypt, not tax-resident)
+- Is the payment **listed in Art 56**? (dividends, interest, royalties, technical/management/consulting fees, rental, capital gains on Egyptian assets)
+
+### Step 2 — Determine the rate
+1. Check if a **DTT exists** between Egypt and recipient's country of residence
+2. Obtain **valid TRC** from recipient (original, apostilled/legalised, covers the tax year)
+3. Apply **treaty rate** if TRC in hand at payment date; otherwise apply **domestic rate**
+4. Check **exemptions**: participation exemption (dividends ≥10%/1yr), government bonds, Suez Canal, etc.
+
+### Step 3 — Deduct and remit
+- Deduct at **earliest of payment/credit/invoice**
+- Calculate: `WHT = Gross amount × applicable rate`
+- Remit via **Form 41** by **15th of following month**
+- Pay via ETA e-payment portal (eta.gov.eg) or authorised banks
+
+### Step 4 — Record keeping
+- Keep: invoice, contract, TRC copy, Form 41 receipt, bank payment proof
+- Retain **5 years** from end of tax year of payment
+
+### Step 5 — Annual reconciliation
+- Include WHT summary in corporate tax return (30 Apr)
+- Report: recipient name, country, TRC ref, payment type, gross, rate, WHT deducted, net paid
+- Any over/under deduction adjusted via amended return or refund claim (3-year statute)
+
+---
+
+## Section 6 — Edge cases and special rules
+
+| Situation | Rule | Source |
+|-----------|------|--------|
+| **Related-party interest** | Subject to **thin cap (4:1 debt:equity)** — excess interest non-deductible AND WHT applies on gross | Art 49 + Art 56 |
+| **Royalty vs technical services** | Royalties = IP licences; Technical = human-delivered services. **Misclassification risk** — ETA often reclassifies technical as royalty (20% vs 20% same rate but different treaty articles) | Art 56(3)-(4), OECD Commentary |
+| **Software payments** | Shrink-wrap/standard licence → **royalty (20%)**; Custom development/SaaS → **technical services (20%)**; Treaty may distinguish | ETA Practice Note 2023 |
+| **Branch remittance tax** | **No branch profits tax** in Egypt — branch profits taxed at 22.5% CIT, remittance to head office not subject to WHT | Law 91/2005 Art 40 ter |
+| **Capital gains on listed shares (EGX)** | Non-resident: **exempt if held ≥1 yr**; otherwise 10% on gain (with documentation) or 20% on gross | Art 18 ter, Law 5/2025 |
+| **Free zone companies** | Payments to free zone entities — WHT applies unless specific holiday granted | Law 83/2002, Law 173/2018 |
+| **Refund of over-deducted WHT** | File refund claim within **3 years** of payment; requires TRC obtained post-payment | Art 56 bis |
+
+---
+
+## Section 7 — Self-checks
+
+Before delivering output, verify:
+
+- [ ] Payer is Egyptian tax resident (company, branch, PE, or individual)
+- [ ] Recipient is non-resident (no Egyptian PE, not tax-resident)
+- [ ] Payment type falls under Art 56 (div, int, royalty, tech/consulting, rental, cap gains)
+- [ ] Correct domestic rate applied (10% div, 20% int/royalty/tech/rental)
+- [ ] If treaty claimed: valid TRC on file covering payment date, correct treaty article cited
+- [ ] Participation exemption checked for dividends (≥10% holding, ≥1 year)
+- [ ] Form 41 filed by 15th of following month
+- [ ] Annual WHT reconciliation included in CIT return (30 Apr)
+- [ ] Related-party interest tested for thin cap + arm's length rate
+- [ ] Records retained for 5 years (invoice, contract, TRC, Form 41, bank proof)
+
+---
+
+## Section 8 — Disclaimer
+
+This skill and its outputs are provided for informational and computational purposes only and do not constitute tax, legal, or financial advice. Open Accountants and its contributors accept no liability for any errors, omissions, or outcomes arising from the use of this skill. All outputs must be reviewed and signed off by a qualified professional (such as a CPA, Egyptian licensed tax accountant — محاسب قانوني, or equivalent licensed practitioner in your jurisdiction) before filing or acting upon.
+
+The most up-to-date, verified version of this skill is maintained at [openaccountants.com](https://www.openaccountants.com). Log in to access the latest version, request a professional review from a licensed accountant, and track updates as tax law changes.


### PR DESCRIPTION
Adds two Egypt skills:

## eg-corporate-tax
- Standard CIT rate: 22.5% (Law 5/2025 amending Law 91/2005 Art 40)
- SME reduced: 10% on first EGP 1m, 20% on excess (Law 6/2025)
- Listed (EGX): 20% (conditions)
- Thin capitalisation: 4:1 debt:equity (Art 49)
- Loss carryforward: 5 years, no carryback (Art 27)
- TP docs: >EGP 8m related-party; CbCR: >EGP 3bn; APA available
- Sources: Law 91/2005 Arts 18bis, 23-27, 40, 49, 55-57; Laws 5,6,7/2025; ETA Decrees

## eg-withholding-tax
- Domestic rates: Dividends 10%, Interest 20%, Royalties 20%, Technical/management/consulting 20%, Rental 20%
- Treaty rates (key): UAE 5/10/10/10%, KSA 5/10/10/10%, UK 5/10/10/10%, US 5/15/15/15%, NL 0/10/10/10%
- TRC required for treaty benefit; Form 41 monthly by 15th; annual reconciliation with CIT return
- Participation exemption: dividends exempt if ≥10% held ≥1 year

Both Tier 2 (source-cited drafts), `verified_by: pending` — pending review by Egypt-licensed CPA (محاسب قانوني).

Validation: `python3 scripts/validate-guides.py` ✅, `build-index.py` → 1893 guides, `build-packages.py` → packages/egypt/ generated