### PR TITLE
fix: regenerate stale index.json + llms-full.txt (unbreak CI)

### DIFF
--- a/index.json
+++ b/index.json
@@ -1,7 +1,7 @@
 {
- "generated_at": "2026-07-13T10:53:04+00:00",
+ "generated_at": "2026-07-14T05:53:39+00:00",
  "counts": {
-  "guides": 1898,
+  "guides": 1899,
   "jurisdictions": 243,
   "accountant_reviewed": 45
  },

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -130,7 +130,7 @@ https://www.openaccountants.com
 
 ========================================================================
 
-## Guide inventory (1898 guides, 243 jurisdictions, 45 accountant-reviewed)
+## Guide inventory (1899 guides, 243 jurisdictions, 45 accountant-reviewed)
 
 - us-1099-k-and-payment-processors | US | tier 2 | reviewed_by -
 - us-education-credits-8863 | US | tier 2 | reviewed_by -


### PR DESCRIPTION
## Problem
After merging PRs #69, #70, #71, and #73, the `index.json` and `llms-full.txt` were not regenerated, causing the **Validate Guides** CI to fail on `main`:

```
ERROR: index.json is stale (`counts` differs) — regenerate with: python3 scripts/build-index.py
ERROR: llms-full.txt is stale (its embedded docs or the guide inventory changed) — regenerate: python3 scripts/build-llms-full.py
```

## Fix
- Regenerated `index.json` via `scripts/build-index.py` (1899 guides, 243 jurisdictions)
- Regenerated `llms-full.txt` via `scripts/build-llms-full.py`
- Verified `scripts/validate-guides.py` passes locally

## Verification
```
checked 1899 guides (2 non-guide .md files skipped)
WARN: 15 guides missing `jurisdiction (jurisdiction-agnostic dirs)`

validation passed (1 warning group(s))
```

This unblocks CI on main.