### PR TITLE
CLA: allowlist maintainer + sync bot

### DIFF
--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -43,5 +43,5 @@ jobs:
           path-to-document: "https://github.com/openaccountants/openaccountants/blob/main/CLA.md"
           path-to-signatures: "signatures/cla.json"
           branch: "cla-signatures"
-          allowlist: "dependabot[bot],github-actions[bot]"
+          allowlist: "michaelcutajar1995,openaccountants-sync[bot],dependabot[bot],github-actions[bot]"
           custom-notsigned-prcomment: "Thanks for your contribution. Before we can merge, please confirm you accept the [Contributor License Agreement](CLA.md) by commenting exactly: **I have read the CLA Document and I hereby sign the CLA**"

--- a/skills/international/australia/au-super-guarantee.md
+++ b/skills/international/australia/au-super-guarantee.md
@@ -9,7 +9,6 @@ tax_year_notes: "2026-27 (payday super regime; quarterly rules apply to earnings
 tier: 2
 last_updated: 2026-08-01
 category: international
-tier: 2
 license: AGPL-3.0-or-later (code) / OpenAccountants Guide License v1.0 (content)
 ---
 

--- a/skills/international/australia/australia-payroll.md
+++ b/skills/international/australia/australia-payroll.md
@@ -18,7 +18,6 @@ tax_year_notes: "2026-27 (payday super regime; 15% second-bracket PAYG rate from
 tier: 2
 last_updated: 2026-08-01
 category: payroll
-tier: 2
 license: AGPL-3.0-or-later (code) / OpenAccountants Guide License v1.0 (content)
 ---
 


### PR DESCRIPTION
Two fixes:

**1. CLA allowlist.** The CLA gate exists for external contributors, but it currently fires (and always fails — no `CLA_SIGNATURES_TOKEN` secret yet) on the maintainer's own PRs and the sync bot's pushes, putting a red X on every internal PR. This allowlists `michaelcutajar1995` and the sync bot. External contributor PRs still get the CLA prompt. Longer-term the check needs either the PAT secret or a downgrade to the PR-template checkbox — that decision is still open.

**2. Duplicate `tier:` key cleanup.** `au-super-guarantee.md` and `australia-payroll.md` each carry a duplicated `tier: 2` frontmatter line (a merge artifact from #81) which is exactly what's failing the Validate run on main right now. Removed — this turns main's CI green.