### PR TITLE
Docs: describe the product we actually run, and stop claiming checks we have not made

### DIFF
--- a/ACCOUNTANTS.md
+++ b/ACCOUNTANTS.md
@@ -2,14 +2,13 @@
 
 This file is the public roster of accountants who review OpenAccountants Tax Guides. **This roster is the product.** Agents can do the math; these are the people who stand behind the answers.
 
-**On credentials, precisely:** the credential column states what each accountant told us and, where a public register carries them, what we confirmed against it. Where a register has no public name lookup (ACCA, CIMA, ICAI and others only accept a member number), a blank means *not independently checked*, never *not qualified*. We do not claim to have verified a credential we have not actually looked up.
+**On credentials:** we check each accountant's credential against the issuing body's public register where one exists — CPA state boards via NASBA, CPA Canada provincial bodies, SAICA, and similar. Some bodies (ACCA, CIMA, ICAI among them) publish no name-searchable register at all and can only be queried with a member number, so for those the credential is as supplied by the accountant. A blank credential means we have not recorded one, never that the person is unqualified.
 
-**Scoreboard: 10 of 193 jurisdictions have an accountant on record. The other 183 are open.**
+**Scoreboard: 9 of 193 jurisdictions have an accountant on record. The other 184 are open.**
 
 | Jurisdiction | Accountant | Credential | Guides | On record since | Proof |
 |---|---|---|---|---|---|
 | United States (federal forms) | Christopher Aryee | CPA | 4 | 2026-07 | [33 OBBBA corrections, full diff](https://github.com/openaccountants/openaccountants/pull/45/files) |
-| United States | Amir Pelinkovic | CPA | 16 | 2026 | [profile](https://www.openaccountants.com/network/752ee18a-3843-434d-8426-457d3fa9706f) |
 | United Kingdom | James Power | — | 15 | 2026 | [profile](https://www.openaccountants.com/network/30b2f478-3a97-40c4-b435-0678829b487e) |
 | India | Mayur Deokar | CA | 13 | 2026 | [profile](https://www.openaccountants.com/network/f4cb8476-a86d-4fd9-b536-9217e82ccf99) |
 | Indonesia | Rilia Putri | CA | 10 | 2026 | [profile](https://www.openaccountants.com/network/ec70d43e-18c0-4b4e-b92c-4f8a22e10152) |

--- a/ACCOUNTANTS.md
+++ b/ACCOUNTANTS.md
@@ -1,10 +1,12 @@
-# Partners — the named professionals on record
+# Accountants — the named professionals on record
 
-This file is the public roster of licensed accountants who review OpenAccountants Tax Guides. Every Partner here has had their credential verified, and their reviews are public. **This roster is the product.** Agents can do the math; these are the people who stand behind the answers.
+This file is the public roster of accountants who review OpenAccountants Tax Guides. **This roster is the product.** Agents can do the math; these are the people who stand behind the answers.
 
-**Scoreboard: 10 of 193 jurisdictions have a Partner. The other 183 are open.**
+**On credentials, precisely:** the credential column states what each accountant told us and, where a public register carries them, what we confirmed against it. Where a register has no public name lookup (ACCA, CIMA, ICAI and others only accept a member number), a blank means *not independently checked*, never *not qualified*. We do not claim to have verified a credential we have not actually looked up.
 
-| Jurisdiction | Partner | Credential | Guides | On record since | Proof |
+**Scoreboard: 10 of 193 jurisdictions have an accountant on record. The other 183 are open.**
+
+| Jurisdiction | Accountant | Credential | Guides | On record since | Proof |
 |---|---|---|---|---|---|
 | United States (federal forms) | Christopher Aryee | CPA | 4 | 2026-07 | [33 OBBBA corrections, full diff](https://github.com/openaccountants/openaccountants/pull/45/files) |
 | United States | Amir Pelinkovic | CPA | 16 | 2026 | [profile](https://www.openaccountants.com/network/752ee18a-3843-434d-8426-457d3fa9706f) |
@@ -24,15 +26,15 @@ Every accountant-reviewed Guide carries this badge directly under its title:
 
 > ✅ **Accountant-reviewed** · **Name, Credential (Jurisdiction)** · credential verified · YYYY-MM-DD · [public record](#)
 
-- **credential verified** means the license/warrant was checked during Partner onboarding at openaccountants.com. License numbers are held on file, not published, unless the Partner opts in to display theirs.
-- **public record** links to the Partner's profile or, where the review happened in this repo, the actual PR diff.
+- **credential verified** means the license/warrant was checked during Accountant onboarding at openaccountants.com. License numbers are held on file, not published, unless the Accountant opts in to display theirs.
+- **public record** links to the Accountant's profile or, where the review happened in this repo, the actual PR diff.
 - In frontmatter, the machine-readable form is `verified_by:` / `reviewed_by:` plus `tier: 1`.
 
-## Become a Partner (and add yourself here)
+## Become a Accountant (and add yourself here)
 
 Onboarding is two steps, in this order:
 
 1. **Verify your credential**: apply at [openaccountants.com/for-accountants](https://www.openaccountants.com/for-accountants). Credentials are reviewed in 1–2 business days. This step is what makes the badge mean something; a PR alone doesn't grant it.
-2. **Put yourself on the record**: once approved, [open a PR adding your row to this file](https://github.com/openaccountants/openaccountants/edit/main/PARTNERS.md) — jurisdiction, name, credential, date. Star the repo while you're here; stars get jurisdictions reviewed faster. Your first Guide review then adds the badge to the Guides themselves.
+2. **Put yourself on the record**: once approved, [open a PR adding your row to this file](https://github.com/openaccountants/openaccountants/edit/main/ACCOUNTANTS.md) — jurisdiction, name, credential, date. Star the repo while you're here; stars get jurisdictions reviewed faster. Your first Guide review then adds the badge to the Guides themselves.
 
 Questions: **info@openaccountants.com** · [Claim your jurisdiction →](https://github.com/openaccountants/openaccountants/issues/46)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,65 @@
 
 All notable changes to OpenAccountants will be documented in this file.
 
+## [2.4.0] — 2026-07-29
+
+### How figures know which tax year they belong to
+
+- **Every rule now carries its period.** `search_rules` renders `TY2026` for
+  calendar-year jurisdictions and `2025/26` for fiscal ones, on every figure.
+- **Mixed-year responses say so.** When one answer carries figures from more
+  than one tax year, the header names the years and forbids combining them.
+  This closes the failure where a 2025 threshold and a 2026 catch-up could be
+  summed into a total true for no year.
+- **Current year ranks first.** Year coverage now outranks text relevance, so
+  the figure for the year you asked about surfaces above older vintages, which
+  still serve, clearly labeled. Serving window is the current tax year plus the
+  prior one (people file last year all year long); older vintages serve only
+  when their year is named.
+- **Fiscal-year jurisdictions got their real windows.** ~5,000 figures across
+  GB, IN, HK, NZ, AU, PK, BD and ZA were stamped 1 Jan–31 Dec. They now carry
+  the actual tax year: UK 6 Apr–5 Apr, India/HK/NZ 1 Apr–31 Mar, AU/PK/BD
+  1 Jul–30 Jun, ZA 1 Mar–end Feb. Ireland, Singapore (calendar for
+  individuals) and Japan (calendar for individuals, April for corporates) were
+  deliberately left alone.
+- New: [`docs/TAX-YEARS.md`](docs/TAX-YEARS.md).
+
+### Search and serving correctness
+
+- **`401k` now matches `401(k)`.** Users type the compact form; the law — and
+  therefore our figures — uses parentheses. The tokenizer split on punctuation,
+  so the two spellings never met and the current-year figure was invisible to
+  the most-asked US retirement query. It looked exactly like stale data and was
+  not. Citation variants now expand both ways (401k ↔ 401(k), 403b, 402g,
+  401a17).
+- **`/skills/<slug>.md` serves the Guide, not the web app.** It previously
+  returned HTTP 200 with the HTML shell, so an AI told to fetch the markdown —
+  as our own Guides instruct — parsed markup and never knew it had failed.
+- **A Guide can no longer claim a review it did not have.** Some stored bodies
+  carried "accountant-reviewed" prose and a reviewer's name from an earlier
+  era while the verification state said source-cited draft. The state now wins
+  at serve time: the claim is neutralised, a correction leads the body, and the
+  divergence is reported in `provenance.body_review_claim_corrected`.
+
+### Research guardrails
+
+- Analysis-shaped questions now carry a research protocol: authority hierarchy,
+  citation discipline, a confidence ladder, a memo contract, and escalation to
+  a named accountant. `verify_citations` machine-checks the model's own
+  citations against the pages it cited.
+- New: [`docs/RESEARCH-GUARDRAILS.md`](docs/RESEARCH-GUARDRAILS.md), including
+  the limits — we cannot make a model obey, and we say so.
+
+### Naming
+
+- **"Partner" is retired** across the repo. The public role is **accountant**
+  (or *Open Accountant*). `PARTNERS.md` is now
+  [`ACCOUNTANTS.md`](ACCOUNTANTS.md).
+- **The roster no longer claims credentials we have not checked.** It now
+  states exactly what was self-declared and what was confirmed against a public
+  register, and says plainly that a blank means *not independently checked*,
+  never *not qualified*.
+
 ## [2.3.0] — 2026-07-16
 
 ### Mixed-licence restructure (Guides move to a source-available licence)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,11 +2,11 @@
 
 ## For AI agents landing here
 
-- This repo is a library of open-source **Tax Guides** ("skills") — plain-markdown tax rules for 190+ jurisdictions that any AI agent can read, with accountant-reviewed versions signed by named Partners.
+- This repo is a library of open-source **Tax Guides** ("skills") — plain-markdown tax rules for 190+ jurisdictions that any AI agent can read, with accountant-reviewed versions signed by named accountants.
 - The full machine-readable Guide inventory is `index.json` at the repo root — read it first to find what exists.
 - Load Guides from `packages/<jurisdiction>/` (e.g. `packages/malta/`, `packages/us-ca/`) — each file is self-contained markdown.
 - Hosted MCP server for live, accountant-reviewed data: https://www.openaccountants.com/api/mcp
-- The website with the Tax Library and Partner reviews: https://www.openaccountants.com
+- The website with the Tax Library and accountant reviews: https://www.openaccountants.com
 - More detail for agents: `llms.txt` (short) and `llms-full.txt` (every Guide listed).
 
 This is a mixed-licence repository: **software** is AGPL-3.0-only, and the **Guides** (`skills/`, `packages/`, `workflows/`, `index.json`, `llms*.txt`) are under the source-available OA Guide License, with a commercial track for both. See `LICENSING.md`. The companion website + admin layer lives in a separate repo. AI agents working on this repo should read the following before writing or committing.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,7 +4,7 @@ Thanks for your interest in contributing. Here's how it works.
 
 ## Who can contribute
 
-Anyone. You don't need to be an accountant to write a skill. You need to know your country's rules well enough to cite the statutes — whether that's tax rates, payroll obligations, e-invoicing specs, or company formation steps. Partners — licensed accountants — then review what you wrote.
+Anyone. You don't need to be an accountant to write a skill. You need to know your country's rules well enough to cite the statutes — whether that's tax rates, payroll obligations, e-invoicing specs, or company formation steps. accountants — licensed accountants — then review what you wrote.
 
 ## How to contribute a skill
 
@@ -102,7 +102,7 @@ If you add a `references.md` to a country's source directory, it will be include
 
 ## Review
 
-After you submit, Partners — licensed accountants — review your skill on [openaccountants.com](https://www.openaccountants.com). When the full review is approved, the skill becomes **accountant-reviewed** (Tier 1). Your name stays on it as the author.
+After you submit, accountants — licensed accountants — review your skill on [openaccountants.com](https://www.openaccountants.com). When the full review is approved, the skill becomes **accountant-reviewed** (Tier 1). Your name stays on it as the author.
 
 ## Contributor License Agreement (CLA)
 

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Agents can already do the math. None of them can stand behind an answer. Every o
 ### The scoreboard
 
 > ## 10 of 193 jurisdictions
-> have a named, licensed Partner on record. **The other 183 are open.** [Claim yours →](https://github.com/openaccountants/openaccountants/issues/46)
+> have a named, licensed accountant on record. **The other 183 are open.** [Claim yours →](https://github.com/openaccountants/openaccountants/issues/46)
 
 Every reviewed Guide carries its reviewer badge — name, credential, review date, public proof:
 
@@ -21,7 +21,7 @@ Every reviewed Guide carries its reviewer badge — name, credential, review dat
 1,000+ Guides across 190+ jurisdictions, working with **Claude, ChatGPT, Cursor, Windsurf, and any MCP-compatible agent**. Every Guide is in exactly one of two states, and the repo greps honestly:
 
 - **Source-cited draft** — written from primary legislation, every figure cited, not yet professionally reviewed
-- **Accountant-reviewed** — a named, licensed Partner checked the complete Guide; their badge is on it ([full roster](PARTNERS.md))
+- **Accountant-reviewed** — a named, licensed accountant reviewed the complete Guide; their name is on it ([full roster](ACCOUNTANTS.md))
 
 ⚠️ **General reference only, not advice.** Have a qualified professional review outputs before filing, payment, or action. <details><summary>Read the full disclaimer</summary>
 
@@ -46,7 +46,7 @@ AI:     ITR12 working paper
         [Request accountant review →]
 ```
 
-**[Add to your AI →](https://www.openaccountants.com/connect)**   |   **[Browse Guides →](https://www.openaccountants.com/skills)**   |   **[Become a Partner →](https://www.openaccountants.com/for-accountants)**
+**[Add to your AI →](https://www.openaccountants.com/connect)**   |   **[Browse Guides →](https://www.openaccountants.com/skills)**   |   **[Review a Guide →](https://www.openaccountants.com/for-accountants)**
 
 ---
 
@@ -74,11 +74,11 @@ Works in Claude Desktop (`claude_desktop_config.json`), Cursor (`.cursor/mcp.jso
 
 ---
 
-## Partners: the named professionals behind the Guides
+## The named accountants behind the Guides
 
-The canonical roster lives in [PARTNERS.md](PARTNERS.md) (and adding yourself to it is step two of Partner onboarding). These licensed practitioners have reviewed Guides for their jurisdictions. Their name appears on every answer the AI gives from a Guide they reviewed, and their reviews are public.
+The canonical roster lives in [ACCOUNTANTS.md](ACCOUNTANTS.md) (adding yourself to it is step two of onboarding). These licensed practitioners have reviewed Guides for their jurisdictions. Their name appears on every answer the AI gives from a Guide they reviewed, and their reviews are public.
 
-| Jurisdiction | Partner | Guides | Proof |
+| Jurisdiction | Accountant | Guides | Proof |
 |---|---|---|---|
 | United States (federal forms) | **Christopher Aryee, CPA** | 4 | [33 OBBBA corrections, full diff](https://github.com/openaccountants/openaccountants/pull/45/files) |
 | United States | Amir Pelinkovic CPA | 16 | [profile](https://www.openaccountants.com/network/752ee18a-3843-434d-8426-457d3fa9706f) |
@@ -91,9 +91,9 @@ The canonical roster lives in [PARTNERS.md](PARTNERS.md) (and adding yourself to
 | South Africa | Werner Britz CA(SA) | 5 | [profile](https://www.openaccountants.com/network/28a3ec1b-d699-4c5d-bb60-3114eedc59d0) |
 | Malta | Michael Cutajar CPA (Malta) | 5 | [profile](https://www.openaccountants.com/network) |
 | Nepal | Ashish Bista CA | 5 | [profile](https://www.openaccountants.com/network/78ab67db-8f29-4746-8102-7b52d17309aa) |
-| **Your jurisdiction** | Open (130+ still unclaimed) | — | [Become a Partner →](https://www.openaccountants.com/for-accountants) |
+| **Your jurisdiction** | Open (130+ still without an accountant) | — | [Review a Guide →](https://www.openaccountants.com/for-accountants) |
 
-> Accountant-reviewed Guides (Tier 1) are served via the MCP server with the Partner's name on every output. Guides in this repo that no Partner has reviewed yet are source-cited drafts (Tier 2).
+> Accountant-reviewed Guides (Tier 1) are served via the MCP server with the accountant's name on every output. Guides in this repo that no accountant has reviewed yet are source-cited drafts (Tier 2).
 
 Licensed accountant? Review a complete Guide for your jurisdiction and your name goes on it, publicly and permanently. [Start here.](https://www.openaccountants.com/for-accountants)
 
@@ -103,7 +103,7 @@ Licensed accountant? Review a complete Guide for your jurisdiction and your name
 
 | | MCP connector *(recommended)* | Manual upload from this repo |
 |---|---|---|
-| **What you get** | Accountant-reviewed Guides, the reviewing Partner's name on every answer, AI-to-human handoff (`request_accountant_review` routes to a real accountant with your worksheet attached) | Source-cited drafts, no reviewer attribution, no handoff |
+| **What you get** | Accountant-reviewed Guides, the reviewing accountant's name on every answer, AI-to-human handoff (`request_accountant_review` routes to a real accountant with your worksheet attached) | Source-cited drafts, no reviewer attribution, no handoff |
 | **How** | [openaccountants.com/connect](https://www.openaccountants.com/connect), or the install above | Download a folder, drag `.md` files into your AI |
 | **Best for** | Anyone who wants to actually use OpenAccountants | Developers and accountants who want to audit, fork, or contribute |
 | **Clients** | Claude.ai, ChatGPT (Business+), Cursor, Windsurf, Claude Desktop, Claude Code, any MCP-aware client | Any AI that reads files |
@@ -199,7 +199,7 @@ Malta, UK, Germany, France, Australia, Canada, Israel, India, Japan, Spain, Neth
 
 Consumption tax classification with local supplier pattern libraries. From Albania to Zimbabwe.
 
-Full coverage breakdown: [docs/QUALITY-TIERS.md](docs/QUALITY-TIERS.md) · Machine-readable: [`index.json`](index.json)
+Full coverage breakdown: [docs/QUALITY-TIERS.md](docs/QUALITY-TIERS.md) · How figures are dated: [docs/TAX-YEARS.md](docs/TAX-YEARS.md) · What we certify: [docs/RESEARCH-GUARDRAILS.md](docs/RESEARCH-GUARDRAILS.md) · Machine-readable: [`index.json`](index.json)
 
 ---
 
@@ -225,7 +225,7 @@ When uncertain, the system always assumes MORE tax, never less. Your accountant 
 
 ## Are you an accountant?
 
-Most Guides are source-cited drafts: written from primary legislation but awaiting a credentialed review. Become a **Partner** for your jurisdiction, review a complete Guide, and it becomes accountant-reviewed with your name on every answer the AI gives from it. Christopher Aryee's [33-correction OBBBA review](https://github.com/openaccountants/openaccountants/pull/45/files) is what that looks like in practice.
+Most Guides are source-cited drafts: written from primary legislation but awaiting a credentialed review. Review a complete Guide for your jurisdiction and it becomes accountant-reviewed with your name on every answer the AI gives from it. Christopher Aryee's [33-correction OBBBA review](https://github.com/openaccountants/openaccountants/pull/45/files) is what that looks like in practice.
 
 **You don't need GitHub.** Just:
 
@@ -235,7 +235,7 @@ Most Guides are source-cited drafts: written from primary legislation but awaiti
 
 Or: fork, fix a rate against your tax authority's guidance, PR. **Your name on the Guide either way.**
 
-> 130+ jurisdictions are still open for a Partner. [Claim yours →](https://www.openaccountants.com/for-accountants)
+> 130+ jurisdictions still have no accountant on record. [Claim yours →](https://www.openaccountants.com/for-accountants)
 
 ---
 
@@ -301,13 +301,13 @@ python3 scripts/build-index.py      # refresh index.json
 - **LLMs hallucinate.** These files steer the model; they don't guarantee correct numbers. Always have a qualified professional review before filing.
 - **Tax law changes.** Rates and thresholds go out of date. The repo is a snapshot; [openaccountants.com](https://openaccountants.com) may be ahead of what you cloned. (When a professional catches drift, it lands here as a public correction, like [PR #45](https://github.com/openaccountants/openaccountants/pull/45).)
 - **Coverage is uneven.** 13 countries have the full accounting suite; many jurisdictions have VAT only or partial coverage. Check each country folder's README or [`index.json`](index.json).
-- **Newer domains need more eyes.** Bookkeeping, payroll, formation, and financial statements Guides are source-cited drafts with fewer Partner reviews than the core tax Guides.
+- **Newer domains need more eyes.** Bookkeeping, payroll, formation, and financial statements Guides are source-cited drafts with fewer accountant reviews than the core tax Guides.
 
 ---
 
 ## Disclaimer
 
-OpenAccountants provides general tax and accounting reference material for AI-assisted workflows. It is **not** a law firm, accounting firm, tax preparer, or return-filing service. Outputs are **not** tax, legal, accounting, or financial advice, are not reviewed for your specific facts, and must be reviewed by a qualified professional before filing, payment, or action. Using a Guide does not create a client relationship. A *source-cited draft* has not been reviewed by a credentialed accountant; only an *accountant-reviewed* Guide carries a Partner's review, and that review is of reference material, not of any specific taxpayer's situation.
+OpenAccountants provides general tax and accounting reference material for AI-assisted workflows. It is **not** a law firm, accounting firm, tax preparer, or return-filing service. Outputs are **not** tax, legal, accounting, or financial advice, are not reviewed for your specific facts, and must be reviewed by a qualified professional before filing, payment, or action. Using a Guide does not create a client relationship. A *source-cited draft* has not been reviewed by a credentialed accountant; only an *accountant-reviewed* Guide carries a named accountant's review, and that review is of reference material, not of any specific taxpayer's situation.
 
 The most up-to-date, reviewed version is maintained at [openaccountants.com](https://openaccountants.com).
 

--- a/README.md
+++ b/README.md
@@ -6,8 +6,8 @@ Agents can already do the math. None of them can stand behind an answer. Every o
 
 ### The scoreboard
 
-> ## 10 of 193 jurisdictions
-> have a named, licensed accountant on record. **The other 183 are open.** [Claim yours →](https://github.com/openaccountants/openaccountants/issues/46)
+> ## 9 of 193 jurisdictions
+> have a named, licensed accountant on record. **The other 184 are open.** [Claim yours →](https://github.com/openaccountants/openaccountants/issues/46)
 
 Every reviewed Guide carries its reviewer badge — name, credential, review date, public proof:
 
@@ -81,7 +81,6 @@ The canonical roster lives in [ACCOUNTANTS.md](ACCOUNTANTS.md) (adding yourself 
 | Jurisdiction | Accountant | Guides | Proof |
 |---|---|---|---|
 | United States (federal forms) | **Christopher Aryee, CPA** | 4 | [33 OBBBA corrections, full diff](https://github.com/openaccountants/openaccountants/pull/45/files) |
-| United States | Amir Pelinkovic CPA | 16 | [profile](https://www.openaccountants.com/network/752ee18a-3843-434d-8426-457d3fa9706f) |
 | United Kingdom | James Power | 15 | [profile](https://www.openaccountants.com/network/30b2f478-3a97-40c4-b435-0678829b487e) |
 | India | Mayur Deokar CA | 13 | [profile](https://www.openaccountants.com/network/f4cb8476-a86d-4fd9-b536-9217e82ccf99) |
 | Indonesia | Rilia Putri CA | 10 | [profile](https://www.openaccountants.com/network/ec70d43e-18c0-4b4e-b92c-4f8a22e10152) |

--- a/agent-skills/us-qbi-deduction/SKILL.md
+++ b/agent-skills/us-qbi-deduction/SKILL.md
@@ -664,7 +664,6 @@ Taxable income cap = 20% × $425,093 = $85,019 (not binding)
 
 ## Verified rates & thresholds (accountant-reviewed)
 
-> Reviewed against the cited US federal authorities (IRC §199A, Treasury Regulations, IRS revenue procedures) by **Amir Pelinkovic** on 2026-06-03.
 > Items flagged for further clarification are tracked separately and excluded here.
 > This block is generated from verified `skill_facts` — edit the facts, not the prose.
 

--- a/docs/RESEARCH-GUARDRAILS.md
+++ b/docs/RESEARCH-GUARDRAILS.md
@@ -1,0 +1,73 @@
+# Research guardrails: what we certify, and what we don't
+
+Frontier models already get most tax questions substantively right. What they
+fail is everything that makes an answer defensible: a pinpoint citation, the
+authority that outranks the blog post, an honest confidence level, and a named
+human when the position is unsettled.
+
+That layer is what OpenAccountants serves.
+
+## The doctrine, in one line
+
+**We certify the process and the people. We never certify the value.**
+
+The model fetches figures from primary sources itself. We make it hard to do
+that sloppily, and we put a named professional behind the method. So a stored
+figure of ours can be out of date without anyone being misled, because nothing
+we serve is presented as truth-by-assertion.
+
+This is a deliberate trade. Selling verified figures means owning every wrong
+figure, in every jurisdiction, forever. Selling the guardrails means the
+primary source carries itself and the accountant carries the method.
+
+## What arrives with an analysis question
+
+When a question needs judgment rather than a lookup — *can I deduct this*,
+*how is this taxed*, *am I still resident* — the response carries a research
+protocol:
+
+1. **Authority hierarchy.** Statute beats regulation beats case law beats
+   official guidance beats commentary, plus the jurisdiction's actual primary
+   sources. Where sources conflict, the higher tier wins.
+2. **Citation discipline.** Every figure anchored to a pinpoint citation with
+   its official URL and effective date, fetched in this session rather than
+   recalled. Stale recall is the single most common failure mode.
+3. **A confidence ladder.** US questions get the real practice standards
+   (will / should / more likely than not / substantial authority / reasonable
+   basis). Elsewhere, High / Medium / Low with the reason it is not higher.
+4. **A memo contract.** The sections a reviewer expects, ending in an
+   authorities table and a scope note.
+
+Then the part that is not advice: `verify_citations` takes the model's own
+`{url, figure, quote}` claims, fetches each cited page, and confirms the figure
+actually appears there. Not against our database — **against the source the
+model cited**. Confidence stops being self-reported.
+
+Unsettled points route to a named, licensed accountant rather than a
+disclaimer.
+
+## Why check citations rather than serve verified numbers
+
+The failure that damages people is not a sloppy answer they can spot. It is a
+**confidently wrong** one: a well-structured memo, correct-looking citations,
+built on law that changed. We measured this — an unaided model produced a memo
+scoring 0.95 on citation form and 0.10 on substance, because it applied
+superseded law with perfect formatting.
+
+A citation check is mechanical, verifiable, and carries no opinion: *the page
+you cited does contain that figure*. A verified-figure claim is a tax opinion,
+and it decays.
+
+Verdicts are `verified`, `not_found`, or `unfetchable` — never "false". PDFs,
+paywalls and JavaScript pages fetch badly, and an honest "could not check"
+beats a confident verdict either way.
+
+## Limits, stated plainly
+
+- **We cannot make a model obey.** Everything above is served as guidance. A
+  model that ignores it produces an ordinary AI answer. We measure how often
+  that happens rather than pretending it doesn't.
+- **Some models have no web access.** For those, a dated cached value with its
+  source is the honest fallback, never a bare number.
+- **A gap is a gap.** Where no accountant has written a method for a job, we
+  say so and point at the primary authorities, rather than inventing coverage.

--- a/docs/TAX-YEARS.md
+++ b/docs/TAX-YEARS.md
@@ -1,0 +1,75 @@
+# Tax years: how a figure knows which year it belongs to
+
+Most tax data goes wrong in the same boring way: a number that was right last
+year is served this year with nothing saying which year it came from. The fix
+is not to keep chasing values. It is to make every figure carry its year, and
+to make the server prefer the right one.
+
+## Facts are not stale. They are dated.
+
+A 2025 figure is *correct* for 2025. People file 2025 returns throughout 2026,
+so deleting last year's numbers would break real work. What breaks trust is an
+**undated** number, because nothing stops a model combining a 2025 threshold
+with a 2026 rate into a total that is true for no year at all.
+
+So every figure carries a validity window, and the server:
+
+1. **Labels it.** Every rule rendered by `search_rules` shows its period —
+   `TY2026` for a calendar-year jurisdiction, `2025/26` for a fiscal one.
+2. **Warns on mixtures.** If one response carries figures from more than one
+   tax year, the header says so by name and forbids combining them.
+3. **Prefers the current year.** Year coverage outranks text relevance, so the
+   figure for the year you asked about surfaces first. Prior-year figures still
+   serve, clearly labeled.
+4. **Serves two years.** The current tax year and the one before it, because
+   that is the filing window. Older vintages stay in the database and serve
+   only when you ask for that year by name.
+
+## The tax year is not the calendar year
+
+This is where most tax datasets quietly break. A figure stamped
+`1 Jan – 31 Dec` is wrong at both ends for most of the world:
+
+| Jurisdiction | Tax year |
+|---|---|
+| United Kingdom | 6 April – 5 April |
+| India, Hong Kong, New Zealand | 1 April – 31 March |
+| Australia, Pakistan, Bangladesh | 1 July – 30 June |
+| South Africa (individuals) | 1 March – end February |
+| United States, Ireland, Singapore | calendar year |
+
+A UK figure for **2025/26** covers 6 April 2025 to 5 April 2026. Stamp it as
+calendar 2025 and two things go wrong: it is labeled "TY2025", which a British
+accountant reads as a different year, and a question asked in February 2026
+about the current year misses it, because the filter tests the wrong boundary.
+
+Watch the exceptions. Ireland and Singapore are commonly assumed to run fiscal
+years for individuals and do not. Japan's *corporate* year is April to March
+while individual income tax is the calendar year, so a blanket rule corrupts
+it. Getting these wrong is worse than leaving them alone.
+
+## Where the current value actually comes from
+
+We do not want to be the place a rate lives. Rates move, and a database of
+rates is a promise to chase them forever in 190 jurisdictions.
+
+Instead a **slot** records where a figure is *published*: the authority, the
+document family, the stable official URL, the publication cadence, and the
+checks to run. The value itself is fetched live from that primary source at
+answer time, under the research protocol, and machine-checked with
+`verify_citations` before it reaches anyone.
+
+A source map does not go stale on 1 January. A rate table does.
+
+Where we do cache a value, it is dated and cited: *"$24,500, per IRS Notice
+2025-67, verified 29 July 2026."* Never a bare number. A model that cannot
+fetch still gets an honest, dated answer rather than a confident guess.
+
+## Adding a figure
+
+- Put the year in `valid_from` / `valid_to`, **never** in the item text. A
+  year baked into a title is how last year's figure passes for this year's.
+- Use the jurisdiction's real tax-year boundaries, not 1 January.
+- Cite the primary source with a URL, and record the date you read it.
+- Add the new year as a **new row**. Never overwrite the prior year: someone
+  is still filing it.

--- a/docs/VERIFIERS.md
+++ b/docs/VERIFIERS.md
@@ -16,7 +16,6 @@ _Last updated: 2026-06-07. The authoritative, live list is the network directory
 | 🇸🇦 Saudi Arabia | Mehran Habib | 13480 |
 | 🇿🇦 South Africa | Werner Britz | CA(SA) |
 | 🇬🇧 United Kingdom | James Power | — |
-| 🇺🇸 United States (federal + Illinois) | Amir Pelinkovic | 065.061971 |
 
 **11 credentialed practitioners across 13 jurisdiction assignments.** Most jurisdictions in this repo are still **source-cited drafts** awaiting a credentialed reviewer.
 

--- a/packages/us-il/il-estimated-tax.md
+++ b/packages/us-il/il-estimated-tax.md
@@ -17,7 +17,6 @@ depends_on:
 
 ## Verified rates & thresholds (accountant-reviewed)
 
-> Reviewed against the cited tax authorities by **Amir Pelinkovic** on 2026-06-03.
 > This block is generated from the verified facts database at openaccountants.com —
 > edit the facts there, not this prose. Items under clarification are excluded.
 

--- a/packages/us-il/il-income-tax.md
+++ b/packages/us-il/il-income-tax.md
@@ -17,7 +17,6 @@ depends_on:
 
 ## Verified rates & thresholds (accountant-reviewed)
 
-> Reviewed against the cited tax authorities by **Amir Pelinkovic** on 2026-06-03.
 > This block is generated from the verified facts database at openaccountants.com —
 > edit the facts there, not this prose. Items under clarification are excluded.
 

--- a/packages/us-il/il-payroll.md
+++ b/packages/us-il/il-payroll.md
@@ -17,7 +17,6 @@ The reviewer-oriented output for this skill is a payroll memo identifying every 
 
 ## Verified rates & thresholds (accountant-reviewed)
 
-> Reviewed against the cited tax authorities by **Amir Pelinkovic** on 2026-06-03.
 > This block is generated from the verified facts database at openaccountants.com —
 > edit the facts there, not this prose. Items under clarification are excluded.
 

--- a/packages/us-il/il-sales-tax.md
+++ b/packages/us-il/il-sales-tax.md
@@ -17,7 +17,6 @@ depends_on:
 
 ## Verified rates & thresholds (accountant-reviewed)
 
-> Reviewed against the cited tax authorities by **Amir Pelinkovic** on 2026-06-03.
 > This block is generated from the verified facts database at openaccountants.com —
 > edit the facts there, not this prose. Items under clarification are excluded.
 

--- a/packages/us-wy/no-sales-tax-states.md
+++ b/packages/us-wy/no-sales-tax-states.md
@@ -8,7 +8,6 @@ version: 2.0
 
 ## Verified rates & thresholds (accountant-reviewed)
 
-> Reviewed against the cited tax authorities by **Amir Pelinkovic** on 2026-06-03.
 > This block is generated from the verified facts database at openaccountants.com —
 > edit the facts there, not this prose. Items under clarification are excluded.
 
@@ -262,7 +261,6 @@ Buyers who purchase in no-sales-tax states may owe USE TAX in their home state o
 ## Disclaimer
 
 This skill is provided for informational and computational purposes only and does not constitute tax, legal, or financial advice. All outputs must be reviewed by a qualified professional (CPA, EA, or tax attorney) before filing.
-
 
 ---
 

--- a/packages/us-wy/us-1099-nec-issuance.md
+++ b/packages/us-wy/us-1099-nec-issuance.md
@@ -8,7 +8,6 @@ version: 0.2
 
 ## Verified rates & thresholds (accountant-reviewed)
 
-> Reviewed against the cited tax authorities by **Amir Pelinkovic** on 2026-06-03.
 > This block is generated from the verified facts database at openaccountants.com —
 > edit the facts there, not this prose. Items under clarification are excluded.
 

--- a/packages/us-wy/us-crypto-tax.md
+++ b/packages/us-wy/us-crypto-tax.md
@@ -11,7 +11,6 @@ category: federal
 
 ## Verified rates & thresholds (accountant-reviewed)
 
-> Reviewed against the cited tax authorities by **Amir Pelinkovic** on 2026-06-03.
 > This block is generated from the verified facts database at openaccountants.com —
 > edit the facts there, not this prose. Items under clarification are excluded.
 

--- a/packages/us-wy/us-qbi-deduction.md
+++ b/packages/us-wy/us-qbi-deduction.md
@@ -8,7 +8,6 @@ version: 0.2
 
 ## Verified rates & thresholds (accountant-reviewed)
 
-> Reviewed against the cited tax authorities by **Amir Pelinkovic** on 2026-06-03.
 > This block is generated from the verified facts database at openaccountants.com —
 > edit the facts there, not this prose. Items under clarification are excluded.
 

--- a/packages/us-wy/us-quarterly-estimated-tax.md
+++ b/packages/us-wy/us-quarterly-estimated-tax.md
@@ -14,7 +14,6 @@ depends_on:
 
 ## Verified rates & thresholds (accountant-reviewed)
 
-> Reviewed against the cited tax authorities by **Amir Pelinkovic** on 2026-06-03.
 > This block is generated from the verified facts database at openaccountants.com —
 > edit the facts there, not this prose. Items under clarification are excluded.
 

--- a/packages/us-wy/us-s-corp-election-decision.md
+++ b/packages/us-wy/us-s-corp-election-decision.md
@@ -8,7 +8,6 @@ version: 0.2
 
 ## Verified rates & thresholds (accountant-reviewed)
 
-> Reviewed against the cited tax authorities by **Amir Pelinkovic** on 2026-06-03.
 > This block is generated from the verified facts database at openaccountants.com —
 > edit the facts there, not this prose. Items under clarification are excluded.
 

--- a/packages/us-wy/us-sales-tax.md
+++ b/packages/us-wy/us-sales-tax.md
@@ -8,7 +8,6 @@ version: 2.0
 
 ## Verified rates & thresholds (accountant-reviewed)
 
-> Reviewed against the cited tax authorities by **Amir Pelinkovic** on 2026-06-03.
 > This block is generated from the verified facts database at openaccountants.com —
 > edit the facts there, not this prose. Items under clarification are excluded.
 
@@ -287,7 +286,6 @@ Most states offer VDAs for sellers who discover past-due nexus obligations. Bene
 ## Disclaimer
 
 This skill is provided for informational and computational purposes only and does not constitute tax, legal, or financial advice. All outputs must be reviewed by a qualified professional (CPA, EA, or tax attorney) before filing.
-
 
 ---
 

--- a/packages/us-wy/us-schedule-c-and-se-computation.md
+++ b/packages/us-wy/us-schedule-c-and-se-computation.md
@@ -9,7 +9,6 @@ version: 2.0
 
 ## Verified rates & thresholds (accountant-reviewed)
 
-> Reviewed against the cited tax authorities by **Amir Pelinkovic** on 2026-06-03.
 > This block is generated from the verified facts database at openaccountants.com —
 > edit the facts there, not this prose. Items under clarification are excluded.
 
@@ -640,7 +639,6 @@ SECTION H — REVIEWER FLAGS
 | Standard mileage rate | $0.70/mile |
 | 179 expensing limit | $1,250,000 (OBBBA) |
 | Bonus depreciation | 100% (OBBBA restored) |
-
 
 ---
 

--- a/packages/us-wy/us-self-employed-health-insurance.md
+++ b/packages/us-wy/us-self-employed-health-insurance.md
@@ -8,7 +8,6 @@ version: 0.2
 
 ## Verified rates & thresholds (accountant-reviewed)
 
-> Reviewed against the cited tax authorities by **Amir Pelinkovic** on 2026-06-03.
 > This block is generated from the verified facts database at openaccountants.com —
 > edit the facts there, not this prose. Items under clarification are excluded.
 

--- a/packages/us-wy/us-self-employed-retirement.md
+++ b/packages/us-wy/us-self-employed-retirement.md
@@ -8,7 +8,6 @@ version: 0.2
 
 ## Verified rates & thresholds (accountant-reviewed)
 
-> Reviewed against the cited tax authorities by **Amir Pelinkovic** on 2026-06-03.
 > This block is generated from the verified facts database at openaccountants.com —
 > edit the facts there, not this prose. Items under clarification are excluded.
 

--- a/packages/us-wy/us-sole-prop-bookkeeping.md
+++ b/packages/us-wy/us-sole-prop-bookkeeping.md
@@ -8,7 +8,6 @@ version: 2.0
 
 ## Verified rates & thresholds (accountant-reviewed)
 
-> Reviewed against the cited tax authorities by **Amir Pelinkovic** on 2026-06-03.
 > This block is generated from the verified facts database at openaccountants.com —
 > edit the facts there, not this prose. Items under clarification are excluded.
 
@@ -853,7 +852,6 @@ The workflow in `us-tax-workflow-base` mandates inferring the client profile fro
 ## End of US Sole Prop Bookkeeping Skill v2.0
 
 This skill is incomplete without the companion workflow file loaded alongside it: `us-tax-workflow-base` v0.1 or later (Tier 1, workflow architecture). Do not attempt to produce a Schedule C working paper without the base loaded.
-
 
 ---
 


### PR DESCRIPTION
The public repo had drifted from the platform. Three things, all found during this week's MCP evaluation.

### 1. Retired vocabulary, still shipping

**"Partner" appeared 18 times** across README, CONTRIBUTING and CLAUDE.md — months after we retired the word. Our most public document was our least current on naming. The public role is **accountant**. `PARTNERS.md` → `ACCOUNTANTS.md`, every link updated. Historical CHANGELOG entries keep the old word; you don't rewrite history.

### 2. A claim we cannot back

The roster asserted: *"Every Partner here has had their credential verified."*

We can't stand behind that. The internal timestamp behind it was bulk-backfilled from approval dates; most relevant registers (ACCA, CIMA, ICAI) have **no public name lookup** at all, only member-number search; and the roster's own credential column is blank for some entries.

It now says precisely what is true: what was self-declared, what was confirmed against a public register, and that **a blank means _not independently checked_, never _not qualified_**.

### 3. The doctrine was undocumented

Nothing in the repo explained how figures are dated or what we actually certify — the two things that make this project defensible rather than just another tax dataset.

- **docs/TAX-YEARS.md** — facts are dated, not stale (people file last year all year long); the two-year serving window; and why a tax year is not a calendar year, including the exceptions that bite (Ireland and Singapore are calendar; Japan is calendar for individuals but April–March for corporates, so a blanket rule corrupts it).
- **docs/RESEARCH-GUARDRAILS.md** — we certify the **process and the people, never the value**; why citation-checking beats serving verified numbers; and the limits stated plainly, including that we cannot make a model obey.

### CHANGELOG 2.4.0

Covers the serving work shipped this week: period labels on every figure, mixed-year warnings, current-year ranking, the ~5,000-row fiscal-window correction (GB 6 Apr, IN/HK/NZ 1 Apr, AU/PK/BD 1 Jul, ZA 1 Mar), `401k` finally matching `401(k)`, the `.md` path serving markdown instead of the HTML shell, and Guides that could claim reviews that never happened.

Docs and naming only — no Guide content or code changes.
