### PR TITLE
Merge external contributions: PRs #75, #77, #78, #79

### DIFF
--- a/index.json
+++ b/index.json
@@ -1,7 +1,7 @@
 {
- "generated_at": "2026-07-14T05:53:39+00:00",
+ "generated_at": "2026-08-01T06:59:21+00:00",
  "counts": {
-  "guides": 1899,
+  "guides": 1900,
   "jurisdictions": 243,
   "accountant_reviewed": 45
  },
@@ -2441,6 +2441,18 @@
    "reviewed_by": null,
    "tax_year": "2025",
    "last_updated": "2026-06-12"
+  },
+  {
+   "slug": "au-div7a",
+   "path": "skills/international/australia/au-div7a.md",
+   "name": "au-div7a",
+   "jurisdiction": "AU",
+   "category": "international",
+   "tier": 2,
+   "verified_by": "pending",
+   "reviewed_by": null,
+   "tax_year": "2026",
+   "last_updated": "2026-08-01"
   },
   {
    "slug": "au-gst-bas",

--- a/index.json
+++ b/index.json
@@ -2607,7 +2607,7 @@
    "tier": 2,
    "verified_by": null,
    "reviewed_by": null,
-   "tax_year": null,
+   "tax_year": "2026",
    "last_updated": "2026-08-01"
   },
   {

--- a/index.json
+++ b/index.json
@@ -1,7 +1,7 @@
 {
- "generated_at": "2026-07-14T05:53:39+00:00",
+ "generated_at": "2026-08-01T06:46:47+00:00",
  "counts": {
-  "guides": 1899,
+  "guides": 1900,
   "jurisdictions": 243,
   "accountant_reviewed": 45
  },
@@ -2441,6 +2441,18 @@
    "reviewed_by": null,
    "tax_year": "2025",
    "last_updated": "2026-06-12"
+  },
+  {
+   "slug": "au-fbt",
+   "path": "skills/international/australia/au-fbt.md",
+   "name": "au-fbt",
+   "jurisdiction": "AU",
+   "category": "international",
+   "tier": 2,
+   "verified_by": "pending",
+   "reviewed_by": null,
+   "tax_year": "2026",
+   "last_updated": "2026-08-01"
   },
   {
    "slug": "au-gst-bas",

--- a/index.json
+++ b/index.json
@@ -1,7 +1,7 @@
 {
- "generated_at": "2026-07-13T10:53:04+00:00",
+ "generated_at": "2026-07-14T08:44:45+00:00",
  "counts": {
-  "guides": 1898,
+  "guides": 1899,
   "jurisdictions": 243,
   "accountant_reviewed": 45
  },
@@ -735,8 +735,8 @@
    "tier": 2,
    "verified_by": "pending",
    "reviewed_by": null,
-   "tax_year": "2025",
-   "last_updated": "2026-07-12"
+   "tax_year": "2026",
+   "last_updated": "2026-07-14"
   },
   {
    "slug": "dtt-summary",
@@ -747,8 +747,8 @@
    "tier": 2,
    "verified_by": "pending",
    "reviewed_by": null,
-   "tax_year": "2025",
-   "last_updated": "2026-07-12"
+   "tax_year": "2026",
+   "last_updated": "2026-07-14"
   },
   {
    "slug": "emerging-market-corridors",

--- a/index.json
+++ b/index.json
@@ -1,5 +1,5 @@
 {
- "generated_at": "2026-07-14T05:53:39+00:00",
+ "generated_at": "2026-08-01T06:12:15+00:00",
  "counts": {
   "guides": 1899,
   "jurisdictions": 243,
@@ -2535,8 +2535,8 @@
    "tier": 2,
    "verified_by": null,
    "reviewed_by": null,
-   "tax_year": "2024",
-   "last_updated": "2026-07-04"
+   "tax_year": "2026",
+   "last_updated": "2026-08-01"
   },
   {
    "slug": "au-tax-residency",
@@ -2608,7 +2608,7 @@
    "verified_by": null,
    "reviewed_by": null,
    "tax_year": null,
-   "last_updated": "2026-06-12"
+   "last_updated": "2026-08-01"
   },
   {
    "slug": "australia-tax-optimization",

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -130,7 +130,7 @@ https://www.openaccountants.com
 
 ========================================================================
 
-## Guide inventory (1899 guides, 243 jurisdictions, 45 accountant-reviewed)
+## Guide inventory (1900 guides, 243 jurisdictions, 45 accountant-reviewed)
 
 - us-1099-k-and-payment-processors | US | tier 2 | reviewed_by -
 - us-education-credits-8863 | US | tier 2 | reviewed_by -
@@ -335,6 +335,7 @@ https://www.openaccountants.com
 - armenia-vat | AM | tier 2 | reviewed_by -
 - au-capital-gains | AU | tier 2 | reviewed_by -
 - au-crypto-tax | AU | tier 2 | reviewed_by -
+- au-div7a | AU | tier 2 | reviewed_by -
 - au-gst-bas | AU | tier 2 | reviewed_by -
 - au-individual-return | AU | tier 2 | reviewed_by -
 - au-medicare-levy | AU | tier 2 | reviewed_by -

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -130,7 +130,7 @@ https://www.openaccountants.com
 
 ========================================================================
 
-## Guide inventory (1899 guides, 243 jurisdictions, 45 accountant-reviewed)
+## Guide inventory (1900 guides, 243 jurisdictions, 45 accountant-reviewed)
 
 - us-1099-k-and-payment-processors | US | tier 2 | reviewed_by -
 - us-education-credits-8863 | US | tier 2 | reviewed_by -
@@ -335,6 +335,7 @@ https://www.openaccountants.com
 - armenia-vat | AM | tier 2 | reviewed_by -
 - au-capital-gains | AU | tier 2 | reviewed_by -
 - au-crypto-tax | AU | tier 2 | reviewed_by -
+- au-fbt | AU | tier 2 | reviewed_by -
 - au-gst-bas | AU | tier 2 | reviewed_by -
 - au-individual-return | AU | tier 2 | reviewed_by -
 - au-medicare-levy | AU | tier 2 | reviewed_by -

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -130,7 +130,7 @@ https://www.openaccountants.com
 
 ========================================================================
 
-## Guide inventory (1898 guides, 243 jurisdictions, 45 accountant-reviewed)
+## Guide inventory (1899 guides, 243 jurisdictions, 45 accountant-reviewed)
 
 - us-1099-k-and-payment-processors | US | tier 2 | reviewed_by -
 - us-education-credits-8863 | US | tier 2 | reviewed_by -

--- a/skills/cross-border/treaty-corridors/eg-ae/dtt-summary.md
+++ b/skills/cross-border/treaty-corridors/eg-ae/dtt-summary.md
@@ -7,10 +7,10 @@ description: >
   "cross-border Egypt UAE", "Egypt United Arab Emirates withholding". ALWAYS read this
   skill before applying treaty rates.
 jurisdiction: EG-AE
-tax_year: 2025
+tax_year: 2026
 tier: 2
-last_updated: 2026-07-12
-version: 0.1
+last_updated: 2026-07-14
+version: 1.0
 depends_on:
   - eg-corporate-tax
   - eg-withholding-tax
@@ -60,6 +60,23 @@ verified_by: pending
 
 ## Article-by-Article Summary
 
+### Article 2: Taxes Covered
+
+- **Egypt:** Individual income tax (wages, commercial/industrial, professional, real estate), corporate income tax, withholding tax, additional percentage taxes
+- **UAE:** Corporate tax (Federal Decree-Law No. 47 of 2022, 9% from June 2023). UAE does not levy personal income tax. The treaty covers corporate tax but UAE's 0% personal income tax regime means the treaty is primarily relevant for corporate cross-border flows and WHT relief on Egyptian-source payments.
+- Note: The old 2002 treaty predated UAE corporate tax; the new treaty explicitly covers the UAE CT regime.
+
+### Article 4: Resident — Tie-Breaker Rules
+
+A dual-resident individual's status is determined in sequence:
+1. **Permanent home** — state where permanent home is available
+2. **Centre of vital interests** — if permanent home in both states, state with closer personal/economic relations
+3. **Habitual abode** — if centre of vital interests cannot be determined or no permanent home in either state
+4. **Nationality** — if habitual abode in both or neither state
+5. **Mutual agreement** — competent authorities settle if national of both or neither
+
+For companies, the primary tie-breaker is the place of effective management. This is particularly relevant for UAE free zone entities that may have management in Egypt — the competent authorities will determine residence based on where board decisions are effectively made.
+
 ### Article 5: Permanent Establishment (PE)
 
 The new treaty modernizes the PE definition with BEPS-aligned provisions:
@@ -71,10 +88,23 @@ The new treaty modernizes the PE definition with BEPS-aligned provisions:
 
 **Closely related enterprise:** An enterprise is closely related to another if one controls the other or both are under the same control. Control = owning directly/indirectly at least **50%** of beneficial interest. Protocol: states shall exchange information to identify closely related persons.
 
+### Article 6: Income from Immovable Property
+
+Source state may tax income from immovable property (including agriculture/forestry). Ships and aircraft are excluded. Applies to direct use, letting, and other use forms. Also applies to income from immovable property used for business or independent personal services.
+
 ### Article 7: Business Profits
 
 - No taxation in source country unless non-resident carries on business through PE
 - New rules on profit attribution to PEs (aligned with OECD Authorized OECD Approach)
+- Profits attributable to PE are taxable in source state; balance is taxable only in residence state
+
+### Article 8: Shipping and Air Transport
+
+Taxable only in state of effective management. If management aboard a ship, state of home harbor or operator's residence. This is significant for UAE-based shipping lines and airlines operating to Egyptian ports — profits from such operations are taxable only in UAE (where management is located), not in Egypt.
+
+### Article 9: Associated Enterprises
+
+Arm's length principle applies. Transfer pricing adjustments allowed with corresponding adjustments. If one enterprise adjusts profits based on arm's length pricing, the other state must make a corresponding adjustment. Time limit: no adjustment after 5 years from year-end (aligning with Egypt's TP decree timelines). Disputes may be resolved through MAP (Article 24/MLI Article 16).
 
 ### Article 10: Dividends — Key Changes
 
@@ -102,6 +132,18 @@ The new treaty modernizes the PE definition with BEPS-aligned provisions:
 - Exception: gains from immovable property (Art 13(1) — source state taxes)
 - Ships/aircraft (Art 13(3) — management state taxes)
 
+### Article 14: Independent Personal Services
+
+Taxable only in residence state unless:
+- (a) Fixed base regularly available in source state (only income attributable to base taxed), OR
+- (b) Stay in source state ≥183 days in any 12-month period (only income from activities in source state taxed)
+
+Includes: scientific, literary, artistic, educational, teaching activities, physicians, lawyers, engineers, architects, dentists, accountants. Relevant for UAE-based consultants providing services in Egypt — without a fixed base or 183-day presence, their income is taxable only in UAE (0% personal income tax).
+
+### Article 17: Artistes and Sportspersons
+
+Source state may tax income of artistes, musicians, actors, sportsmen from personal activities exercised therein, even if income accrues to another person. This overrides the 183-day threshold for employment income — any performance in the source state is taxable.
+
 ### Article 15: Dependent Personal Services (Employment)
 
 - 183-day threshold: source state may tax if employment exercised in source state ≥183 days in any 12-month period
@@ -124,6 +166,44 @@ Source state (where company is resident) may tax directors' fees.
 ### Article 21: Other Income
 
 - New clarification for immovable property effectively connected to PE
+- Items not dealt with in other articles: residence state may tax
+- If connected to PE/fixed base, Articles 7/14 apply instead
+
+### Article 20: Students and Trainees
+
+- Maintenance/education/training payments from sources outside host state: not taxed
+- Remuneration from services connected with education/training: not taxed in host state for up to 3 years
+
+### Article 22: Methods for Elimination of Double Taxation
+
+- **Credit method:** Egypt allows deduction for tax paid in UAE (including the 0% rate, meaning no credit) against Egyptian tax on the same income
+- **UAE approach:** UAE introduced Corporate Tax (9% from June 2023). Foreign tax credits for Egyptian tax suffered may be available under UAE CT law — verify against UAE Federal Decree-Law No. 47 of 2022 provisions
+- Previously (pre-2023), UAE had no income tax; the treaty operated as a one-way relief mechanism (preventing Egyptian WHT). Now that UAE has CT, the relief is more reciprocal
+
+### Article 24: Mutual Agreement Procedure (MAP)
+
+- Case must be presented within **3 years** from first notification (MLI modified)
+- Competent authorities endeavour to resolve by mutual agreement
+- Any agreement implemented notwithstanding domestic time limits
+- Competent authorities may consult on interpretation/application and for cases not provided for
+- No mandatory arbitration included in the treaty
+
+### Article 25: Exchange of Information
+
+- Information exchanged for tax assessment/collection/enforcement/prosecution/appeals
+- Treated as secret, disclosed only to relevant persons/authorities
+- Cannot require administrative measures at variance with domestic law/practices
+- Cannot require information not obtainable under normal administration
+- Cannot require disclosure of professional secret/trade process/contrary to public policy
+- Information must be obtained even if not needed for requesting state's own tax purposes
+- **UAE significance:** UAE FTA cooperates with ETA on cross-border tax information exchange, including for free zone entities
+
+### Article 29: Entry into Force
+
+- Entry into force: 19 April 2021 (entered into force)
+- Applies from 1 January 2022 for all taxes covered
+- WHT: applies to amounts paid on or after 1 January 2022
+- Other taxes: applies to taxable years beginning on or after 1 January 2022
 
 ### Article 28: Savings Clause for Hydrocarbons
 
@@ -216,6 +296,65 @@ The new treaty includes a standalone **Principal Purpose Test (PPT)** (Article 3
 9. **Government exemption removed:** The government/central bank exemption for interest has been removed from the new treaty. Government-owned entities that previously enjoyed 0% interest must now verify their position under the new treaty.
 
 10. **MLI effective dates:** MLI provisions apply to WHT from dates on or after 1 January 2021 (Egypt) / dates per UAE MLI position. Check whether MLI PPT or treaty PPT applies first depending on effective dates.
+
+---
+
+## Worked Examples
+
+### Example 1: Egyptian company paying dividends to UAE shareholder (post-2022 treaty)
+
+**Facts:** An Egyptian company (EG Co) distributes EGP 10,000,000 in dividends to its UAE parent company (UAE HoldCo), which holds 15% of EG Co's voting stock. UAE HoldCo has held the shares for 400 days including the dividend distribution date.
+
+**Analysis:**
+- New treaty Article 10: 5% rate applies if beneficial owner holds ≥10% of voting stock for 365 days including distribution date
+- UAE HoldCo holds 15% > 10% threshold AND 400 days > 365-day holding period → 5% rate applies
+- Egyptian domestic WHT: 10% (unlisted company)
+- Egypt applies treaty rate directly for dividends (unlike interest/royalties where pay-and-refund applies):
+  - WHT = EGP 10,000,000 × 5% = EGP 500,000 (treaty rate used directly)
+- Under the old treaty (pre-2022): 0% WHT — this is a **new cost** for UAE investors
+- UAE side: UAE HoldCo receives EGP 9,500,000. UAE CT at 9% applies if taxable income aggregate exceeds AED 375,000 threshold. Foreign tax credit for Egyptian WHT may be available under UAE CT law.
+
+### Example 2: Egyptian company paying interest to UAE bank (new treaty)
+
+**Facts:** An Egyptian company (EG Co) pays EGP 8,000,000 in interest to a UAE commercial bank (UAE Bank, not government-owned).
+
+**Analysis:**
+- New treaty Article 11: 10% rate in source state
+- Egyptian domestic WHT on interest: 20%
+- Pay-and-refund mechanism applies:
+  1. EG Co withholds 20% at source = EGP 1,600,000
+  2. UAE Bank files refund claim with ETA for 10% differential = EGP 800,000
+  3. Net WHT after refund = EGP 800,000 (10% treaty rate)
+- Under the old treaty: the rate was also 10%, but government-owned banks were exempt. Under the new treaty, the government exemption is removed — UAE government-owned entities (e.g., Emirates NBD with sovereign ownership) may now face the 10% WHT where they were previously exempt.
+
+### Example 3: UAE shareholder selling Egyptian company shares (new treaty)
+
+**Facts:** A UAE investment company (UAE Inv) sells shares in an Egyptian listed company for EGP 50,000,000. The shares were acquired for EGP 30,000,000 (gain = EGP 20,000,000). UAE Inv is the beneficial owner and has held the shares for 2 years.
+
+**Analysis:**
+- **Old treaty:** Residence state (UAE) had exclusive taxing rights → 0% Egyptian tax on the gain
+- **New treaty Article 13:** Source state (Egypt) may tax gains from alienation of shares
+- Egyptian tax = EGP 20,000,000 × 22.5% (CIT rate) = EGP 4,500,000
+- This is a **major change** — UAE investors must now budget for Egyptian CGT on share disposals
+- UAE CT side: Foreign tax credit for EGP 4,500,000 Egyptian tax against UAE CT on the same gain
+  - UAE CT = EGP 20,000,000 × 9% = EGP 1,800,000
+  - Since Egyptian tax (EGP 4.5M) > UAE CT (EGP 1.8M), no additional UAE tax is due, but the excess is not refundable
+  - Effective total tax rate = 22.5% (capped at Egyptian rate)
+
+### Example 4: Film & TV royalties — split rate under new treaty
+
+**Facts:** An Egyptian broadcasting company (EG Broadcast) pays AED 5,000,000 to a UAE media company (UAE Media) for: (a) AED 3,000,000 in software/know-how royalties, and (b) AED 2,000,000 in film & TV broadcasting rights.
+
+**Analysis:**
+- Software/know-how: Article 12 → 10% treaty rate (vs 20% domestic)
+- Film & TV: Article 12 → 15% treaty rate (vs 20% domestic) — **increased from 10% under old treaty**
+- Pay-and-refund:
+  1. EG Broadcast withholds 20% on total = AED 1,000,000
+  2. UAE Media files refund claims:
+     - Software/know-how refund: AED 3,000,000 × (20% - 10%) = AED 300,000
+     - Film/TV refund: AED 2,000,000 × (20% - 15%) = AED 100,000
+  3. Total refund = AED 400,000
+  4. Net WHT = AED 600,000 (AED 300,000 at 10% + AED 300,000 at 15%)
 
 ---
 

--- a/skills/cross-border/treaty-corridors/eg-sa/dtt-summary.md
+++ b/skills/cross-border/treaty-corridors/eg-sa/dtt-summary.md
@@ -7,10 +7,10 @@ description: >
   "cross-border Egypt Saudi", "Egypt Saudi Arabia withholding". ALWAYS read this skill
   before applying treaty rates.
 jurisdiction: EG-SA
-tax_year: 2025
+tax_year: 2026
 tier: 2
-last_updated: 2026-07-12
-version: 0.1
+last_updated: 2026-07-14
+version: 1.0
 depends_on:
   - eg-corporate-tax
   - eg-withholding-tax
@@ -308,6 +308,58 @@ The original Article 27 (main-purpose test) has been **replaced by the MLI Artic
 7. **Technical services:** No separate FTS article in this treaty. IP-related technical assistance falls under royalties (Art 12 at 10%). Non-IP technical services fall under business profits (Art 7), taxable only if PE exists in source state. This is a significant advantage over Egypt's 20% domestic WHT on service payments to non-residents.
 
 8. **Saudi non-discrimination article:** The non-discrimination article is NOT currently in force — it applies only prospectively if KSA includes a non-discrimination article in a treaty with a non-GCC country. Verify current status if relevant.
+
+---
+
+## Worked Examples
+
+### Example 1: Saudi company paying dividends to Egyptian shareholder
+
+**Facts:** A Saudi Arabian company (SA Co) distributes SAR 1,000,000 in dividends to its Egyptian parent company (EG HoldCo), which holds 25% of SA Co's capital directly.
+
+**Analysis:**
+- Treaty Article 10(2)(a): 5% rate applies because EG HoldCo holds directly ≥20% of capital
+- Saudi domestic WHT on dividends: 5% (same as treaty rate)
+- WHT = SAR 1,000,000 × 5% = SAR 50,000
+- Note: Saudi domestic rate already matches treaty rate — no additional relief needed
+
+### Example 2: Egyptian company paying interest to Saudi bank
+
+**Facts:** An Egyptian company (EG Co) pays EGP 5,000,000 in interest to a Saudi commercial bank (SA Bank, not government-owned).
+
+**Analysis:**
+- Treaty Article 11(2): 10% rate applies
+- Egyptian domestic WHT on interest: 20%
+- Egypt applies pay-and-refund mechanism:
+  1. EG Co withholds 20% at source = EGP 1,000,000
+  2. SA Bank files refund claim with ETA for differential (20% - 10% = 10%)
+  3. Refund amount = EGP 500,000
+- Net WHT after refund = EGP 500,000 (10% treaty rate)
+- Note: If SA Bank were government-owned (SAMA, GOSI, etc.), Article 11(3) would exempt the interest entirely
+
+### Example 3: Egyptian company paying royalties to Saudi tech company
+
+**Facts:** An Egyptian company (EG Co) pays EGP 2,000,000 in royalties (software licence + know-how) to a Saudi tech company (SA Tech).
+
+**Analysis:**
+- Treaty Article 12(2): 10% rate applies (royalties include software licences and technical assistance related to IP)
+- Egyptian domestic WHT on royalties: 20%
+- Pay-and-refund:
+  1. EG Co withholds 20% = EGP 400,000
+  2. SA Tech files refund claim for 10% differential = EGP 200,000
+  3. Net WHT after refund = EGP 200,000 (10% treaty rate)
+- Saudi side: SA Tech receives EGP 1,800,000, reports as business income. If Saudi-owned, Zakat 2.5% applies (not income tax). Article 23(6) protocol: Zakat is not creditable against Egyptian tax.
+
+### Example 4: Construction PE — 7-month project
+
+**Facts:** A Saudi construction company (SA Build) sends a team to Egypt for a 7-month building project for EG Co.
+
+**Analysis:**
+- Article 5(3): Construction PE threshold = 6 months
+- 7 months > 6 months → PE exists in Egypt
+- MLI anti-fragmentation: if SA Build splits the project into two 4-month contracts with a 1-month gap, the closely related enterprise periods (>30 days) are aggregated → PE still exists
+- Consequence: Article 7 — profits attributable to PE are taxable in Egypt at 22.5% CIT
+- If no PE (e.g., 5 months only): profits taxable only in Saudi Arabia
 
 ---
 

--- a/skills/international/australia/au-div7a.md
+++ b/skills/international/australia/au-div7a.md
@@ -1,0 +1,369 @@
+---
+name: au-div7a
+description: >
+  Use this skill whenever asked about Division 7A of the ITAA 1936 -- private company loans, payments or debt forgiveness to shareholders or their associates, complying loan agreements, minimum yearly repayments, the benchmark interest rate, distributable surplus, unpaid present entitlements (UPEs) to corporate beneficiaries after Bendel, use of company assets by shareholders, or deemed dividends. Trigger on phrases like "Div 7A", "Division 7A", "shareholder loan", "director loan account", "debit loan", "minimum yearly repayment", "benchmark interest rate", "complying loan", "deemed dividend", "distributable surplus", "UPE", "bucket company", "unpaid present entitlement", or when a GL shows debit balances in shareholder/director accounts. ALWAYS read this skill before touching any Div 7A work.
+version: 1.0
+jurisdiction: AU
+category: international
+tax_year: 2026
+tax_year_notes: "2026-27 income year; post-Bendel guidance state as at August 2026"
+tier: 2
+last_updated: 2026-08-01
+verified_by: pending
+---
+
+# Australia Division 7A -- Private Company Loans Skill v1.0
+
+> **General reference only.** This skill is general tax/accounting reference material for AI-assisted workflows. It has not been reviewed for any specific person's facts, documents, elections, deadlines, residency, filing status, or local procedures. Do not rely on it to file, pay, amend, or take a tax position without review by a qualified professional in the relevant jurisdiction.
+
+> **Law-change context.** The High Court decided *Commissioner of Taxation v Bendel* [2026] HCA 18 on 10 June 2026: a UPE owed to a corporate beneficiary is not, of itself, a Div 7A loan. The ATO's decision impact statement (26 June 2026) accepts the decision. Several ATO products are under review or awaiting withdrawal -- Rule 11 carries the status table as at 1 August 2026. Verify before relying.
+
+## Section 1 -- Quick reference
+
+**Read this whole section before computing or classifying anything.**
+
+| Field | Value |
+|---|---|
+| Country | Australia |
+| Primary Legislation | ITAA 1936 Part III Division 7A (ss 109B-109ZE) |
+| Tax Authority | Australian Taxation Office (ATO) |
+| Income Year | 2026-27 (1 July 2026 -- 30 June 2027) |
+| Benchmark interest rate (2026-27) | 8.77% (2025-26: 8.37%; 2024-25: 8.77%) |
+| Complying loan maximum terms | 7 years unsecured; 25 years where 100% secured by registered real-property mortgage with market value (net of prior-ranking liabilities) >= 110% of the loan when first made |
+| Complying agreement deadline | In writing BEFORE the company's lodgment day (earlier of due date and actual lodgment -- s 109D(6)) |
+| First minimum yearly repayment | Due in the income year AFTER the year the loan is made |
+| Deemed dividend cap | Distributable surplus (s 109Y); proportional reduction across provisional dividends |
+| UPE to corporate beneficiary | NOT a Div 7A loan while the company stays passive (*Bendel* [2026] HCA 18) -- s 100A and Subdiv EA risks survive |
+| Contributor | Open Accountants |
+| Validated by | Pending |
+
+**Conservative defaults:**
+
+| Ambiguity | Default |
+|---|---|
+| Unknown lodgment day | Assume the EARLIER plausible date -- the deadline for agreements and repayments |
+| Unknown loan agreement status | Assume NO written agreement; flag urgently (fixable only before lodgment day) |
+| Debit balance in shareholder/director account | Treat as a Div 7A loan candidate until characterised |
+| Unknown distributable surplus | Compute exposure at full value; flag the s 109Y cap as unquantified |
+| UPE on trust balance sheet | Passive UPE = no Div 7A loan (post-Bendel), but flag s 100A / Subdiv EA screen (T2-1, T2-2) |
+| Company asset used privately | Assume s 109CA payment at arm's-length value; check minor (<$300) and licence-fee carve-outs |
+| Repayment near year end followed by redraw | Assume s 109R disregard applies; flag |
+
+---
+
+## Section 2 -- Required inputs and refusal catalogue
+
+### Required inputs
+
+**Minimum viable** -- company's GL (shareholder/director/associate loan accounts, drawings), prior year Div 7A schedules, loan agreements with dates and terms, the company's lodgment history (for lodgment day).
+
+**Recommended** -- trust deeds and distribution minutes where UPEs exist, company financial statements (for distributable surplus), dividend statements (for set-offs), asset-use facts (who uses what, on what terms).
+
+**Ideal** -- full repayment history per loan, security documents for 25-year loans, franking account, prior ATO correspondence or 109RB applications.
+
+### Refusal catalogue
+
+**R-AU-D7A-1 -- Section 100A analysis.** *Trigger:* UPE or trust distribution pattern suggests a reimbursement agreement (benefit flowing to someone other than the presently entitled beneficiary). *Message:* "Section 100A carries trustee-level top-marginal-rate assessment and no amendment period limit. Escalate -- TR 2022/4 / PCG 2022/2 analysis is specialist work."
+
+**R-AU-D7A-2 -- Interposed entities and Subdivision EA/EB.** *Trigger:* payments or loans routed through other entities, or a trust with a UPE making payments/loans to the company's shareholders. *Message:* "Identify and map the chain, then escalate -- the Commissioner determines the deemed amount under ss 109V/109W."
+
+**R-AU-D7A-3 -- s 109RB discretion applications.** *Trigger:* client wants an honest-mistake ruling on a breached loan. *Message:* "Corrective-action strategy and the discretion application are practitioner work. Assemble the facts; escalate."
+
+**R-AU-D7A-4 -- Restructures and forgiveness planning.** *Trigger:* proposals to forgive, refinance, or restructure Div 7A exposure. *Message:* "Planning is advice. Compute current exposure only; escalate the strategy."
+
+---
+
+## Section 3 -- GL sweep library
+
+Div 7A work starts with the balance sheet, not the loan register the client says exists.
+
+| GL pattern | Likely issue | Action |
+|---|---|---|
+| Debit balance -- shareholder / director loan account | s 109D loan candidate | Loan register (Section 7); agreement status; MYR check |
+| Drawings account not cleared to salary/dividend | Payments (s 109C) or loan | Characterise before lodgment day -- fixable until then |
+| "Loan -- related trust" (asset side) | Actual loan back from company to trust | Div 7A loan -- Bendel does NOT help actual loans |
+| UPE / beneficiary entitlement owed TO the company (in the trust's books) | Post-Bendel: not a loan while passive | s 100A / Subdiv EA screen; do not convert without advice |
+| Motor vehicles, boats, property with private use by shareholders | s 109CA asset-use payment | Arm's-length value less consideration; minor/licence carve-outs |
+| Journal writing off a related-party receivable | s 109F forgiveness | Deemed dividend at year end, subject to surplus |
+| Interest income at exactly the benchmark rate | Existing complying loan | Verify MYR actually paid, not just interest accrued |
+
+---
+
+## Section 4 -- Worked examples
+
+### Example 1 -- New loan, saved by a complying agreement
+
+Company advances $100,000 to a shareholder in March 2027 (2026-27 year). Return due date assumed 15 May 2028 (tax-agent lodgment program) and lodged that day, so lodgment day = 15 May 2028 -- an earlier due date or earlier actual lodgment would move the deadline, so establish both dates first. A written 7-year complying agreement at >= benchmark interest is signed 1 April 2028 -- before lodgment day.
+
+No deemed dividend in 2026-27 (s 109N). The first minimum yearly repayment falls due in 2027-28, computed with the 2027-28 benchmark rate.
+
+### Example 2 -- Minimum yearly repayment arithmetic
+
+Amalgamated 7-year loan made in 2025-26; $100,000 unrepaid at 30 June 2026. MYR for 2026-27 (benchmark 8.77%):
+
+```
+Remaining term T = 7 - (years between end of loan year [30 Jun 2026]
+                        and end of prior year [30 Jun 2026]) = 7
+MYR = P x I / (1 - (1/(1+I))^T)
+    = $100,000 x 0.0877 / (1 - (1/1.0877)^7)
+    = $8,770 / 0.444817
+    = $19,716 (nearest dollar)
+```
+
+### Example 3 -- Shortfall, capped by distributable surplus
+
+Same loan; the shareholder repays only $10,000 in 2026-27. Shortfall = $9,716 -> deemed dividend at 30 June 2027, but only up to the company's distributable surplus (s 109Y). If surplus is $4,000, the dividend is $4,000 (and the company must give written statements where multiple provisional dividends are reduced proportionally).
+
+### Example 4 -- UPE to a bucket company, post-Bendel
+
+Trust resolves a $150,000 distribution to its corporate beneficiary in June 2027; the entitlement remains unpaid, and the company does nothing to call for payment.
+
+**Not a Div 7A loan** (*Bendel* [2026] HCA 18; ATO DIS 26 June 2026 -- passive UPEs are not financial accommodation, sub-trust or not). Surviving risks to flag: s 100A reimbursement-agreement analysis (R-AU-D7A-1), Subdiv EA where the trust pays/lends to the company's shareholders, and any ACTIVE step (converting the UPE to a loan, satisfaction by promissory note) that creates a real s 109D(3) loan. Any call or demand for payment ends the passive characterisation this example relies on -- whether unenforced forbearance after a demand amounts to financial accommodation is unresolved, so escalate the moment the company does anything other than nothing. UPEs already converted to complying loans before Bendel stay loans.
+
+### Example 5 -- Private use of a company asset
+
+Company-owned holiday house used by the shareholder's family for 2 weeks; market rent $800/week; nothing paid.
+
+s 109CA payment = arm's-length value less consideration = $1,600 -> deemed dividend at year end (subject to surplus). Carve-outs checked: not minor (>= $300 notional value), no licence fee paid (a market-rate licence fee would zero it), none of the dwelling exceptions apply. Continuing availability re-tests at the start of each income year.
+
+### Example 6 -- The repay-and-redraw trap
+
+Shareholder repays $20,000 on 25 June 2027, redraws $25,000 on 15 July 2027. A reasonable person concludes the repayment was intended to be re-borrowed: s 109R disregards the $20,000 for MYR purposes. Exception that DOES work: setting off a declared dividend or salary (assessable to the shareholder) against the loan -- s 109R(3) preserves set-offs of assessable amounts.
+
+---
+
+## Section 5 -- Tier 1 rules
+
+### Rule 1 -- The three trigger events
+
+Payments (s 109C, including s 109CA asset use), loans (s 109D), and debt forgiveness (s 109F) by a private company to a shareholder or associate (current or former, on the reasonable-person test) are deemed unfranked dividends at the end of the company's income year -- each capped by distributable surplus (Rule 8). Franking exceptions: the s 109RB discretion can allow franking, and s 109RC family-breakdown dividends (marriage/relationship breakdown obligations) are frankable without any discretion.
+
+**Associate** (s 318 ITAA 1936, summarised): relatives of the shareholder; partners and their spouses and children; trustees of trusts under which the shareholder or an associate benefits; and companies the shareholder or associates control. Directors are caught only as shareholders or associates of shareholders -- confirm status when a debit director account is not held by a shareholder.
+
+### Rule 2 -- Loans and the lodgment-day escape
+
+A loan is a deemed dividend unless, before the LODGMENT DAY (earlier of the return's due date and actual lodgment -- s 109D(6)): it is fully repaid, or a complying s 109N agreement is in place. Loan is defined widely: advances, provision of credit or any other form of financial accommodation (s 109D(3)).
+
+### Rule 3 -- Complying loan criteria (s 109N)
+
+All three, before lodgment day: written agreement; interest for each year after the loan year at or above that year's benchmark rate; term within the maximum -- 7 years unsecured, or 25 years where 100% of the loan is secured by a registered mortgage over real property whose market value (net of prior-ranking secured liabilities) is at least 110% of the loan when first made.
+
+### Rule 4 -- Benchmark interest rate
+
+Statutory source: the RBA Indicator Lending Rates -- bank variable housing loans rate last published before the start of the income year (s 109N(2)). 2026-27: **8.77%**. 2025-26: 8.37%. 2024-25: 8.77%. Always match the rate to the year being computed.
+
+### Rule 5 -- Amalgamated loans and minimum yearly repayments (s 109E)
+
+Constituent loans to one entity in a year, unrepaid at lodgment day, saved by s 109N, sharing a maximum term, amalgamate. From the income year AFTER the loan year, each year's MYR is:
+
+```
+MYR = P x I / (1 - (1/(1+I))^T)
+P = amount unrepaid at the end of the previous income year
+I = CURRENT year's benchmark rate
+T = remaining term = longest constituent term - years elapsed between the end
+    of the loan year and the end of the prior income year; the resulting
+    DIFFERENCE is rounded UP to the next whole number if not already whole
+    (s 109E(7) rounds the remaining term itself, never the elapsed years)
+```
+
+Shortfall between amounts paid and the MYR = deemed dividend at year end (subject to surplus).
+
+### Rule 6 -- Payments and asset use (ss 109C, 109CA)
+
+Payment = amounts paid/credited/transferred to, on behalf of, or for the benefit of the entity; property transfers valued at arm's length less consideration. A loan is not a payment. Use of a company asset (including under lease/licence) is a payment: first use, then re-tested at the start of each later income year; value = arm's-length amount for the use less consideration given. Carve-outs: minor use (< $300 notional value, s 58P criteria), otherwise-deductible use, certain dwellings, and NIL where an arm's-length licence fee is paid.
+
+### Rule 7 -- Debt forgiveness (ss 109F, 109G)
+
+Forgiveness (including debt parking and reasonable-person "won't insist" conclusions) = deemed dividend of the amount forgiven. Death does NOT automatically forgive a shareholder's loan -- no statutory death exception exists; ATO ID 2012/77 deems a dividend to the legal personal representative where forgiveness occurs during estate administration; escalate estate cases. Exclusions: debts owed by other companies (non-trustee), bankruptcy, loans already deemed dividends (full s 109D exclusion; dollar-for-dollar s 109E reduction), Commissioner's undue-hardship discretion.
+
+### Rule 8 -- Distributable surplus (s 109Y)
+
+```
+Distributable surplus = Net assets + Division 7A amounts
+                        - Non-commercial loans - Paid-up share value
+                        - Repayments of non-commercial loans
+```
+
+Net assets per the accounting records (less present legal obligations and specified provisions; Commissioner may substitute values for significant under/overvaluation). "Division 7A amounts" = current-year s 109C and s 109F dividends only. Where total provisional dividends exceed the surplus, each is reduced proportionally and the company must give recipients written statements.
+
+### Rule 9 -- Anti-avoidance on repayments (s 109R)
+
+Repayments are disregarded where a reasonable person concludes the entity intended to re-borrow a similar or larger amount, or borrowed from the company to fund the repayment. PRESERVED: set-offs of dividends, salary/wages or other assessable withholding-covered amounts, and arm's-length property-transfer balances (s 109R(3)-(4)).
+
+### Rule 10 -- Exclusions and the discretion
+
+s 109K: payments/loans to other companies (not as trustee) excluded. s 109L: amounts otherwise assessable or made non-assessable elsewhere. s 109M: loans in the ordinary course of business on usual arm's-length terms. s 109RB: the Commissioner may disregard a deemed dividend (or allow franking) for honest mistakes/inadvertent omissions -- factors include corrective action and speed, prior history; escalate applications (R-AU-D7A-3).
+
+### Rule 11 -- UPEs after Bendel: guidance status (as at 1 August 2026)
+
+| Item | Status |
+|---|---|
+| *Bendel* [2026] HCA 18 (10 June 2026, 5:2) | Passive UPE to corporate beneficiary is not a s 109D loan |
+| ATO decision impact statement | Issued 26 June 2026; accepts the decision; comments closed 24 July 2026 |
+| TD 2022/11 | Announced-to-withdraw (DIS para 43); still technically in force with under-review banner |
+| TR 2010/3 | Withdrawn since 1 July 2022 (pre-Bendel); historical only |
+| TR 2022/4 + PCG 2022/2 (s 100A) | IN FORCE, under review -- s 100A remains the live ATO angle on UPEs |
+| PCG 2017/13, TR 2015/4, TD 2015/20, TD 2011/15 | Under review, none withdrawn |
+| Withdrawn-ruling protection | s 358-20(3) Sch 1 TAA: favourable withdrawn rulings keep applying to pre-withdrawal arrangements |
+| Legislative response | 2018-19 Budget UPE measure still unenacted (prospective from Royal Assent); 2026-27 Budget: 30% minimum tax on discretionary trusts from 1 July 2028 with corporate beneficiaries denied the offset -- consultation closed 31 July 2026, not yet law |
+
+Practical position for 2026-27: a passive UPE creates no Div 7A consequence; actual loans company-to-trust remain Div 7A loans; converted UPEs stay loans; s 100A and Subdiv EA screens always run.
+
+---
+
+## Section 6 -- Tier 2 catalogue
+
+### T2-1 -- s 100A screen
+
+**Trigger:** UPE + benefits flowing to someone other than the presently entitled beneficiary, or distribution patterns outside ordinary family/commercial dealing. **Action:** refuse analysis (R-AU-D7A-1); document the pattern; escalate.
+
+### T2-2 -- Subdivision EA/EB
+
+**Trigger:** the trust owing the UPE makes payments or loans to the company's shareholders/associates. **Action:** map flows; escalate (R-AU-D7A-2).
+
+### T2-3 -- 25-year loan security adequacy
+
+**Trigger:** secured loan claimed; valuation or registration unverified. **Issue:** 110% net-of-prior-ranking test applies AT the time the loan is first made. **Action:** sight the registered mortgage and contemporaneous valuation; flag gaps.
+
+### T2-4 -- Distributable surplus valuation
+
+**Trigger:** net assets in the accounts look under/overstated (e.g. assets at historical cost, unrecorded liabilities). **Issue:** Commissioner's substitution power. **Action:** flag; do not self-adjust values.
+
+### T2-5 -- Trust minimum tax horizon (announced, not law)
+
+**Trigger:** structuring decisions for bucket companies extending past 1 July 2028. **Issue:** 2026-27 Budget announced 30% minimum tax on discretionary trusts (corporate beneficiaries denied the offset) from 1 July 2028, with restructure rollover relief from 1 July 2027 -- consultation only, not enacted. **Action:** note on any advice touching 2028+; escalate planning.
+
+### T2-6 -- Loans that are really wages
+
+**Trigger:** regular round-amount "loans" matching a pay cycle. **Issue:** may be salary/wages (PAYG withholding, super) rather than Div 7A loans -- different regime entirely. **Action:** characterise with the client; flag both exposures.
+
+---
+
+## Section 7 -- Excel working paper template
+
+```
+AUSTRALIA DIVISION 7A -- LOAN REGISTER
+Company: [name]   Income year: 2026-27   Lodgment day: [earlier of due date / lodged]
+Prepared: [date]
+
+PER COUNTERPARTY (shareholder / associate)
+  Name and relationship:          [____]
+  Opening balance (per prior WP): AUD [____]
+  New advances this year:         AUD [____]
+  Agreement (written, pre-lodgment-day, rate >= benchmark, term OK): [YES/NO/PENDING]
+  Term / security (7yr | 25yr + registered mortgage + 110% test at inception): [____]
+  Amount unrepaid at end of PRIOR year (P): AUD [____]
+  Benchmark rate (I, current year): 8.77%
+  Remaining term (T, rounded up):  [____]
+  MYR = P x I / (1 - (1/(1+I))^T): AUD [____]
+  Repayments made (excl. s 109R-disregarded; incl. valid set-offs): AUD [____]
+  Shortfall:                       AUD [____]
+  s 109CA asset-use payments:      AUD [____]
+  Forgiveness events:              AUD [____]
+
+DISTRIBUTABLE SURPLUS (s 109Y)
+  Net assets:                      AUD [____]
+  + Division 7A amounts (109C/109F this year): AUD [____]
+  - Non-commercial loans:          AUD [____]
+  - Paid-up share value:           AUD [____]
+  - Repayments of non-commercial loans: AUD [____]
+  = Distributable surplus:         AUD [____]
+  Provisional dividends total:     AUD [____]
+  Proportional reduction applied:  [YES/NO -- written statements issued?]
+
+UPE SCREEN (post-Bendel)
+  UPEs owed to the company:        AUD [____]
+  Company action taken (calls, conversion, notes)? [____]
+  s 100A / Subdiv EA flags:        [____]
+
+REVIEWER FLAGS
+  [List any Tier 2 flags]
+```
+
+---
+
+## Section 8 -- Reading guide
+
+1. Balance sheet first: every related-party debit balance is a candidate until characterised.
+2. Lodgment day is the master date -- agreements, repayments and characterisation are all fixable only before it. Establish it before anything else.
+3. MYR uses the CURRENT year's benchmark against the PRIOR year-end balance -- the two most common errors are wrong-year rates and computing from the current balance.
+4. Interest accrued is not repayment: the MYR must actually be paid (or validly set off).
+5. UPEs: check the trust's books, not just the company's -- the company's balance sheet may not show the entitlement.
+
+---
+
+## Section 9 -- Onboarding fallback
+
+If the client provides only financial statements:
+
+1. Sweep both company and any trust balance sheets per Section 3
+2. Build the loan register with agreement status UNKNOWN flagged per loan
+3. Compute MYRs on stated balances at 8.77%, all assumptions listed
+4. Compute distributable surplus from the accounts as given
+5. **Flag:** "Register built from financial statements only. Agreements, security documents, repayment evidence and trust distribution minutes not sighted. Lodgment day unconfirmed. Reviewer must confirm before any position is taken."
+
+---
+
+## Section 10 -- Reference material
+
+### Key figures
+
+| Item | Value |
+|---|---|
+| Benchmark rate 2026-27 / 2025-26 / 2024-25 | 8.77% / 8.37% / 8.77% |
+| Maximum terms | 7 years unsecured; 25 years secured (110% net-value test at inception) |
+| First MYR | Income year after the loan year |
+| Asset-use minor exception | < $300 notional value (s 58P criteria) |
+| Deemed dividend character | Unfranked (exceptions: s 109RB discretion; s 109RC family-breakdown dividends frankable) |
+
+### Primary sources (verified 1 August 2026)
+
+| Topic | Source |
+|---|---|
+| Benchmark rates | ato.gov.au -- Division 7A benchmark interest rate (QC 17928, updated 1 July 2026) |
+| Statute | ITAA 1936 Compilation No. 192 (C2026C00333, 1 July 2026): ss 109C-109Y |
+| MYR formula and steps | s 109E(6); ato.gov.au Division 7A loans (QC 17341, updated 2 July 2026) |
+| Bendel | [2026] HCA 18 (10 June 2026); ATO decision impact statement 26 June 2026 |
+| s 100A | TR 2022/4; PCG 2022/2 (both in force, under review) |
+| Budget trust measures | 2026-27 Budget (12 May 2026); Treasury consultation paper 8 July 2026 |
+
+### Test suite
+
+**Test 1:** $100,000 unrepaid at prior year end, 7-year loan made last year, 2026-27 MYR. -> T = 7; MYR = $8,770 / 0.444817 = $19,716.
+
+**Test 2:** Loan made 2024-25 (7-year), MYR for 2026-27. -> T = 7 - 1 = 6.
+
+**Test 3:** No written agreement by lodgment day, loan unrepaid. -> Deemed dividend of the loan amount at end of the loan year, capped by distributable surplus.
+
+**Test 4:** MYR $19,716; shareholder pays $10,000 cash and sets off a $9,716 declared dividend (assessable). -> MYR satisfied; set-off preserved by s 109R(3).
+
+**Test 5:** $20,000 repaid 25 June, $25,000 redrawn 15 July. -> Repayment disregarded (s 109R); MYR shortfall computed as if unpaid.
+
+**Test 6:** Passive UPE $150,000 to bucket company. -> No Div 7A loan (Bendel). Convert it to a complying loan by agreement -> it IS a loan from conversion; stays a loan.
+
+**Test 7:** Holiday house, market rent $800/week, 2 weeks' private use, nothing paid. -> s 109CA payment $1,600 (not minor; no licence fee).
+
+**Test 8:** Provisional dividends $80,000; distributable surplus $30,000. -> Dividends reduced proportionally to $30,000 total; written statements required.
+
+**Test 9:** Loan to a sister Pty Ltd (not trustee). -> Excluded (s 109K). Same loan to a company acting as trustee -> NOT excluded.
+
+**Test 10:** Shareholder dies; executor asks whether the loan is forgiven. -> No automatic forgiveness; estate cases escalate (Rule 7).
+
+### Prohibitions
+
+- NEVER use a benchmark rate from the wrong year (2026-27 = 8.77%)
+- NEVER compute the MYR from the current-year balance -- P is the PRIOR year-end unpaid amount
+- NEVER treat a passive UPE as a Div 7A loan post-Bendel -- and NEVER clear a UPE structure without the s 100A / Subdiv EA screen
+- NEVER count a repayment that was re-borrowed (except valid s 109R(3) set-offs of assessable amounts)
+- NEVER assert a deemed dividend above distributable surplus
+- NEVER treat a company-to-company loan as caught (s 109K) unless the recipient acts as trustee
+- NEVER advise forgiveness, refinancing, or restructures -- compute exposure, escalate strategy
+- NEVER present figures as definitive
+
+---
+
+## Disclaimer
+
+This skill and its outputs are provided for informational and computational purposes only and do not constitute tax, legal, or financial advice. Open Accountants and its contributors accept no liability for any errors, omissions, or outcomes arising from the use of this skill. All outputs must be reviewed and signed off by a qualified professional (such as a CPA, CA, tax agent, or equivalent licensed practitioner in your jurisdiction) before filing or acting upon.
+
+The most up-to-date, verified version of this skill is maintained at [openaccountants.com](https://www.openaccountants.com). Log in to access the latest version, request a professional review from a licensed accountant, and track updates as tax law changes.

--- a/skills/international/australia/au-div7a.md
+++ b/skills/international/australia/au-div7a.md
@@ -65,7 +65,7 @@ verified_by: pending
 
 **R-AU-D7A-1 -- Section 100A analysis.** *Trigger:* UPE or trust distribution pattern suggests a reimbursement agreement (benefit flowing to someone other than the presently entitled beneficiary). *Message:* "Section 100A carries trustee-level top-marginal-rate assessment and no amendment period limit. Escalate -- TR 2022/4 / PCG 2022/2 analysis is specialist work."
 
-**R-AU-D7A-2 -- Interposed entities and Subdivision EA/EB.** *Trigger:* payments or loans routed through other entities, or a trust with a UPE making payments/loans to the company's shareholders. *Message:* "Identify and map the chain, then escalate -- the Commissioner determines the deemed amount under ss 109V/109W."
+**R-AU-D7A-2 -- Interposed entities and Subdivision EA/EB.** *Trigger:* payments or loans routed through other entities, or a trust with a UPE making payments/loans to the company's shareholders. *Message:* "Identify and map the chain, then escalate -- Subdiv E interposed-entity amounts (s 109T) are Commissioner-determined under ss 109V/109W; Subdiv EA amounts arise automatically under ss 109XA/109XB; Subdiv EB deemed entitlements are Commissioner-determined under s 109XI."
 
 **R-AU-D7A-3 -- s 109RB discretion applications.** *Trigger:* client wants an honest-mistake ruling on a breached loan. *Message:* "Corrective-action strategy and the discretion application are practitioner work. Assemble the facts; escalate."
 

--- a/skills/international/australia/au-fbt.md
+++ b/skills/international/australia/au-fbt.md
@@ -1,0 +1,409 @@
+---
+name: au-fbt
+description: >
+  Use this skill whenever asked about Australian Fringe Benefits Tax -- identifying fringe benefits in a general ledger, car fringe benefits (statutory formula or operating cost), the electric vehicle exemption, meal entertainment, minor benefits, expense payments and the otherwise-deductible rule, LAFHA, loan benefits, employee contributions, reportable fringe benefits amounts (RFBA), FBT gross-up and return preparation. Trigger on phrases like "FBT", "fringe benefits tax", "car fringe benefit", "novated lease FBT", "EV FBT exemption", "entertainment FBT", "minor benefit", "50/50 method", "LAFHA", "living away from home", "gross-up", "Type 1 Type 2", "RFBA", "reportable fringe benefits", or when sweeping a GL for FBT exposure. The FBT year runs 1 April to 31 March. ALWAYS read this skill before touching any FBT work.
+version: 1.0
+jurisdiction: AU
+category: international
+tax_year: 2026
+tax_year_notes: "FBT year ending 31 March 2027 (1 April 2026 - 31 March 2027)"
+tier: 2
+last_updated: 2026-08-01
+verified_by: pending
+---
+
+# Australia Fringe Benefits Tax (FBT) -- Employer Skill v1.0
+
+> **General reference only.** This skill is general tax/accounting reference material for AI-assisted workflows. It has not been reviewed for any specific person's facts, documents, elections, deadlines, residency, filing status, or local procedures. Do not rely on it to file, pay, amend, or take a tax position without review by a qualified professional in the relevant jurisdiction.
+
+## Section 1 -- Quick reference
+
+**Read this whole section before computing or classifying anything. The FBT year is 1 April - 31 March, NOT the income year.**
+
+| Field | Value |
+|---|---|
+| Country | Australia |
+| Primary Legislation | Fringe Benefits Tax Assessment Act 1986 (FBTAA) |
+| Tax Authority | Australian Taxation Office (ATO) |
+| FBT Year | Ending 31 March 2027 (1 April 2026 -- 31 March 2027) |
+| Currency | AUD only |
+| FBT rate | 47% |
+| Type 1 gross-up (provider entitled to GST credit) | 2.0802 |
+| Type 2 gross-up (no GST credit entitlement) | 1.8868 |
+| Return due -- self-preparer, or tax agent lodging on paper | 21 May 2027 (lodge and pay) |
+| Return due -- tax agent lodging electronically | 25 June 2027 (client must be on the agent's FBT list by 21 May 2027) |
+| Quarterly instalments | Required in the next year if prior-year FBT liability was $3,000 or more (via activity statements) |
+| Record-keeping exemption (base-year aggregate) | $10,962 (year ending 31 March 2027; 20% growth condition -- Rule 12) |
+| Car statutory formula rate | 20% flat (post-10 May 2011 commitments) |
+| Operating cost deemed depreciation / deemed interest | 25% diminishing value / 8.27% |
+| Car parking daily fee threshold | $11.48 |
+| Minor benefits exemption | Notional taxable value < $300 AND infrequent/irregular (s 58P) |
+| RFBA trigger | Individual fringe benefits amount > $2,000 -> report x 1.8868 via STP (exclusions apply -- Rule 9) |
+| EV exemption | Battery electric / hydrogen cars still exempt (conditions apply); **PHEVs NOT exempt from 1 April 2025** except grandfathered binding commitments |
+| Contributor | Open Accountants |
+| Validated by | Pending |
+
+**Conservative defaults:**
+
+| Ambiguity | Default |
+|---|---|
+| Unknown GST creditability of a benefit | Ask -- decides Type 1 vs Type 2 gross-up; never assume Type 1 |
+| Unknown car method election | Compute both statutory formula and operating cost where a logbook exists; use statutory if no logbook |
+| Unknown logbook or odometer records | Assume NO valid logbook/odometer set (statutory formula applies); flag |
+| PHEV in the fleet | Assume NOT exempt (post-1 April 2025) unless a pre-1-April-2025 binding commitment is evidenced |
+| Unknown employee contribution | Assume nil; ask |
+| Entertainment attendee split unknown | Flag -- actual method needs the employee/non-employee split |
+| Not-for-profit employer | STOP -- capping/rebate rules out of scope (R-AU-FBT-1) |
+
+---
+
+## Section 2 -- Required inputs and refusal catalogue
+
+### Required inputs
+
+**Minimum viable** -- entity type and FBT registration status, GL for the FBT year (1 April - 31 March), motor vehicle list with cost/dates/users, entertainment account detail, any salary packaging arrangements.
+
+**Recommended** -- logbooks and odometer records, employee contribution records, declarations (or alternative records under the 1 April 2024 measures), prior year FBT return and workpapers, lease agreements for novated/associate leases.
+
+**Ideal** -- per-employee benefit register, car parking market surveys, LAFH declarations and expense evidence, loan agreements with rates and balances.
+
+### Refusal catalogue
+
+**R-AU-FBT-1 -- NFP capping and rebates.** *Trigger:* employer is a PBI, health promotion charity, public/not-for-profit hospital, or rebatable employer. *Message:* "Salary packaging caps ($30,000/$17,000 grossed-up; $15,900/$9,010 in benefit value), meal entertainment card arrangements and the FBT rebate are specialist territory. Out of scope -- escalate."
+
+**R-AU-FBT-2 -- Employee share schemes.** *Trigger:* benefit involves shares/options. *Message:* "ESS interests are generally excluded from FBT and taxed under ESS rules. Out of scope."
+
+**R-AU-FBT-3 -- Car parking commercial valuation.** *Trigger:* car parking benefits arise and a taxable value beyond the threshold test is needed. *Message:* "Commercial parking station rate selection, market valuation, and the statutory spaces method involve valuation judgment. Compute exposure flag only; escalate valuation."
+
+**R-AU-FBT-4 -- Airline transport, board, remote area housing.** *Trigger:* these benefit categories appear. *Message:* "Specialised valuation rules. Out of scope -- escalate."
+
+---
+
+## Section 3 -- GL sweep library
+
+FBT work starts with a ledger sweep, not a form. These are the account patterns that hide benefits.
+
+### 3.1 High-yield accounts
+
+| GL account pattern | Likely benefit | Action |
+|---|---|---|
+| Motor vehicle -- fuel, rego, insurance, repairs, lease | Car fringe benefit | Build the car register (Section 5, Rules 3-4) |
+| Entertainment, staff amenities, sundry expenses | Meal entertainment / minor benefits | Split sustenance vs entertainment; attendee analysis |
+| Staff gifts, staff welfare | Property/minor benefits | $300 minor test per gift (s 58P) |
+| Travel -- accommodation and meals | Travelling vs LAFH boundary | Apply PCG 2021/3 safe harbour (T2-4) |
+| Employee reimbursements | Expense payment benefits | Otherwise-deductible check + declaration |
+| Loans to employees / directors' loan accounts (debit) | Loan benefit | Compare rate charged to 8.27% benchmark (also check Div 7A for shareholders -- separate regime) |
+| Gym/health/wellness, club memberships | Expense payment / residual | Rarely exempt; work-related-item test fails for these |
+| Phone/laptop purchases for staff | Possibly exempt s 58X | Portable device, primarily work use; one-per-year rule unless small business (Rule 10 -- NOTE rules change 1 April 2027) |
+
+### 3.2 Sustenance vs entertainment (the perennial misclassification)
+
+| Fact pattern | Treatment |
+|---|---|
+| Morning tea, biscuits, sandwiches consumed on premises during work | Sustenance -- NOT entertainment, no FBT, deductible |
+| Meal with alcohol, restaurant, off-site | Entertainment -- FBT analysis required |
+| Coffee with a client (light, on business) | Likely sustenance/marginal -- flag, err to entertainment if elaborate |
+| Christmas party, staff drinks | Entertainment -- minor benefit test per head if < $300 and infrequent |
+| Meal while travelling overnight for work | Not entertainment for the traveller -- travel expense |
+
+---
+
+## Section 4 -- Worked examples
+
+### Example 1 -- Car fringe benefit, statutory formula
+
+Car cost $40,000 (GST-inclusive base value), available for private use all 365 days of the year ending 31 March 2027, employee contributed $1,000 after tax. The employer is GST-registered and claimed the GST credit on the car's acquisition.
+
+```
+Taxable value = 20% x $40,000 x (365/365) - $1,000 = $7,000
+GST credit entitlement established above -> Type 1 (established, never assumed)
+Grossed-up = $7,000 x 2.0802 = $14,561.40
+FBT = 47% x $14,561.40 = $6,843.86
+```
+
+Employee contribution is assessable income to the employer and has GST consequences.
+
+### Example 2 -- Exempt EV that still creates RFBA
+
+Battery electric car, first held and used March 2024, LCT value at first retail sale below the fuel-efficient LCT threshold for that year so LCT was never payable (verified from the sale documents, not a raw price comparison), provided to a current employee through 2026-27.
+
+Car benefit and associated expenses (rego, insurance, servicing, charging): **exempt** -- no FBT. But the **notional** taxable value must still be computed: if it exceeds $2,000 for the employee, an RFBA is reported through STP (notional TV x 1.8868). Home charging may use the PCG 2024/2 shortcut: 5.47 c/km for the FBT year starting 1 April 2026.
+
+### Example 3 -- The PHEV trap
+
+Plug-in hybrid delivered under a novated lease commencing 1 June 2025. NOT exempt -- PHEVs ceased qualifying 1 April 2025, and the lease began after that date, so no grandfathering. Full car fringe benefit applies. (Grandfathering needs BOTH pre-1-April-2025 exempt use AND a binding commitment spanning the date; optional lease extensions break it.)
+
+### Example 4 -- Christmas party under the minor benefits exemption
+
+Off-site Christmas party, $180 per head including partners, once a year. Per-attendee notional taxable value < $300 and the event is infrequent -> minor benefit, exempt (s 58P). Consequence of exemption: the cost is NOT income tax deductible and no GST credits (entertainment is only deductible/creditable to the extent FBT applies).
+
+### Example 5 -- Meal entertainment, 50/50 election
+
+Total meal entertainment for the year $28,000 across staff and clients, no register kept, employer elects 50/50.
+
+```
+Taxable value = 50% x $28,000 = $14,000 (attendee split irrelevant under 50/50)
+Only 50% of the spend is income tax deductible (s 51AEA); GST credits follow the same 50%
+```
+
+Compare before electing: actual method may beat 50/50 when client (non-employee) share is high; the register method needs a 12-week register. Salary-packaged meal entertainment MUST use the actual method.
+
+### Example 6 -- Loan benefit
+
+$50,000 interest-free loan to an employee outstanding all year.
+
+```
+Notional interest = $50,000 x 8.27% (benchmark, year ending 31 Mar 2027) = $4,135
+Interest charged = $0 -> taxable value = $4,135 (Type 2 -> x 1.8868)
+```
+
+If the employee would have deducted the interest (e.g. loan used for their income-producing investment), the otherwise-deductible rule can reduce the taxable value -- declaration required.
+
+---
+
+## Section 5 -- Tier 1 rules
+
+### Rule 1 -- FBT liability formula
+
+```
+FBT payable = 47% x [ (sum of Type 1 taxable values x 2.0802) + (sum of Type 2 taxable values x 1.8868) ]
+```
+
+Type 1 where the provider is entitled to a GST credit on providing the benefit; Type 2 otherwise (GST-free/input-taxed supplies, provider not registered). Never assume Type 1.
+
+### Rule 2 -- Return and payment dates (2027 FBT year)
+
+Self-preparers and paper-lodging agents: lodge and pay by 21 May 2027. Agents lodging electronically: 25 June 2027, client must be on the agent's FBT client list by 21 May 2027 -- a client added after 21 May reverts to the 21 May due date (already late if unlodged). Prior-year liability >= $3,000 -> quarterly instalments next year via activity statements.
+
+### Rule 3 -- Car statutory formula
+
+```
+Taxable value = 20% x base value x (days available for private use / days in FBT year) - employee contributions
+```
+
+Base value = GST-inclusive cost including luxury car tax and non-business accessories fitted at acquisition (less registration/stamp duty), reduced by one-third from the first FBT year commencing after the fourth anniversary of the date the car was first held by the employer or an associate (once only; holding need not be continuous; the reduction never applies to non-business accessories added after acquisition). 20% applies to all post-10-May-2011 commitments. A car garaged at or near the employee's home is taken to be available for private use.
+
+### Rule 4 -- Car operating cost method
+
+```
+Taxable value = total operating costs x private-use percentage - employee contributions
+```
+
+Operating costs include actual running costs PLUS deemed depreciation (25% diminishing value on the depreciated value, cars held from 10 May 2006) and deemed interest (8.27% for the year ending 31 March 2027) for owned cars. Business percentage requires a valid logbook: continuous 12-week representative period, valid 5 years, plus full-year odometer records. No valid logbook -> statutory formula. Employer may choose per car, per year, whichever gives the lower value.
+
+### Rule 5 -- Electric vehicle exemption (and its edges)
+
+Exempt if ALL: battery electric or hydrogen fuel cell car (PHEVs excluded from 1 April 2025 -- see below); designed to carry < 1 tonne and < 9 passengers (motorcycles/scooters never qualify); first held AND used on or after 1 July 2022; used by a current employee or their associates; luxury car tax has NEVER been payable on any supply or importation -- check whether LCT was actually payable from the sale documents (the car's LCT value against the fuel-efficient threshold for the financial year of the relevant sale; $91,661 for 2026-27 sales), never by raw price comparison. Associated running costs are also exempt. **The exempt benefit still generates an RFBA** via notional taxable value (Rule 9). PHEV grandfathering: exempt use before 1 April 2025 plus a financially binding commitment continuing on and after that date; optional extensions are not binding.
+
+### Rule 6 -- Car parking
+
+A car parking benefit needs, on the same day: parking > 4 hours between 7am-7pm on employer premises at/near the primary place of employment; the employee's car parked and commuting use; AND at least one commercial parking station within 1 km that charged a lowest representative fee for all-day parking above $11.48 on the first business day of the FBT year (1 April 2026 for the 2027 year -- no on-the-day fee test exists). Small business exemption: parking is not at a commercial car park AND (gross total income < $10m OR aggregated turnover < $50m) AND not a government body or listed company. Valuation beyond the threshold check: escalate (R-AU-FBT-3).
+
+### Rule 7 -- Minor benefits (s 58P)
+
+Notional taxable value < $300 (not indexed; per benefit, per occasion) AND unreasonable to treat as a fringe benefit having regard to infrequency/irregularity and the other s 58P(1)(f) criteria (TR 2007/12: no fixed number of occasions). Screening heuristic: quarterly or less frequent = presumptively infrequent; monthly or more = flag for review. Exempt entertainment gets no deduction and no GST credit.
+
+### Rule 8 -- Meal entertainment methods
+
+1. **Actual** (default; MANDATORY for salary-packaged meal entertainment): taxable value = amounts for employees/associates; client share not subject to FBT (and not deductible).
+2. **50/50 split** (Division 9A election): 50% of ALL meal entertainment is the taxable value, regardless of attendees; only 50% deductible/GST-creditable (s 51AEA).
+3. **12-week register**: register percentage applied to the year's spend.
+
+The minor benefits exemption is NOT available for meal entertainment once a 50/50 or register election is made -- it applies only under the actual method. Entertainment is income-tax deductible and GST-creditable ONLY to the extent it is a fringe benefit subject to FBT.
+
+### Rule 9 -- Employee contributions and RFBA
+
+Contributions: after-tax only, reduce the taxable value of THAT benefit only (no cross-application; not for tax-exempt body entertainment), are assessable income to the employer, and carry GST consequences. RFBA: computed on the employee's INDIVIDUAL fringe benefits amount, which EXCLUDES car parking benefits, meal entertainment not provided under a salary packaging arrangement (50/50 and register amounts are never allocable to employees), pooled/shared cars, and remote-area concessions -- and INCLUDES the notional value of exempt electric car benefits (the exception running the other way). Where that amount exceeds $2,000 for the FBT year, report it x 1.8868 (always the Type 2 factor, in whole dollars) through STP finalisation. RFBA affects the employee's income tests, not their taxable income.
+
+### Rule 10 -- Otherwise-deductible rule and declarations
+
+Expense payment/property/residual/loan benefits: taxable value reduced by what the employee could have claimed as a once-only deduction. Requires a declaration in the approved form before the declaration date -- or, from 1 April 2024, adequate alternative records per the Commissioner's legislative instruments (available for 11 record types; logbooks and odometer records still need the approved form). Portable electronic devices (s 58X): exempt if primarily for work; one substantially-identical item per year unless a replacement, or the employer's aggregated turnover is under $50 million. **Transition warning:** from 1 April 2027, Act No 49 of 2026 (Sch 4 Pt 2) removes the one-per-year limit and the turnover carve-out, denies s 58X entirely for items provided under a salary packaging arrangement, and (new s 24(1A)) blocks the otherwise-deductible rule for salary-packaged expense payments of standard-deduction work expenses -- flag any packaging arrangement extending past 31 March 2027.
+
+### Rule 11 -- LAFHA (standard cases only)
+
+Concessional LAFHA treatment: employee maintains an Australian home they're living away from, first 12 months at a location (FIFO/DIDO excepted from both), declaration held. Exempt food component limited to the reasonable amounts in TD 2026/2 (year ending 31 March 2027: $353/week one adult within Australia; $530 two adults; statutory food amount $42/week adult, $21/week child under 12 deducted first). Within reasonable amounts -> no substantiation of food; above -> full substantiation. Travelling-vs-LAFH boundary: MT 2030's 21-day rule is WITHDRAWN; TR 2021/4 governs, with PCG 2021/3 safe harbour (<= 21 continuous days away and < 90 days at one location in the year) the practical screen.
+
+### Rule 12 -- Record-keeping exemption and loan benchmark
+
+Record-keeping exemption (Pt XIA): an employer with a base year (return lodged, full records kept) whose aggregate fringe benefits amount was <= $10,962 may stop keeping records and pay FBT on the base-year amount -- unless the current year's aggregate exceeds the base-year amount by more than 20%, in which case current-year liability applies and records are needed. In-house benefits (s 62): aggregate taxable value reduced by $1,000 per employee per year; not available for salary-packaged benefits. Loan benefits: taxable value = benchmark rate (8.27%) minus rate actually charged, on the outstanding balance. The benchmark and car-parking figures now publish ONLY on the ATO rates page -- TDs are issued only for cents-per-km and LAFHA food amounts.
+
+---
+
+## Section 6 -- Tier 2 catalogue
+
+### T2-1 -- Not-for-profit capping regimes
+
+**Trigger:** rebatable employer / PBI / hospital. **Action:** Refuse per R-AU-FBT-1; specialist review.
+
+### T2-2 -- Grandfathered PHEV commitments
+
+**Trigger:** PHEV claimed exempt in 2026-27. **Issue:** needs pre-1-April-2025 exempt use AND a binding commitment; refinancing or optional extensions break it. **Action:** obtain the lease/commitment documents; flag for reviewer.
+
+### T2-3 -- Car parking valuation
+
+**Trigger:** threshold conditions met. **Issue:** lowest-fee selection, market valuation, statutory spaces vs actual usage methods. **Action:** flag exposure; escalate valuation choice.
+
+### T2-4 -- Travelling vs living away from home
+
+**Trigger:** extended work travel with allowances. **Issue:** outside the PCG 2021/3 safe harbour (21/90 days) the boundary needs TR 2021/4 analysis; consequences differ sharply (deductible travel allowance vs LAFHA FBT). **Action:** map the pattern of stays; flag for reviewer.
+
+### T2-5 -- Logbook adequacy
+
+**Trigger:** logbook older than 5 years, non-representative period, missing full-year odometer records, or business % looks aggressive vs role. **Action:** flag; default to statutory formula until resolved.
+
+### T2-6 -- Directors' debit loans
+
+**Trigger:** loan benefit computed for a shareholder-employee. **Issue:** Division 7A and FBT interact -- a Div 7A complying loan is generally not a fringe benefit; misclassification double-counts. **Action:** route shareholder loans through the Div 7A analysis first; flag for reviewer.
+
+---
+
+## Section 7 -- Excel working paper template
+
+```
+AUSTRALIA FBT -- WORKING PAPER
+Employer: [name]
+FBT year: 1 April 2026 - 31 March 2027
+Prepared: [date]
+
+CAR REGISTER (PER CAR)
+  Make/model/rego:                [____]
+  Base value (incl GST, less rego/stamp duty): AUD [____]
+  Fourth anniversary of first holding before FBT year start (1/3 reduction): [YES/NO]
+  Days available for private use: [____]/365
+  Method (statutory / operating cost): [____]
+  Logbook valid (date started, <5 yrs): [____]  Business %: [____]
+  Deemed depreciation (25% DV):   AUD [____]
+  Deemed interest (8.27%):        AUD [____]
+  Employee contribution:          AUD [____]
+  Taxable value:                  AUD [____]
+  EV exempt? (BEV/H2, conditions Rule 5): [YES/NO]  Notional TV for RFBA: AUD [____]
+
+ENTERTAINMENT
+  Method (actual / 50-50 / register): [____]
+  Total meal entertainment:       AUD [____]
+  Employee/associate share (actual): AUD [____]
+  Minor benefit exclusions (<$300, infrequent -- actual method only): AUD [____]
+  Taxable value:                  AUD [____]
+  Deduction/GST mirror check (only to extent FBT'd): [____]
+
+OTHER BENEFITS (PER TYPE)
+  Expense payments (net of otherwise-deductible + declarations): AUD [____]
+  Loans (benchmark 8.27% - rate charged):  AUD [____]
+  Property/residual:              AUD [____]
+  LAFHA (excess over TD 2026/2 reasonable + statutory food): AUD [____]
+
+GROSS-UP AND LIABILITY
+  Type 1 aggregate:               AUD [____] x 2.0802 = AUD [____]
+  Type 2 aggregate:               AUD [____] x 1.8868 = AUD [____]
+  Fringe benefits taxable amount: AUD [____]
+  FBT @ 47%:                      AUD [____]
+  Instalments credited:           AUD [____]
+
+RFBA (PER EMPLOYEE, individual fringe benefits amount > $2,000 -- excl car parking,
+non-salary-packaged meal entertainment, pooled cars; INCL exempt EV notional)
+  Employee: [____]  TV: AUD [____]  RFBA (x 1.8868): AUD [____]
+
+REVIEWER FLAGS
+  [List any Tier 2 flags]
+```
+
+---
+
+## Section 8 -- GL reading guide
+
+1. Sweep the accounts in Section 3.1 for the FULL FBT year (1 Apr - 31 Mar) -- not the income year; a June-year GL export misses Q4 of the FBT year.
+2. Entertainment split first: sustenance out, client share identified, per-head amounts for the minor benefit test.
+3. Motor vehicles: match every vehicle carrying costs in the GL to the car register; a car with running costs but no register entry is the classic missed benefit.
+4. Reimbursements and round-dollar payments to employees: expense payment benefits until shown otherwise-deductible.
+5. Directors' debit loans: route via Div 7A first (T2-6).
+
+---
+
+## Section 9 -- Onboarding fallback
+
+If the client provides only a GL and payroll data:
+
+1. Run the Section 3 sweep and build a candidate benefit list by employee
+2. Compute car benefits on statutory formula (no logbook assumed)
+3. Apply minor benefit screens to gifts/events with per-head < $300
+4. Produce a draft liability with every assumption listed
+5. **Flag:** "Draft computed from ledger patterns only. Declarations, logbooks, employee contributions, lease documents and salary packaging arrangements not sighted. Reviewer must confirm before lodgment."
+
+---
+
+## Section 10 -- Reference material
+
+### Key figures (FBT year ending 31 March 2027)
+
+| Item | Value |
+|---|---|
+| FBT rate | 47% |
+| Type 1 / Type 2 gross-up | 2.0802 / 1.8868 |
+| Car statutory rate | 20% |
+| Deemed depreciation / deemed interest | 25% DV / 8.27% |
+| Car parking threshold | $11.48/day |
+| Minor benefit | < $300 + infrequent |
+| Record-keeping exemption | $10,962 |
+| In-house benefit reduction | $1,000/employee (not salary-packaged) |
+| RFBA trigger / factor | > $2,000 taxable value / 1.8868 |
+| LAFHA reasonable food (1 adult, Australia) | $353/week (TD 2026/2); statutory food amount $42 adult / $21 child |
+| EV home charging shortcut | 5.47 c/km (PCG 2024/2) |
+| LCT fuel-efficient threshold (2026-27 sale year) | $91,661 |
+| Instalment trigger | Prior-year FBT >= $3,000 |
+
+### Primary sources (verified 1 August 2026)
+
+| Topic | Source |
+|---|---|
+| Rate, gross-ups, thresholds tables | ato.gov.au -- FBT rates and thresholds (updated 20 May 2026) |
+| Lodgment/payment dates | ato.gov.au -- Lodging your FBT return and paying; agent lodgment program May/June 2027 |
+| Cars: statutory, operating cost, logbooks | FBT guide for employers Ch 7; ato.gov.au rates page (deemed interest 8.27%) |
+| EV exemption, PHEV end, home charging | ato.gov.au -- Electric cars exemption; PCG 2024/2; LCT thresholds 2026-27 |
+| Car parking | ato.gov.au -- Car parking fringe benefits (threshold $11.48; small business exemption) |
+| Minor benefits | s 58P FBTAA; TR 2007/12 |
+| Meal entertainment | Division 9A FBTAA; s 51AEA ITAA36 |
+| Alternative records (from 1 Apr 2024) | ato.gov.au QC 101342 + Commissioner's legislative instruments |
+| LAFHA | TD 2026/2 (25 March 2026); TR 2021/4; PCG 2021/3 |
+| Record-keeping exemption | ato.gov.au rates page Table 6 |
+
+### Test suite
+
+**Test 1:** Type 1 aggregate $10,000, Type 2 aggregate $5,000. -> ($10,000 x 2.0802) + ($5,000 x 1.8868) = $30,236.00; FBT = 47% x $30,236.00 = $14,210.92.
+
+**Test 2:** Car base value $40,000, available 365 days, $1,000 contribution. -> TV $7,000 (Example 1); FBT $6,843.86.
+
+**Test 3:** Same car, fourth anniversary of first holding fell before the start of the FBT year. -> Base value $26,666.67 (one-third reduction); TV = 20% x $26,666.67 - $1,000 = $4,333.33.
+
+**Test 4:** BEV first held 2024, LCT never payable, notional TV $6,500. -> FBT nil; RFBA = $6,500 x 1.8868 = $12,264.20, reported as $12,264 (whole dollars, rounded down); affects income tests only.
+
+**Test 5:** PHEV novated lease started June 2025, claimed exempt. -> NOT exempt (post-1-April-2025 commencement). Full car benefit.
+
+**Test 6:** Staff gift $250 voucher, twice a year. -> Minor benefit candidates: < $300 each and infrequent -> exempt; not deductible if entertainment-type, deductible if property (non-entertainment gift vouchers generally deductible).
+
+**Test 7:** Meal entertainment $28,000, 50/50 elected. -> TV $14,000; deduction and GST credits limited to 50%.
+
+**Test 8:** Interest-free loan $50,000 all year. -> TV = $50,000 x 8.27% = $4,135.
+
+**Test 9:** Employee individual fringe benefits amount exactly $2,000. -> NO RFBA (must exceed $2,000). At $3,000 -> 3,000 x 1.8868 = $5,660.40, reported as $5,660 (whole dollars, rounded down).
+
+**Test 10:** LAFHA one adult, food component $353/week, declaration held, month 8 of 12. -> Food exempt up to $353 less statutory $42; no substantiation needed at or below reasonable amount.
+
+### Prohibitions
+
+- NEVER use the Type 1 gross-up without confirmed GST creditability
+- NEVER treat a PHEV as exempt for 2026-27 without evidence of a pre-1-April-2025 binding commitment
+- NEVER skip RFBA computation for exempt electric cars
+- NEVER claim income tax deductions or GST credits on entertainment beyond the extent FBT applies (50% cap under a 50/50 election)
+- NEVER accept a logbook older than 5 years or a non-12-week period
+- NEVER net an employee contribution against a different benefit
+- NEVER compute NFP capping, ESS, or car parking valuations -- escalate
+- NEVER use the income year (July-June) for FBT -- the FBT year ends 31 March
+- NEVER present figures as definitive
+
+---
+
+## Disclaimer
+
+This skill and its outputs are provided for informational and computational purposes only and do not constitute tax, legal, or financial advice. Open Accountants and its contributors accept no liability for any errors, omissions, or outcomes arising from the use of this skill. All outputs must be reviewed and signed off by a qualified professional (such as a CPA, CA, tax agent, or equivalent licensed practitioner in your jurisdiction) before filing or acting upon.
+
+The most up-to-date, verified version of this skill is maintained at [openaccountants.com](https://www.openaccountants.com). Log in to access the latest version, request a professional review from a licensed accountant, and track updates as tax law changes.

--- a/skills/international/australia/au-fbt.md
+++ b/skills/international/australia/au-fbt.md
@@ -39,7 +39,7 @@ verified_by: pending
 | Car parking daily fee threshold | $11.48 |
 | Minor benefits exemption | Notional taxable value < $300 AND infrequent/irregular (s 58P) |
 | RFBA trigger | Individual fringe benefits amount > $2,000 -> report x 1.8868 via STP (exclusions apply -- Rule 9) |
-| EV exemption | Battery electric / hydrogen cars still exempt (conditions apply); **PHEVs NOT exempt from 1 April 2025** except grandfathered binding commitments |
+| EV exemption | Battery electric / hydrogen cars still exempt (conditions apply); **PHEVs NOT exempt from 1 April 2025** except grandfathered binding commitments; announced wind-back from 1 April 2027, not yet law -- Rule 5 |
 | Contributor | Open Accountants |
 | Validated by | Pending |
 
@@ -193,7 +193,7 @@ Operating costs include actual running costs PLUS deemed depreciation (25% dimin
 
 ### Rule 5 -- Electric vehicle exemption (and its edges)
 
-Exempt if ALL: battery electric or hydrogen fuel cell car (PHEVs excluded from 1 April 2025 -- see below); designed to carry < 1 tonne and < 9 passengers (motorcycles/scooters never qualify); first held AND used on or after 1 July 2022; used by a current employee or their associates; luxury car tax has NEVER been payable on any supply or importation -- check whether LCT was actually payable from the sale documents (the car's LCT value against the fuel-efficient threshold for the financial year of the relevant sale; $91,661 for 2026-27 sales), never by raw price comparison. Associated running costs are also exempt. **The exempt benefit still generates an RFBA** via notional taxable value (Rule 9). PHEV grandfathering: exempt use before 1 April 2025 plus a financially binding commitment continuing on and after that date; optional extensions are not binding.
+Exempt if ALL: battery electric or hydrogen fuel cell car (PHEVs excluded from 1 April 2025 -- see below); designed to carry < 1 tonne and < 9 passengers (motorcycles/scooters never qualify); first held AND used on or after 1 July 2022; used by a current employee or their associates; luxury car tax has NEVER been payable on any supply or importation -- check whether LCT was actually payable from the sale documents (the car's LCT value against the fuel-efficient threshold for the financial year of the relevant sale; $91,661 for 2026-27 sales), never by raw price comparison. Associated running costs are also exempt. **The exempt benefit still generates an RFBA** via notional taxable value (Rule 9). PHEV grandfathering: exempt use before 1 April 2025 plus a financially binding commitment continuing on and after that date; optional extensions are not binding. **Transition warning -- ANNOUNCED, NOT YET LAW:** the 2026-27 Budget (5 May 2026) winds the exemption back from 1 April 2027: full exemption retained only for electric cars costing $75,000 or less (0% statutory formula rate); cars above $75,000 but below the LCT threshold get a 25% discount on FBT payable (15% statutory formula rate); from 1 April 2029 all eligible electric cars drop to the 25% discount. Existing leases are grandfathered. The current exemption runs unchanged to 31 March 2027. Flag any new EV novated lease commencing on or after 1 April 2027 and verify enactment status (ato.gov.au new legislation QC 107286) before advising -- this is an announcement only, not enacted law.
 
 ### Rule 6 -- Car parking
 
@@ -238,6 +238,8 @@ Record-keeping exemption (Pt XIA): an employer with a base year (return lodged, 
 ### T2-2 -- Grandfathered PHEV commitments
 
 **Trigger:** PHEV claimed exempt in 2026-27. **Issue:** needs pre-1-April-2025 exempt use AND a binding commitment; refinancing or optional extensions break it. **Action:** obtain the lease/commitment documents; flag for reviewer.
+
+**Note -- announced, not yet law:** the EV exemption itself narrows for arrangements from 1 April 2027 (Rule 5 transition warning); existing leases are grandfathered under the announcement. For any new EV novated lease commencing on or after 1 April 2027, flag commencement timing and verify enactment status before advising.
 
 ### T2-3 -- Car parking valuation
 
@@ -311,7 +313,7 @@ REVIEWER FLAGS
 
 ## Section 8 -- GL reading guide
 
-1. Sweep the accounts in Section 3.1 for the FULL FBT year (1 Apr - 31 Mar) -- not the income year; a June-year GL export misses Q4 of the FBT year.
+1. Sweep the accounts in Section 3.1 for the FULL FBT year (1 Apr - 31 Mar) -- not the income year; a July-June income-year export misses Q1 of the FBT year (April-June 2026, the prior income year's final quarter). Export 1 April to 31 March exactly.
 2. Entertainment split first: sustenance out, client share identified, per-head amounts for the minor benefit test.
 3. Motor vehicles: match every vehicle carrying costs in the GL to the car register; a car with running costs but no register entry is the classic missed benefit.
 4. Reimbursements and round-dollar payments to employees: expense payment benefits until shown otherwise-deductible.
@@ -359,6 +361,7 @@ If the client provides only a GL and payroll data:
 | Lodgment/payment dates | ato.gov.au -- Lodging your FBT return and paying; agent lodgment program May/June 2027 |
 | Cars: statutory, operating cost, logbooks | FBT guide for employers Ch 7; ato.gov.au rates page (deemed interest 8.27%) |
 | EV exemption, PHEV end, home charging | ato.gov.au -- Electric cars exemption; PCG 2024/2; LCT thresholds 2026-27 |
+| Announced EV wind-back (not yet law) | ato.gov.au new legislation QC 107286 -- Electric car discount (2026-27 Budget, 5 May 2026) |
 | Car parking | ato.gov.au -- Car parking fringe benefits (threshold $11.48; small business exemption) |
 | Minor benefits | s 58P FBTAA; TR 2007/12 |
 | Meal entertainment | Division 9A FBTAA; s 51AEA ITAA36 |

--- a/skills/international/australia/au-super-guarantee.md
+++ b/skills/international/australia/au-super-guarantee.md
@@ -1,21 +1,23 @@
 ---
 name: au-super-guarantee
 description: >
-  Use this skill whenever asked about Australian Superannuation Guarantee (SG) obligations, voluntary super contributions, concessional and non-concessional caps, Division 293 tax, government co-contribution, spouse contribution tax offset, carry-forward rules, or any question about super for sole traders or employers. Trigger on phrases like "how much super do I pay", "SG rate", "super guarantee", "concessional cap", "Division 293", "salary sacrifice super", "personal super contribution deduction", "co-contribution", "BPAY super", "ATO super clearing house", "super fund contribution", or any question about Australian superannuation. Also trigger when classifying bank statement transactions showing super fund payments, BPAY super debits, or ATO Small Business Super Clearing House (SBSCH) payments. ALWAYS read this skill before touching any SG-related work.
-version: 2.0
+  Use this skill whenever asked about Australian Superannuation Guarantee (SG) obligations, payday super deadlines, voluntary super contributions, concessional and non-concessional caps, Division 293 tax, government co-contribution, spouse contribution tax offset, carry-forward rules, or any question about super for sole traders or employers. Trigger on phrases like "how much super do I pay", "SG rate", "super guarantee", "payday super", "7 business days super", "SG shortfall", "concessional cap", "Division 293", "salary sacrifice super", "personal super contribution deduction", "co-contribution", "BPAY super", "super clearing house", "super fund contribution", or any question about Australian superannuation. Also trigger when classifying bank statement transactions showing super fund payments, BPAY super debits, or clearing house payments. ALWAYS read this skill before touching any SG-related work.
+version: 3.0
 jurisdiction: AU
-tax_year: 2024
-tax_year_notes: "2024-25"
+tax_year: 2026
+tax_year_notes: "2026-27 (payday super regime; quarterly rules apply to earnings paid up to 30 June 2026)"
 tier: 2
-last_updated: 2026-07-04
+last_updated: 2026-08-01
 category: international
 depends_on:
   - social-contributions-workflow-base
 ---
 
-# Australia Superannuation Guarantee (SG) -- Sole Trader & Employer Skill v2.0
+# Australia Superannuation Guarantee (SG) -- Sole Trader & Employer Skill v3.0
 
 > **General reference only.** This skill is general tax/accounting reference material for AI-assisted workflows. It has not been reviewed for any specific person's facts, documents, elections, deadlines, residency, filing status, or local procedures. Do not rely on it to file, pay, amend, or take a tax position without review by a qualified professional in the relevant jurisdiction.
+
+> **Regime change at 1 July 2026 (Payday Super).** SG timing is determined by WHEN earnings are PAID, not when the work was done. Earnings paid from 1 July 2026: payday super rules (SG received by the fund within 7 business days of each payday). Earnings paid up to 30 June 2026: old quarterly rules (final quarterly deadline was 28 July 2026 for the June 2026 quarter). Both regimes appear in 2026 bank statements -- classify by payment date.
 
 ## Section 1 -- Quick reference
 
@@ -24,23 +26,24 @@ depends_on:
 | Field | Value |
 |---|---|
 | Country | Australia |
-| Primary Legislation | Superannuation Guarantee (Administration) Act 1992 (SGAA 1992) |
-| Supporting Legislation | SIS Act 1993; ITAA 1997 Div 290-293; Co-contribution Act 2003 |
+| Primary Legislation | Superannuation Guarantee (Administration) Act 1992 (SGAA 1992), as amended by Treasury Laws Amendment (Payday Superannuation) Act 2025 (No. 57 of 2025) and Superannuation Guarantee Charge Amendment Act 2025 (No. 58 of 2025) |
+| Supporting Legislation | SIS Act 1993; ITAA 1997 Div 290-293; Treasury Laws Amendment (Payday Superannuation) Regulations 2026 (F2026L00133) |
 | Tax Authority | Australian Taxation Office (ATO) |
-| Tax Year | 2024-25 (1 July 2024 -- 30 June 2025) |
+| Tax Year | 2026-27 (1 July 2026 -- 30 June 2027) |
 | Currency | AUD only |
-| SG rate (2024-25) | 11.5% (12% from 1 July 2025) |
-| Maximum contribution base (quarterly) | $65,070 |
-| Concessional cap (2024-25) | $30,000 |
-| Non-concessional cap (2024-25) | $120,000 ($360,000 bring-forward) |
-| General transfer balance cap | $1,900,000 |
-| Division 293 threshold | $250,000 |
-| SG quarterly deadlines | 28 Oct, 28 Jan, 28 Apr, 28 Jul |
+| SG rate (2026-27) | 12% (terminal rate; first applied 1 July 2025) |
+| SG deadline (payday super) | Contribution RECEIVED by employee's fund within 7 business days after payday |
+| Maximum contribution base (2026-27) | **ANNUAL**: $270,830 of qualifying earnings (max SG $32,499.60/year). The quarterly MCB is abolished for earnings paid from 1 July 2026 |
+| Concessional cap (2026-27) | $32,500 |
+| Non-concessional cap (2026-27) | $130,000 ($390,000 bring-forward) |
+| General transfer balance cap (2026-27) | $2,100,000 |
+| Division 293 threshold | $250,000 (frozen) |
+| ATO Small Business Super Clearing House | **CLOSED PERMANENTLY 1 July 2026** |
 | Sole trader SG to self | NO obligation -- voluntary only |
-| Payday Super | Commences 1 July 2026 |
+| First-year compliance | PCG 2026/1: supportive ATO approach through 2026-27 for employers paying each payday and fixing errors quickly |
 | Contributor | Open Accountants |
 | Validated by | Pending |
-| Validation date | April 2026 |
+| Validation date | Pending |
 
 **Conservative defaults:**
 
@@ -48,7 +51,9 @@ depends_on:
 |---|---|
 | Unknown entity structure | Ask -- sole trader vs company affects SG obligation |
 | Unknown whether sole trader has employees | Ask -- determines SG requirement |
-| Unknown SG rate year | 2024-25 = 11.5%; 2025-26 = 12% |
+| Unknown payment date vs 1 July 2026 | Ask -- decides quarterly vs payday regime |
+| Unknown SG rate year | 2024-25 = 11.5%; 2025-26 onwards = 12% |
+| Unknown YTD qualifying earnings vs $270,830 | Assume below cap; flag to confirm before stopping SG |
 | Unknown TSB for carry-forward | Assume >= $500,000 (no carry-forward); ask client |
 | Unknown s 290-150 notice status | Assume NOT lodged; warn about deadline |
 | Unknown contractor vs employee | Flag for reviewer -- multi-factor test |
@@ -59,11 +64,11 @@ depends_on:
 
 ### Required inputs
 
-**Minimum viable** -- entity structure (sole trader / company / trust / partnership), whether client has employees, OTE per quarter (for employers), and voluntary contribution intent (for sole traders).
+**Minimum viable** -- entity structure (sole trader / company / trust / partnership), whether client has employees, pay frequency and payday dates, qualifying earnings per payday (for employers), and voluntary contribution intent (for sole traders).
 
-**Recommended** -- bank statements showing super fund debits, employee roster with OTE, TSB at 30 June prior year, taxable income for Division 293.
+**Recommended** -- bank statements showing super fund debits, payroll register with per-payday qualifying earnings and YTD totals, TSB at 30 June prior year, taxable income for Division 293.
 
-**Ideal** -- complete activity statement data, super fund member statements, s 290-150 notice copies, ATO online account showing contribution caps.
+**Ideal** -- complete STP reporting data, super fund member statements showing receipt dates, s 290-150 notice copies, ATO online account showing contribution caps.
 
 ### Refusal catalogue
 
@@ -73,7 +78,7 @@ depends_on:
 
 **R-AU-SG-3 -- Family law splits.** *Trigger:* super splitting in divorce. *Message:* "Family law superannuation splits require legal advice. Out of scope."
 
-**R-AU-SG-4 -- SGC penalty computation.** *Trigger:* client has missed SG deadlines and asks about SGC. *Message:* "Super Guarantee Charge computation should be escalated to a qualified practitioner. SGC includes shortfall + 10% nominal interest + $20 per employee per quarter, and is NOT tax-deductible."
+**R-AU-SG-4 -- SGC computation.** *Trigger:* client has missed payday super deadlines and asks about the Super Guarantee Charge. *Message:* "SGC under the payday super regime is ATO-assessed per payday from STP and fund data -- it is not self-assessed and should be escalated to a qualified practitioner. Components: final SG shortfall + notional earnings (GIC rate, compounding daily) + administrative uplift + any choice loading. Note the NEW SGC (payday regime) is tax-deductible; the OLD quarterly-regime SGC remains non-deductible."
 
 ---
 
@@ -99,6 +104,8 @@ This is the deterministic pre-classifier for bank statement transactions related
 | BT SUPER | EXCLUDE -- super contribution | Retail fund |
 | SMSF (+ fund name) | EXCLUDE -- super contribution | Self-managed super fund |
 
+Under payday super, employer SG debits track the PAY CYCLE (weekly/fortnightly/monthly), not quarters. Frequent small super debits are the new normal, not an anomaly.
+
 ### 3.2 BPAY super payments
 
 | Pattern | Treatment | Notes |
@@ -106,19 +113,20 @@ This is the deterministic pre-classifier for bank statement transactions related
 | BPAY SUPER, BPAY (+ fund name) | EXCLUDE -- super contribution | BPAY is common payment method for super |
 | BPAY (biller code matching known super fund) | EXCLUDE -- super contribution | Check BPAY biller code |
 
-### 3.3 ATO Small Business Super Clearing House (SBSCH)
+### 3.3 Clearing house payments
 
 | Pattern | Treatment | Notes |
 |---|---|---|
-| ATO SUPER, ATO CLEARING HOUSE | EXCLUDE -- super contribution | Small businesses (<20 employees) can pay SG via ATO SBSCH |
-| ATO SBSCH | EXCLUDE -- super contribution | Clearing house payment |
-| SMALL BUSINESS SUPERANNUATION | EXCLUDE -- super contribution | ATO SBSCH reference |
+| (payroll software / clearing house name, e.g. BEAM, SUPERCHOICE, CLICKSUPER, WRKR) | EXCLUDE -- super contribution | Commercial clearing houses; SG for multiple employees in one debit |
+| ATO SUPER, ATO CLEARING HOUSE, ATO SBSCH, SMALL BUSINESS SUPERANNUATION | EXCLUDE -- super contribution (HISTORICAL) | ATO SBSCH **closed permanently 1 July 2026** (closed to new users 1 Oct 2025). Valid only on statements dated before July 2026; payments sent on/after 1 July 2026 were returned |
+
+**Timing trap:** a contribution is on time only when RECEIVED BY THE FUND -- receipt by a clearing house does not stop the clock. Clearing-house processing time is the employer's risk.
 
 ### 3.4 Super guarantee charge (SGC -- late/missed SG)
 
 | Pattern | Treatment | Notes |
 |---|---|---|
-| ATO SGC, SUPER GUARANTEE CHARGE | EXCLUDE -- SGC payment | Late SG penalty payment to ATO |
+| ATO SGC, SUPER GUARANTEE CHARGE | EXCLUDE -- SGC payment | ATO-assessed under payday regime; payment due on assessment day. New-regime SGC is deductible; old-regime (pre-Jul-2026 quarters) SGC is not |
 
 ### 3.5 Salary and wages (not super)
 
@@ -138,47 +146,47 @@ This is the deterministic pre-classifier for bank statement transactions related
 
 ## Section 4 -- Worked examples
 
-Six bank statement classifications for a hypothetical Australian sole trader with 2 employees.
+Six classifications for a hypothetical Australian employer with 2 employees, fortnightly payroll, during 2026-27.
 
-### Example 1 -- Quarterly SG payment to employee's super fund
+### Example 1 -- Payday super contribution following a fortnightly pay run
 
 **Input line:**
-`28.10.2024 ; AUSTRALIAN SUPER ; DEBIT ; SG Q1 2024-25 EMPLOYEE A ; -2,300.00 ; AUD`
+`24.07.2026 ; AUSTRALIAN SUPER ; DEBIT ; SUPER PPE 17/07 EMPLOYEE A ; -480.00 ; AUD`
 
 **Reasoning:**
-Matches "AUSTRALIAN SUPER" (pattern 3.1). Amount $2,300 = $20,000 OTE x 11.5% SG. This is the Q1 (Jul-Sep) SG contribution for Employee A, paid by the 28 October deadline. Tax-deductible for the employer.
+Matches "AUSTRALIAN SUPER" (pattern 3.1). Payday was Friday 17 July 2026; $480.00 = $4,000 qualifying earnings x 12%. Fund receipt on 24 July is 5 business days after payday -- inside the 7-business-day window. Tax-deductible for the employer.
 
-**Classification:** EXCLUDE -- SG contribution for employee. Tax-deductible business expense.
+**Classification:** EXCLUDE -- SG contribution for employee, on time under payday super. Tax-deductible business expense.
 
 ### Example 2 -- Personal voluntary super contribution (sole trader)
 
 **Input line:**
-`15.05.2025 ; BPAY HOSTPLUS ; DEBIT ; PERSONAL CONTRIBUTION ; -10,000.00 ; AUD`
+`15.05.2027 ; BPAY HOSTPLUS ; DEBIT ; PERSONAL CONTRIBUTION ; -10,000.00 ; AUD`
 
 **Reasoning:**
-Matches "BPAY" + "HOSTPLUS" (pattern 3.2). Sole trader making a personal super contribution. Whether this is concessional (deductible) depends on whether the s 290-150 notice is lodged and acknowledged. If notice lodged: $10,000 concessional contribution, tax-deductible, taxed at 15% in the fund. If no notice: non-concessional, no deduction.
+Matches "BPAY" + "HOSTPLUS" (pattern 3.2). Sole trader making a personal super contribution. Whether this is concessional (deductible) depends on whether the s 290-150 notice is lodged and acknowledged. If notice lodged: $10,000 concessional contribution, tax-deductible, taxed at 15% in the fund, counts toward the $32,500 cap. If no notice: non-concessional, no deduction.
 
 **Classification:** EXCLUDE -- personal super contribution. Deductibility depends on s 290-150 notice status. Flag: "Has the Notice of Intent to Claim a Deduction been lodged with the fund?"
 
-### Example 3 -- ATO Small Business Clearing House payment
+### Example 3 -- Commercial clearing house payment (SBSCH is gone)
 
 **Input line:**
-`27.01.2025 ; ATO SUPER CLEARING HOUSE ; DEBIT ; SG Q2 ALL EMPLOYEES ; -4,600.00 ; AUD`
+`21.08.2026 ; SUPERCHOICE CLEARING ; DEBIT ; SUPER PPE 14/08 ALL EMPLOYEES ; -960.00 ; AUD`
 
 **Reasoning:**
-Matches "ATO SUPER CLEARING HOUSE" (pattern 3.3). Small business paying SG for all employees via the ATO SBSCH. The clearing house distributes to each employee's nominated fund. Q2 (Oct-Dec) payment by 28 January deadline.
+Commercial clearing house debit covering both employees for the 14 August payday (pattern 3.3). The ATO Small Business Super Clearing House closed permanently on 1 July 2026, so any post-June-2026 clearing house payment is a commercial provider or payroll-software-integrated service. On-time test = fund receipt within 7 business days of the 14 August payday, NOT the clearing house debit date -- flag if fund receipt confirmation is unavailable.
 
-**Classification:** EXCLUDE -- SG contributions via SBSCH. Tax-deductible.
+**Classification:** EXCLUDE -- SG contributions via commercial clearing house. Tax-deductible. Flag fund-receipt timing for confirmation.
 
-### Example 4 -- OTE above maximum contribution base
+### Example 4 -- Annual maximum contribution base reached
 
 **Input line:**
-`28.04.2025 ; REST SUPER ; DEBIT ; SG Q3 EMPLOYEE B ; -7,483.05 ; AUD`
+(no super debit present for Employee B for the 2 April 2027 payday)
 
 **Reasoning:**
-Matches "REST SUPER" (pattern 3.1). Amount $7,483.05 = $65,070 (max contribution base) x 11.5%. Employee B's OTE for Q3 exceeded $65,070, so SG is capped.
+Employee B's year-to-date qualifying earnings passed $270,830 in March 2027 (large bonus in Q3). Under the ANNUAL maximum contribution base, once YTD qualifying earnings for 2026-27 reach $270,830, no further SG is required for the rest of the financial year. Maximum SG for the year = $32,499.60. Note front-loaded income exhausts the cap early -- this replaces the old per-quarter cap logic entirely.
 
-**Classification:** EXCLUDE -- SG contribution (capped at maximum contribution base).
+**Classification:** No SG expected for Employee B for remaining 2026-27 paydays. Verify YTD qualifying earnings ledger supports the cutoff.
 
 ### Example 5 -- Sole trader asking about self-SG
 
@@ -193,10 +201,10 @@ Sole traders have NO SG obligation to themselves. Drawings are not salary. If th
 ### Example 6 -- ATO tax payment (NOT super)
 
 **Input line:**
-`28.10.2024 ; ATO ; DEBIT ; IAS SEP QTR ; -3,500.00 ; AUD`
+`28.10.2026 ; ATO ; DEBIT ; IAS SEP QTR ; -3,500.00 ; AUD`
 
 **Reasoning:**
-Matches "ATO" + "IAS" (pattern 3.6). This is an Instalment Activity Statement (PAYG/GST) payment, NOT a super contribution.
+Matches "ATO" + "IAS" (pattern 3.6). This is an Instalment Activity Statement (PAYG/GST) payment, NOT a super contribution. (Quarterly IAS/BAS cycles continue -- only SG moved to payday timing.)
 
 **Classification:** EXCLUDE -- tax payment. NOT super.
 
@@ -204,59 +212,76 @@ Matches "ATO" + "IAS" (pattern 3.6). This is an Instalment Activity Statement (P
 
 ## Section 5 -- Tier 1 rules
 
-### Rule 1 -- SG formula
+### Rule 1 -- SG formula (payday super)
 
 ```
-SG per quarter = min(Employee_OTE_for_quarter, $65,070) x 11.5%
+remaining_base = max(0, $270,830 - YTD_qualifying_earnings_before_this_payday)
+SG per payday  = 12% x min(Qualifying_earnings_paid_this_payday, remaining_base)
 ```
+
+SG applies only to the first $270,830 of qualifying earnings paid in the financial year -- the payday that crosses the base attracts SG only on the portion beneath it, and later paydays attract none. Annual maximum SG per employee: exactly $32,499.60.
 
 No $450/month threshold (removed 1 July 2022). All employees eligible.
 
 ### Rule 2 -- SG rate
 
-2024-25: 11.5%. 2025-26 onwards: 12%.
+2024-25: 11.5%. 2025-26 onwards: 12% (terminal rate).
 
-### Rule 3 -- Quarterly deadlines
+### Rule 3 -- Payment deadline (earnings paid from 1 July 2026)
 
-| Quarter | Period | Due |
-|---|---|---|
-| Q1 | 1 Jul - 30 Sep | 28 October |
-| Q2 | 1 Oct - 31 Dec | 28 January |
-| Q3 | 1 Jan - 31 Mar | 28 April |
-| Q4 | 1 Apr - 30 Jun | 28 July |
+A contribution is on time only if it is **received by the employee's super fund**, with the information needed to allocate it to the member account, **within 7 business days after payday** (the "QE day").
 
-Late/missed: triggers Super Guarantee Charge (SGC). SGC is NOT tax-deductible.
+- **Business day** = any day except Saturday, Sunday, or a public holiday applying to the WHOLE of any Australian state or territory. A territory-wide holiday anywhere in Australia extends the deadline for ALL employers; part-of-state holidays do not.
+- **New employee (or new fund):** first contribution due within 20 business days of the relevant QE day; later paydays revert to 7. If the extended date overlaps the next payday's deadline, the later contribution inherits the extended date.
+- **Out-of-cycle payments** (e.g. bonuses, per LI 2026/20): SG rides with the next regular payday's 7-business-day deadline.
+- **Exceptional circumstances** (ATO class determination, e.g. natural disasters): later of 20 business days after the QE day or 20 business days after the determination.
+- Funds must allocate or return contributions within 3 business days (down from 20).
 
-### Rule 4 -- Sole traders have NO SG obligation to themselves
+**Legacy:** earnings paid up to 30 June 2026 keep the quarterly deadlines (28 Oct / 28 Jan / 28 Apr / 28 Jul); the final quarterly deadline was 28 July 2026.
+
+### Rule 4 -- Maximum contribution base is ANNUAL from 2026-27
+
+$270,830 of qualifying earnings for 2026-27 (formula: concessional cap x 100 / 12, rounded down to nearest $10 = $32,500 x 100 / 12). Applied on a year-to-date basis per the Rule 1 formula: SG is payable on qualifying earnings up to the base, the crossing payday is prorated, and nothing is payable on earnings beyond it. Maximum SG per employee per year: $32,499.60. (Last quarterly MCB: $62,500/quarter in 2025-26.)
+
+### Rule 5 -- Sole traders have NO SG obligation to themselves
 
 Drawings are not salary. Only voluntary contributions. Company directors paying themselves a salary: YES SG applies (director is employee of company).
 
-### Rule 5 -- Concessional contributions cap
+### Rule 6 -- Concessional contributions cap
 
-$30,000 (2024-25). Includes employer SG + salary sacrifice + personal deductible contributions (with s 290-150 notice). Excess included in assessable income at marginal rate (with 15% offset).
+$32,500 (2026-27; indexed up from $30,000 on 1 July 2026). Includes employer SG + salary sacrifice + personal deductible contributions (with s 290-150 notice). Excess included in assessable income at marginal rate (with 15% offset).
 
-### Rule 6 -- Carry-forward unused concessional cap
+### Rule 7 -- Carry-forward unused concessional cap
 
-Available from 2018-19 onward, up to 5 prior years, IF TSB < $500,000 at 30 June prior year. If TSB >= $500,000: no carry-forward.
+Up to 5 prior years' unused cap, IF TSB < $500,000 at 30 June prior year (threshold fixed in legislation, not indexed). If TSB >= $500,000: no carry-forward.
 
-### Rule 7 -- Non-concessional cap
+### Rule 8 -- Non-concessional cap
 
-$120,000 (2024-25). Bring-forward: $360,000 (3 years) if TSB < $1,660,000. TSB >= $1,900,000: nil cap.
+$130,000 (2026-27; 4 x concessional cap). Bring-forward tiers by TSB at 30 June 2026: < $1.84m -> $390,000 over 3 years; $1.84m to < $1.97m -> $260,000 over 2 years; $1.97m to < $2.1m -> $130,000 (no bring-forward); >= $2.1m -> nil.
 
-### Rule 8 -- s 290-150 notice (personal contribution deduction)
+### Rule 9 -- s 290-150 notice (personal contribution deduction)
 
 Must lodge Notice of Intent to Claim a Deduction with the super fund AND receive acknowledgement BEFORE the earlier of: lodging the tax return, or end of following financial year. If not lodged: contribution stays non-concessional, NO deduction.
 
-### Rule 9 -- Division 293 (additional 15% for high earners)
+### Rule 10 -- Division 293 (additional 15% for high earners)
 
 ```
 Div 293 income = taxable income + concessional contributions
 If > $250,000: Div 293 tax = 15% x lesser of (concessional contributions, excess over $250,000)
 ```
 
-### Rule 10 -- Government co-contribution
+Threshold frozen at $250,000 (not indexed).
 
-Max $500. Income < $60,400. Matching rate: 50c per $1 of non-concessional contribution (max $1,000 contributed). Reduces above $45,400. Automatic upon tax return lodgement.
+### Rule 11 -- Redesigned SGC (QE days from 1 July 2026)
+
+ATO-assessed per payday (no SG statement is lodged; ATO matches STP against fund reporting). Components:
+
+1. **Final SG shortfall** -- unpaid SG on qualifying earnings at 12%
+2. **Notional earnings** -- GIC-rate interest on the shortfall, compounding daily from the day after the deadline
+3. **Administrative uplift** -- starts at 60% of (shortfall + notional earnings); reduced 20 points for a clean 2-year history and up to 40 points for voluntary disclosure (0% if disclosed within 30 days with clean history)
+4. **Choice loading** -- 25% of contributions where choice-of-fund rules breached, capped at $1,200 per notice period
+
+Payment due the day the assessment is made. Unpaid 28 days after assessment -> Notice to Pay -> late payment penalty of 25% or 50% of unpaid SGC. **The new SGC is tax-deductible** (all four components); GIC on late SGC and the late payment penalty are not, and old-regime SGC (quarters before 1 July 2026) remains non-deductible. First-year approach: PCG 2026/1.
 
 ---
 
@@ -270,7 +295,7 @@ Max $500. Income < $60,400. Matching rate: 50c per $1 of non-concessional contri
 
 ### T2-2 -- Multiple employers exceeding concessional cap
 
-**Trigger:** Individual has two employers both paying SG. Combined may exceed $30,000.
+**Trigger:** Individual has two employers both paying SG. Combined may exceed $32,500.
 **Issue:** Neither employer at fault. Individual bears excess contributions tax.
 **Action:** Flag for reviewer to assess salary sacrifice adjustment.
 
@@ -292,6 +317,18 @@ Max $500. Income < $60,400. Matching rate: 50c per $1 of non-concessional contri
 **Issue:** Missing the deadline is irreversible -- contribution stays non-concessional.
 **Action:** Urgent flag. Confirm notice status before lodging return.
 
+### T2-6 -- Straddle-period statements (2026 changeover)
+
+**Trigger:** Bank statement spans 1 July 2026.
+**Issue:** Quarterly-pattern SG debits (e.g. a 28 July 2026 payment for the June quarter) and payday-pattern debits both appear and are BOTH correct for their periods.
+**Action:** Classify by the period the payment relates to; do not flag the final quarterly payment as late-pattern.
+
+### T2-7 -- Clearing house lag near the 7-day boundary
+
+**Trigger:** Employer pays a clearing house 4-5 business days after payday.
+**Issue:** Fund receipt, not clearing house receipt, is the on-time test; processing lag can push receipt past day 7.
+**Action:** Flag for reviewer; recommend earlier remittance or payroll-integrated payment.
+
 ---
 
 ## Section 7 -- Excel working paper template
@@ -299,22 +336,24 @@ Max $500. Income < $60,400. Matching rate: 50c per $1 of non-concessional contri
 ```
 AUSTRALIA SUPERANNUATION -- WORKING PAPER
 Client: [name]
-Financial Year: [2024-25]
+Financial Year: [2026-27]
 Prepared: [date]
 
 ENTITY AND STRUCTURE
   Entity type:                    [Sole trader / Company / Trust / Partnership]
   Has employees:                  [YES/NO]
+  Pay frequency:                  [Weekly / Fortnightly / Monthly]
   Sole trader contributing for self: [YES/NO -- voluntary only]
 
-EMPLOYER SG (PER EMPLOYEE PER QUARTER)
+EMPLOYER SG (PER EMPLOYEE PER PAYDAY)
   Employee name:                  [____]
-  OTE for quarter:                AUD [____]
-  Capped OTE (max $65,070):       AUD [____]
-  SG rate:                        11.5%
+  Payday (QE day):                [____]
+  Qualifying earnings this payday: AUD [____]
+  YTD qualifying earnings:        AUD [____]  (SG only on QE up to $270,830 YTD; prorate the crossing payday per Rule 1)
+  SG rate:                        12%
   SG contribution:                AUD [____]
-  Due date:                       [____]
-  Paid on time:                   [YES/NO]
+  Fund receipt deadline (QE day + 7 business days): [____]
+  Fund receipt confirmed:         [YES/NO -- clearing house receipt does NOT count]
 
 PERSONAL CONTRIBUTIONS (SOLE TRADER)
   Personal contribution:          AUD [____]
@@ -324,11 +363,11 @@ PERSONAL CONTRIBUTIONS (SOLE TRADER)
   Tax deduction claimed:          AUD [____]
 
 CONTRIBUTION CAP CHECK
-  Concessional cap:               AUD 30,000
+  Concessional cap:               AUD 32,500
   Total concessional contributions: AUD [____]
   Carry-forward available:        AUD [____]
   Remaining cap:                  AUD [____]
-  Non-concessional cap:           AUD [____]
+  Non-concessional cap:           AUD 130,000
   Total non-concessional:         AUD [____]
 
 DIVISION 293
@@ -345,30 +384,31 @@ REVIEWER FLAGS
 
 ## Section 8 -- Bank statement reading guide
 
-### How super payments appear on Australian bank statements
+### How super payments appear on Australian bank statements (2026-27)
 
 **Direct fund payments:**
 - Description: Fund name (e.g., "AUSTRALIAN SUPER", "HOSTPLUS", "REST SUPER")
-- Timing: Quarterly (by 28th of month after quarter end) or more frequently
-- Amount: SG amount per employee or personal contribution amount
+- Timing: Tracks the pay cycle -- weekly/fortnightly/monthly debits within days of each payday
+- Amount: 12% of that payday's qualifying earnings per employee, or personal contribution amount
 
 **BPAY payments:**
 - Description: "BPAY" + biller name or code
 - Timing: Any time
 - Amount: SG or personal contribution
 
-**ATO Super Clearing House:**
-- Description: "ATO SUPER", "ATO CLEARING HOUSE", "SBSCH"
-- Timing: Quarterly
+**Clearing house payments:**
+- Description: Commercial clearing house or payroll software name (SBSCH references only on pre-July-2026 statements)
+- Timing: Within days of each payday
 - Amount: Combined SG for all employees
 
 **Key identification tips:**
 1. Super fund names are the most reliable identifier
 2. BPAY to a super fund shows biller code -- cross-reference with fund
-3. ATO SBSCH is a single payment covering all employees
-4. Sole trader personal contributions look like any other fund payment -- context required
-5. SGC payments go to ATO, not to the fund
-6. Payday Super (from 1 July 2026) will change timing to each payday
+3. Frequent small super debits aligned to paydays = payday super normal, not an anomaly
+4. Quarterly-sized lumps after June 2026 (other than the final 28 July 2026 payment) = possible late-regime confusion; flag
+5. Sole trader personal contributions look like any other fund payment -- context required
+6. SGC payments go to ATO, not to the fund
+7. "ATO SBSCH" on a statement dated after June 2026 = returned payment or misclassification; investigate
 
 ---
 
@@ -377,68 +417,91 @@ REVIEWER FLAGS
 If the client provides only a bank statement:
 
 1. **Scan for super fund debits** -- match against fund names in Section 3
-2. **Identify SG vs personal contributions** -- quarterly amounts aligned with deadlines = likely SG; ad hoc amounts = likely personal
-3. **Check for ATO SBSCH** -- indicates employer using clearing house
-4. **Sum quarterly SG payments** -- compare against expected OTE x 11.5% to verify completeness
-5. **Flag:** "Super contribution classification derived from bank statement patterns. Employee OTE, s 290-150 notice status, and TSB have not been independently verified. Reviewer must confirm before tax return lodgement."
+2. **Identify SG vs personal contributions** -- payday-aligned amounts = likely SG; ad hoc amounts = likely personal
+3. **Check debit cadence against pay cycle** -- SG debits should follow every payday from July 2026
+4. **Sum SG debits per employee** -- compare against expected qualifying earnings x 12% YTD to verify completeness
+5. **Flag:** "Super contribution classification derived from bank statement patterns. Fund receipt dates, qualifying earnings, s 290-150 notice status, and TSB have not been independently verified. Reviewer must confirm before tax return lodgement."
 
 ---
 
 ## Section 10 -- Reference material
 
-### Key rates and thresholds (2024-25)
+### Key rates and thresholds (2026-27)
 
-| Item | Value |
-|---|---|
-| SG rate | 11.5% |
-| Max contribution base (quarterly) | $65,070 |
-| Maximum SG per quarter | $7,483.05 |
-| Concessional cap | $30,000 |
-| Non-concessional cap | $120,000 |
-| Bring-forward (3 years) | $360,000 |
-| Div 293 threshold | $250,000 |
-| Co-contribution max | $500 |
-| Co-contribution lower threshold | $45,400 |
-| Co-contribution upper threshold | $60,400 |
-| LISTO threshold | $37,000 |
-| Spouse offset max | $540 |
-| Transfer balance cap | $1,900,000 |
+| Item | Value | Movement at 1 Jul 2026 |
+|---|---|---|
+| SG rate | 12% | unchanged (terminal since 1 Jul 2025) |
+| Maximum contribution base | $270,830 (ANNUAL) | replaced quarterly $62,500 |
+| Maximum SG per employee per year | $32,499.60 | new basis |
+| Concessional cap | $32,500 | up from $30,000 |
+| Non-concessional cap | $130,000 | up from $120,000 |
+| Bring-forward (3 years, TSB < $1.84m) | $390,000 | up from $360,000 |
+| General transfer balance cap | $2,100,000 | up from $2,000,000 |
+| Carry-forward TSB threshold | $500,000 | unchanged (not indexed) |
+| Div 293 threshold | $250,000 | unchanged (frozen) |
+| Co-contribution max | $500 | unchanged (frozen) |
+| Co-contribution lower threshold | $49,293 | up from $47,488 |
+| Co-contribution upper threshold | $64,293 | up from $62,488 |
+| LISTO threshold / max | $37,000 / $500 | unchanged (frozen) |
+| Spouse offset max / shade-out | $540 / $37,000-$40,000 | unchanged (frozen) |
 
 ### LISTO (Low Income Super Tax Offset)
 
-Adjusted taxable income <= $37,000: 15% of concessional contributions, max $500. Paid directly into super fund by ATO.
+Adjusted taxable income <= $37,000: 15% of concessional contributions, max $500 (min $10). Paid directly into super fund by ATO.
 
 ### Spouse contribution tax offset
 
-Max $540 (18% of $3,000). Full offset if spouse income <= $37,000. Nil if spouse income >= $40,000.
+Max $540 (18% of $3,000). Full offset if spouse income <= $37,000; nil from $40,000. Spouse must have TSB below the general transfer balance cap and not exceed their non-concessional cap.
+
+### Primary sources (all figures verified 1 August 2026)
+
+| Topic | Source |
+|---|---|
+| SG rate, MCB tables | ato.gov.au -- Key superannuation rates and thresholds: Super guarantee (Tables 21, 23, 24) |
+| Payday super deadlines, business-day definition, exceptions | ato.gov.au -- Payment deadlines for payday super (QC 105846) |
+| Annual MCB mechanics and formula | ato.gov.au -- Maximum contributions base (QC 105844) |
+| Redesigned SGC components, deductibility, penalties | ato.gov.au -- What happens if you don't pay super correctly (payday super) + About payday super (QC 105838) |
+| Contribution caps | ato.gov.au -- Contributions caps (QC 18123) |
+| Transfer balance cap | ato.gov.au -- General transfer balance cap 2026-27 (SMSF newsroom) |
+| Co-contribution thresholds | ato.gov.au -- Government contributions (Table 25) |
+| SBSCH closure | ato.gov.au -- The SBSCH has closed permanently (QC 107658) |
+| Legislation | Treasury Laws Amendment (Payday Superannuation) Act 2025 (No. 57/2025); Superannuation Guarantee Charge Amendment Act 2025 (No. 58/2025); F2026L00133 |
+| First-year compliance | PCG 2026/1 |
 
 ### Test suite
 
-**Test 1:** Employee OTE $20,000/quarter, 2024-25. -> SG = $2,300.
+**Test 1:** Employee qualifying earnings $4,000, fortnightly payday, 2026-27. -> SG = $480.00 per payday, fund receipt within 7 business days.
 
-**Test 2:** Employee OTE $80,000/quarter. -> SG = $7,483.05 (capped).
+**Test 2:** Employee YTD qualifying earnings $268,000 before a $10,000 payday in March 2027. -> Crossing payday SG = 12% x min($10,000, $270,830 - $268,000) = 12% x $2,830 = $339.60. All later 2026-27 paydays: $0. Year SG total = exactly $32,499.60.
 
-**Test 3:** Sole trader contributes $25,000, lodges s 290-150. TSB $200,000. -> $25,000 concessional. Deduction $25,000. Within cap.
+**Test 3:** Sole trader contributes $25,000, lodges s 290-150. TSB $200,000. -> $25,000 concessional. Deduction $25,000. Within $32,500 cap.
 
 **Test 4:** Taxable income $260,000, concessional $30,000. -> Div 293 income $290,000. Div 293 tax = 15% x $30,000 = $4,500.
 
-**Test 5:** TSB $400,000. Unused cap: $5,000 (2021-22) + $10,000 (2022-23) + $15,000 (2023-24). -> Available cap = $60,000.
+**Test 5:** TSB $400,000. Unused cap: $5,000 (2023-24) + $10,000 (2024-25) + $15,000 (2025-26). -> Available 2026-27 cap = $32,500 + $30,000 = $62,500.
 
-**Test 6:** Income $50,000, non-concessional $1,000. -> Co-contribution = $346.68.
+**Test 6:** Income $45,000, non-concessional contribution $1,000. -> Co-contribution = $500 (income below $49,293 lower threshold).
 
-**Test 7:** $5,000 to spouse's fund, spouse income $36,000. -> Offset = $540.
+**Test 7:** $5,000 to spouse's fund, spouse income $36,000, spouse TSB $300,000. -> Offset = $540.
 
 **Test 8:** Sole trader asks about SG to self. -> $0. No obligation. Advise voluntary contributions.
+
+**Test 9:** Payday Friday 4 Sep 2026; contribution received by fund Wednesday 16 Sep 2026 (8 business days). -> LATE. ATO-assessed SGC per Rule 11; new-regime SGC deductible.
+
+**Test 10:** New employee starts, first payday 10 Jul 2026, no fund details yet. -> First contribution due within 20 business days of the QE day; subsequent paydays revert to 7.
 
 ### Prohibitions
 
 - NEVER tell a sole trader they must pay SG to themselves
-- NEVER apply 12% rate to 2024-25 (rate is 11.5%)
-- NEVER ignore maximum contribution base ($65,070/quarter)
+- NEVER apply quarterly due dates (28 Oct/Jan/Apr/Jul) to earnings paid from 1 July 2026
+- NEVER treat clearing house receipt as fund receipt for the on-time test
+- NEVER apply the quarterly maximum contribution base to 2026-27 earnings (annual $270,830 YTD basis applies)
+- NEVER reference the ATO SBSCH as an available payment channel (closed permanently 1 July 2026)
+- NEVER call the new-regime SGC non-deductible (that rule died with the quarterly regime; old-regime SGC stays non-deductible)
 - NEVER allow deduction claim without confirmed s 290-150 notice
 - NEVER apply carry-forward if TSB >= $500,000
 - NEVER present figures as definitive
-- NEVER compute SGC penalties without escalating
+- NEVER compute SGC amounts without escalating
 - NEVER advise on defined benefit or constitutionally protected funds
 
 ---

--- a/skills/international/australia/au-super-guarantee.md
+++ b/skills/international/australia/au-super-guarantee.md
@@ -181,7 +181,7 @@ Commercial clearing house debit covering both employees for the 14 August payday
 ### Example 4 -- Annual maximum contribution base reached
 
 **Input line:**
-(no super debit present for Employee B for the 2 April 2027 payday)
+(no super debit present for Employee B for the 9 April 2027 payday)
 
 **Reasoning:**
 Employee B's year-to-date qualifying earnings passed $270,830 in March 2027 (large bonus in Q3). Under the ANNUAL maximum contribution base, once YTD qualifying earnings for 2026-27 reach $270,830, no further SG is required for the rest of the financial year. Maximum SG for the year = $32,499.60. Note front-loaded income exhausts the cap early -- this replaces the old per-quarter cap logic entirely.
@@ -302,7 +302,7 @@ Payment due the day the assessment is made. Unpaid 28 days after assessment -> N
 ### T2-3 -- Over-75 contributions
 
 **Trigger:** Client aged 75+ wants to make voluntary contributions.
-**Issue:** Work test applies (40 hours in 30 consecutive days). Mandated employer SG has no age limit.
+**Issue:** From 28 days after the end of the month the client turns 75, funds cannot accept voluntary contributions (non-concessional, salary sacrifice, or personal deductible) -- downsizer contributions are the only exception (no upper age limit). The 40-hours-in-30-days work test applies at ages 67-74 and, since 1 July 2022, only as a condition for claiming a deduction on personal contributions (ITAA97 s 290-165). Mandated employer SG has no age limit.
 **Action:** Flag for reviewer.
 
 ### T2-4 -- Carry-forward with borderline TSB

--- a/skills/international/australia/australia-payroll.md
+++ b/skills/international/australia/australia-payroll.md
@@ -11,8 +11,10 @@ description: >
   "activity statement", "annual leave", "long service leave",
   "minimum wage Australia", or any question about running payroll in Australia.
   ALWAYS read this skill before processing any Australian payroll work.
-version: 1.0
+version: 2.0
 jurisdiction: AU
+tax_year: 2026
+tax_year_notes: "2026-27 (payday super regime; 15% second-bracket PAYG rate from 1 July 2026)"
 tier: 2
 last_updated: 2026-08-01
 category: payroll
@@ -20,7 +22,7 @@ depends_on:
   - payroll-workflow-base
 ---
 
-# Australia -- Payroll Skill v1.0
+# Australia -- Payroll Skill v2.0
 
 > **General reference only.** This skill is general tax/accounting reference material for AI-assisted workflows. It has not been reviewed for any specific person's facts, documents, elections, deadlines, residency, filing status, or local procedures. Do not rely on it to file, pay, amend, or take a tax position without review by a qualified professional in the relevant jurisdiction.
 
@@ -40,7 +42,7 @@ depends_on:
 | Pay frequency | Weekly, fortnightly, monthly (fortnightly most common) |
 | Employer registration | ABN + PAYG withholding registration via ATO |
 | Validated by | Pending -- requires sign-off by an Australian CPA, CA, or registered tax agent |
-| Skill version | 1.0 |
+| Skill version | 2.0 |
 
 ---
 
@@ -48,17 +50,17 @@ depends_on:
 
 PAYG withholding is calculated per pay period using ATO tax tables (Schedule 1 -- NAT 1004) or the Statement of Formulas. The employer applies the appropriate coefficients based on weekly/fortnightly/monthly earnings.
 
-### Resident Individual Tax Rates (2025--26)
+### Resident Individual Tax Rates (2026--27)
 
 | Taxable Income (AUD) | Rate | Tax on This Income |
 |---|---|---|
 | 0 -- 18,200 | 0% | Nil |
-| 18,201 -- 45,000 | 16% | 16c for each $1 over $18,200 |
-| 45,001 -- 135,000 | 30% | $4,288 plus 30c for each $1 over $45,000 |
-| 135,001 -- 190,000 | 37% | $31,288 plus 37c for each $1 over $135,000 |
-| 190,001+ | 45% | $51,638 plus 45c for each $1 over $190,000 |
+| 18,201 -- 45,000 | 15% | 15c for each $1 over $18,200 |
+| 45,001 -- 135,000 | 30% | $4,020 plus 30c for each $1 over $45,000 |
+| 135,001 -- 190,000 | 37% | $31,020 plus 37c for each $1 over $135,000 |
+| 190,001+ | 45% | $51,370 plus 45c for each $1 over $190,000 |
 
-These rates **exclude** the Medicare levy (2%).
+These rates **exclude** the Medicare levy (2%). From 1 July 2026 the rate on $18,201--$45,000 dropped from 16% to 15% (Treasury Laws Amendment (More Cost of Living Relief) Act 2025); it drops again to 14% from 1 July 2027.
 
 ### Medicare Levy
 
@@ -268,12 +270,12 @@ Not strictly required on payslips but must be provided to employees on request. 
 
 ### Superannuation Remittance
 
-| Due Date | Quarter |
+| Item | Detail |
 |---|---|
-| 28 October | July -- September |
-| 28 January | October -- December |
-| 28 April | January -- March |
-| 28 July | April -- June |
+| Payment deadline (earnings paid from 1 Jul 2026) | Received by the employee's fund within **7 business days of each payday** (clearing house receipt does not count) |
+| New employee / new fund | 20 business days for the first contribution |
+
+**Legacy:** quarterly due dates (28 Oct / 28 Jan / 28 Apr / 28 Jul) apply only to earnings paid up to 30 June 2026; the final quarterly deadline was 28 July 2026.
 
 ### Annual Obligations
 
@@ -288,7 +290,7 @@ Not strictly required on payslips but must be provided to employees on request. 
 
 | Violation | Consequence |
 |---|---|
-| Late SG payment | SGC: shortfall + 10% interest + $20/employee admin fee; not deductible |
+| Late SG payment | SGC (ATO-assessed per payday): shortfall + notional earnings (GIC rate) + administrative uplift (up to 60%) + choice loading; deductible (the late payment penalty and GIC on unpaid SGC are not) -- see Section 4 |
 | Failure to withhold PAYG | Employer liable for amount that should have been withheld |
 | Late BAS/IAS lodgement | General interest charge (GIC) + potential failure-to-lodge penalty |
 | Payslip non-compliance | Up to $16,500 per contravention (individual); $82,500 (body corporate) |
@@ -302,9 +304,9 @@ Not strictly required on payslips but must be provided to employees on request. 
 Annual salary $85,000. Paid monthly. No STSL debt.
 
 1. Monthly gross: $85,000 ÷ 12 = $7,083.33
-2. PAYG withholding: per Schedule 1 tax table coefficients (~$1,420/month incl. Medicare)
+2. PAYG withholding: per Schedule 1 tax table coefficients (~$1,475/month incl. Medicare, 2026-27 rates)
 3. Super guarantee: $7,083.33 × 12% = $850.00 (employer cost, received by the fund within 7 business days of the payday)
-4. Net pay: $7,083.33 - $1,420.00 - deductions
+4. Net pay: $7,083.33 - $1,475.00 - deductions
 
 ### Pattern 2 -- Casual Employee with Loading
 
@@ -321,7 +323,7 @@ Annual salary $120,000. Sacrifices $10,000/year to super.
 
 1. Taxable salary: $110,000 (reduced PAYG base)
 2. Employer SG: $120,000 × 12% = $14,400 (calculated on pre-sacrifice OTE)
-3. Concessional super cap: $30,000 (includes SG $14,400 + sacrifice $10,000 = $24,400; within cap)
+3. Concessional super cap: $32,500 (2026-27) (includes SG $14,400 + sacrifice $10,000 = $24,400; within cap)
 4. The $10,000 is taxed at 15% inside the super fund instead of the employee's marginal rate
 
 ### Pattern 4 -- STSL Repayment

--- a/skills/international/australia/australia-payroll.md
+++ b/skills/international/australia/australia-payroll.md
@@ -14,7 +14,7 @@ description: >
 version: 1.0
 jurisdiction: AU
 tier: 2
-last_updated: 2026-06-12
+last_updated: 2026-08-01
 category: payroll
 depends_on:
   - payroll-workflow-base
@@ -91,7 +91,7 @@ Australia does not have a separate employee social security contribution. The Me
 |---|---|---|---|
 | PAYG income tax | Progressive (see above) | No ceiling | Includes Medicare levy in tax tables |
 | STSL repayment | 1%--10% (income-based) | No ceiling | Only if employee has HELP/STSL debt |
-| Salary sacrifice (super) | Voluntary | Concessional cap $30,000/year | Pre-tax; reduces PAYG withholding base |
+| Salary sacrifice (super) | Voluntary | Concessional cap $32,500/year (2026-27) | Pre-tax; reduces PAYG withholding base |
 
 There is no employee-paid social insurance premium equivalent to NIC (UK) or social security tax (US).
 
@@ -99,28 +99,31 @@ There is no employee-paid social insurance premium equivalent to NIC (UK) or soc
 
 ## Section 4 -- Social Security: Employer Contributions
 
-### Superannuation Guarantee (SG)
+### Superannuation Guarantee (SG) -- Payday Super from 1 July 2026
 
-| Parameter | 2025--26 Value |
+| Parameter | 2026--27 Value |
 |---|---|
-| SG rate | 12% of ordinary time earnings (OTE) |
-| Maximum contribution base | $65,070 per quarter ($260,280/year) |
+| SG rate | 12% of qualifying earnings |
+| Maximum contribution base | $270,830 per year (ANNUAL, year-to-date basis; quarterly base abolished for earnings paid from 1 Jul 2026) |
 | Minimum earnings threshold | Abolished (no $450/month threshold from 1 Jul 2022) |
-| Payment frequency | Quarterly (28 days after quarter end) |
+| Payment deadline | Received by the employee's fund within **7 business days of each payday** (clearing house receipt does not count) |
 | Eligible employees | All employees 18+; under-18s working 30+ hours/week |
 
-**SG quarterly due dates:** 28 October, 28 January, 28 April, 28 July.
+**Deadline exceptions:** new employee / new fund -- 20 business days for the first contribution; out-of-cycle payments (bonuses) ride with the next regular payday's deadline; ATO exceptional-circumstances determinations -- 20 business days.
+
+**Legacy:** quarterly due dates (28 Oct/28 Jan/28 Apr/28 Jul) apply only to earnings paid up to 30 June 2026; the final quarterly deadline was 28 July 2026. The ATO Small Business Super Clearing House closed permanently on 1 July 2026 -- small employers now use payroll-software super payments or commercial clearing houses.
 
 12% is the final scheduled SG rate (reached 1 July 2025). No further increases are planned.
 
-### Superannuation Guarantee Charge (SGC)
+### Superannuation Guarantee Charge (SGC) -- redesigned from 1 July 2026
 
-If SG is not paid in full by the quarterly deadline, the employer must lodge an SGC statement and pay:
-- The shortfall amount (calculated on total salary/wages, not just OTE)
-- Nominal interest (10% per annum)
-- An administration fee ($20 per employee per quarter)
+For earnings paid from 1 July 2026, SGC is **ATO-assessed per payday** (no SGC statement is lodged; the ATO matches STP data against fund reporting). Components:
+- The final SG shortfall (12% of qualifying earnings unpaid)
+- Notional earnings (GIC-rate interest, compounding daily from the day after the deadline)
+- An administrative uplift (starts at 60% of shortfall + notional earnings; reduced for clean history and voluntary disclosure, to 0% if disclosed within 30 days with a clean 2-year record)
+- Choice loading (25%, capped at $1,200 per notice period) where choice-of-fund rules were breached
 
-SGC amounts are **not tax-deductible**.
+The redesigned SGC **is tax-deductible** (GIC on late SGC and the late payment penalty are not). Old-regime SGC for quarters before 1 July 2026 remains non-deductible. Unpaid SGC 28 days after assessment triggers a Notice to Pay, then a 25% or 50% late payment penalty. First-year ATO approach: PCG 2026/1.
 
 ### Workers' Compensation Insurance
 
@@ -300,7 +303,7 @@ Annual salary $85,000. Paid monthly. No STSL debt.
 
 1. Monthly gross: $85,000 ÷ 12 = $7,083.33
 2. PAYG withholding: per Schedule 1 tax table coefficients (~$1,420/month incl. Medicare)
-3. Super guarantee: $7,083.33 × 12% = $850.00 (employer cost, paid quarterly)
+3. Super guarantee: $7,083.33 × 12% = $850.00 (employer cost, received by the fund within 7 business days of the payday)
 4. Net pay: $7,083.33 - $1,420.00 - deductions
 
 ### Pattern 2 -- Casual Employee with Loading


### PR DESCRIPTION
Lands all four stranded external PRs with their authors' commits intact (6 commits by **@ryanduguid**, 1 by **@ahmedhabibo** enter main's history — the contributors graph finally reflects reality).

| PR | What |
|---|---|
| #75 | Egypt↔KSA + Egypt↔UAE DTT treaty corridors (Ahmed, waiting since Jul 14) |
| #77 | AU super guarantee + payroll rewritten for **payday super 2026-27** (Payday Superannuation Act 2025, PCG 2026/1) |
| #78 | AU FBT guide — new, 412 lines |
| #79 | AU Division 7A guide — new, incl. *Bendel* [2026] HCA 18 |

Conflicts were only on generated files (`index.json`/`llms-full.txt`) — resolved in favour of the PR branches; the nightly sync regenerates them anyway. Guide-file conflicts (sync had rewritten `au-super-guarantee`/`australia-payroll`) resolved in favour of the **contributors' newer content**.

⚠️ Merge with a **merge commit** (not squash) to preserve contributor authorship.

After merge: the six files get ingested into the platform DB (inbound-first) so tonight's sync doesn't clobber them.