### PR TITLE
fix(mcp): stop dropping guides (and every accountant review) from the index

### DIFF
--- a/mcp/openaccountants_mcp/server.py
+++ b/mcp/openaccountants_mcp/server.py
@@ -35,6 +35,7 @@ MCP_STREAMABLE_HTTP_PATH  Path the Streamable-HTTP endpoint is mounted at.
 
 from __future__ import annotations
 
+import logging
 import os
 import re
 from collections import Counter, defaultdict
@@ -47,6 +48,8 @@ from urllib.parse import urlencode
 import yaml
 from mcp.server.fastmcp import FastMCP
 from mcp.types import ToolAnnotations
+
+log = logging.getLogger(__name__)
 
 # ---------------------------------------------------------------------------
 # Resolve repo root + packages directory
@@ -91,15 +94,58 @@ _FM_RE = re.compile(r"^---\s*\n(.*?)\n---\s*\n?(.*)$", re.DOTALL)
 _HEADING_RE = re.compile(r"^(#{1,6})\s+(.*\S)\s*$")
 
 
-def _parse_frontmatter(text: str) -> tuple[dict[str, Any], str]:
+_KEYLINE_RE = re.compile(r"^([A-Za-z_][\w-]*):(.*)$")
+
+
+def _salvage_frontmatter(block: str) -> dict[str, Any]:
+    """Recover the key/value pairs that *do* parse from a malformed block.
+
+    A single unquoted colon shouldn't cost us the whole guide: without this,
+    one bad ``description:`` line drops the file's ``name`` too, and the guide
+    vanishes from the index entirely. Keys that still won't parse are kept as
+    raw strings so ``name``/``jurisdiction`` survive and the guide stays
+    discoverable.
+    """
+    meta: dict[str, Any] = {}
+    key: str | None = None
+    buf: list[str] = []
+
+    def flush() -> None:
+        if key is None:
+            return
+        raw = "\n".join(buf).strip()
+        try:
+            parsed = yaml.safe_load(f"{key}: {raw}") if raw else {key: None}
+            meta[key] = (parsed or {}).get(key)
+        except yaml.YAMLError:
+            meta[key] = " ".join(raw.split())
+
+    for line in block.split("\n"):
+        m = _KEYLINE_RE.match(line)
+        if m and not line.startswith((" ", "\t")):
+            flush()
+            key, buf = m.group(1), [m.group(2)]
+        elif key is not None:
+            buf.append(line)
+    flush()
+    return meta
+
+
+def _parse_frontmatter(text: str, source: Any = None) -> tuple[dict[str, Any], str]:
     """Split a markdown file into (frontmatter dict, body)."""
     m = _FM_RE.match(text)
     if not m:
         return {}, text
     try:
         meta = yaml.safe_load(m.group(1)) or {}
-    except yaml.YAMLError:
-        meta = {}
+    except yaml.YAMLError as exc:
+        meta = _salvage_frontmatter(m.group(1))
+        log.warning(
+            "malformed YAML frontmatter in %s: %s -- salvaged %d key(s)",
+            source or "<unknown>",
+            str(exc).splitlines()[0] if str(exc) else exc.__class__.__name__,
+            len(meta),
+        )
     if not isinstance(meta, dict):
         meta = {}
     return meta, m.group(2)
@@ -113,14 +159,22 @@ def _first_h1(body: str) -> str | None:
     return None
 
 
+#: Frontmatter has migrated to ``reviewed_by``; ``verified_by`` is the legacy
+#: spelling that CONTRIBUTING.md says is being retired. Read both, newest first,
+#: or every guide reviewed under the current convention reports as unreviewed.
+_VERIFIER_KEYS = ("reviewed_by", "verified_by")
+_NOT_A_VERIFIER = {"pending", "pending_review", "none", "n/a", "-"}
+
+
 def _real_verifier(meta: dict[str, Any]) -> str | None:
     """The named verifier, or None. Treats the 'pending' placeholder (and blanks)
     as no verifier so a skill awaiting sign-off isn't claimed as verified."""
-    v = meta.get("verified_by")
-    if isinstance(v, str):
-        v = v.strip()
-        if v and v.lower() != "pending":
-            return v
+    for key in _VERIFIER_KEYS:
+        v = meta.get(key)
+        if isinstance(v, str):
+            v = v.strip()
+            if v and v.lower() not in _NOT_A_VERIFIER:
+                return v
     return None
 
 
@@ -196,7 +250,7 @@ def _index() -> dict[str, dict[str, Any]]:
             text = path.read_text(encoding="utf-8")
         except (OSError, UnicodeDecodeError):
             continue
-        meta, body = _parse_frontmatter(text)
+        meta, body = _parse_frontmatter(text, source=path.relative_to(PACKAGES_DIR))
         slug = meta.get("name")
         if not slug or not isinstance(slug, str):
             continue
@@ -235,7 +289,7 @@ def _read_skill(slug: str) -> tuple[dict[str, Any], str]:
     size = fpath.stat().st_size
     if size > MAX_FILE_BYTES:
         raise ValueError(f"File too large ({size:,} bytes, limit {MAX_FILE_BYTES:,})")
-    _, body = _parse_frontmatter(fpath.read_text(encoding="utf-8"))
+    _, body = _parse_frontmatter(fpath.read_text(encoding="utf-8"), source=fpath.name)
     return rec, body
 
 


### PR DESCRIPTION
## What this PR does

Fixes three compounding defects in the self-hosted MCP server that caused it to report **zero** accountant-reviewed guides against a repo that contains 256 of them.

## Country/jurisdiction affected

All — this is server code, not guide content. The measured impact is heaviest on Canada (provincial packages), the UK, and `_cross-border`.

## The problem

`_parse_frontmatter` caught `yaml.YAMLError` and returned `{}`. With no `name` key, `_index` skipped the file — so a guide with one unquoted colon didn't error, it **silently vanished** from `list_skills`, `search_skills` and `get_skill`. Nothing was logged, so the only way to notice a missing guide was to already know it should exist.

Separately, `_real_verifier` read only `verified_by`. CONTRIBUTING.md states frontmatter has moved to `reviewed_by` (the `verified_by` spelling "is being retired automatically"). Every guide reviewed under the current convention therefore reported `quality_tier: research-verified` and `verified_by: null` — the named accountants who signed off were invisible to every MCP client.

The two defects compound: a reviewed guide with a malformed description was dropped entirely, and one that parsed still lost its reviewer.

## Reproducing on `main`

`mcp/smoke_test.py` currently **aborts** on `main`:

```
ValueError: Skill 'malta-income-tax' not found
```

That guide is one of the dropped files — it's reviewed by Michael Cutajar, CPA (Malta). The suite passes end to end with this PR.

## Changes

- **`_salvage_frontmatter`** — recovers the key/value pairs that *do* parse, so one bad line can no longer cost the whole guide. Keys that still won't parse are kept as raw strings, which is enough for `name` and `jurisdiction` to survive and the guide to stay discoverable.
- **`_parse_frontmatter`** — takes an optional `source` and logs a warning naming the file and the YAML error, so this can't recur invisibly.
- **`_real_verifier`** — reads `reviewed_by` then `verified_by`, and treats `pending_review`/`none`/`n/a` as placeholders alongside the existing `pending`.

## Measured impact

Against `packages/` at 0370542, with no content changes:

| | before | after |
|---|---|---|
| skills indexed | 1,288 | 1,820 |
| accountant-verified | **0** | 256 |
| distinct named accountants | **0** | 31 |

31 lines up with the 32 in VERIFIERS.md, which is a reasonable check that this surfaces real reviews rather than inflating the count.

## Relationship to the content fix

This PR makes the server resilient to malformed frontmatter. A companion PR repairs the 565 source files that are malformed. **They are independent** — either merged alone is an improvement, and I'd suggest this one first since it also protects against future bad input. `alabama-income-tax.md` arrived malformed in today's sync (0370542), so new content is still landing broken.

## Checklist

### Repo & sync (required)

- [x] Only touches `mcp/openaccountants_mcp/server.py` — no `skills/`, no generated trees
- [x] I only edited files under paths the `guard-derived-trees` job allows (`index.json`, `llms-full.txt`, `packages/**` untouched)
- [ ] **Name for attribution** (as it should appear on the guide): _n/a — code change, not a guide_

### Verification

- [x] `mcp/smoke_test.py` — all checks pass (aborts on `main`)
- [x] `scripts/validate-guides.py --no-index-check` — passes, same pre-existing 5-guide jurisdiction warning as `main`
- [x] Rebased on `main` @ 0370542

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)
