### PR TITLE
fix(mcp): bind HTTP transport to loopback by default

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,14 +4,18 @@
 # connectors, ChatGPT, agents behind a reverse proxy, etc.) can connect over
 # HTTP instead of stdio.
 #
-# Usage:
+# Usage (local host only):
 #   docker build -t openaccountants-mcp .
-#   docker run --rm -p 8000:8000 openaccountants-mcp
-#   # then point an MCP client at http://localhost:8000/mcp
+#   docker run --rm -p 127.0.0.1:8000:8000 -e MCP_HOST=0.0.0.0 openaccountants-mcp
+#   # then point a local MCP client at http://localhost:8000/mcp
+#
+# The process defaults to 127.0.0.1. Docker port publishing needs an explicit
+# container-side MCP_HOST=0.0.0.0; the host-side 127.0.0.1 binding above keeps
+# that published port local. See mcp/README.md before exposing it remotely.
 #
 # Environment knobs (all optional, see mcp/openaccountants_mcp/server.py):
 #   MCP_TRANSPORT             stdio | streamable-http | sse   (default here: streamable-http)
-#   MCP_HOST                  bind host                       (default here: 0.0.0.0)
+#   MCP_HOST                  bind host                       (default here: 127.0.0.1)
 #   MCP_PORT                  bind port                       (default here: 8000)
 #   MCP_STREAMABLE_HTTP_PATH  mount path                      (default: /mcp;
 #                             set to "/" when fronted by a proxy that strips
@@ -31,7 +35,7 @@ COPY packages ./packages
 
 ENV OPENACCOUNTANTS_ROOT=/app \
     MCP_TRANSPORT=streamable-http \
-    MCP_HOST=0.0.0.0 \
+    MCP_HOST=127.0.0.1 \
     MCP_PORT=8000
 
 EXPOSE 8000

--- a/mcp/README.md
+++ b/mcp/README.md
@@ -212,14 +212,33 @@ For contributors who'd rather iterate inside a container, the repo root ships a 
 
 ```bash
 docker build -t openaccountants-mcp .
-docker run --rm -p 8000:8000 openaccountants-mcp
+docker run --rm -p 127.0.0.1:8000:8000 -e MCP_HOST=0.0.0.0 openaccountants-mcp
 # Point an MCP client at http://localhost:8000/mcp
 ```
+
+The server itself defaults to the loopback address `127.0.0.1`. Docker's port
+forwarder reaches the container through its network interface, so the local-only
+Docker example above deliberately sets `MCP_HOST=0.0.0.0` **inside the container**
+while binding the published host port to `127.0.0.1`. That keeps the endpoint
+available only to local clients.
+
+Remote network binding is an explicit operator choice, not a default:
+
+```bash
+MCP_TRANSPORT=streamable-http MCP_HOST=0.0.0.0 openaccountants-mcp
+```
+
+This package does not add an authentication layer. Only use a non-loopback
+`MCP_HOST` behind an authenticated, TLS-terminating reverse proxy or equivalent
+network controls; do not publish the raw MCP endpoint directly to the internet.
 
 When fronted by a reverse proxy that strips an upstream path prefix (e.g. Caddy `uri strip_prefix /oamcp`), set `MCP_STREAMABLE_HTTP_PATH=/` so the endpoint mounts at the proxied root:
 
 ```bash
-docker run --rm -p 8000:8000 -e MCP_STREAMABLE_HTTP_PATH=/ openaccountants-mcp
+docker run --rm -p 127.0.0.1:8000:8000 \
+  -e MCP_HOST=0.0.0.0 \
+  -e MCP_STREAMABLE_HTTP_PATH=/ \
+  openaccountants-mcp
 ```
 
 The default stdio transport (`pip install ./mcp && openaccountants-mcp`) is unchanged.
@@ -230,7 +249,7 @@ The default stdio transport (`pip install ./mcp && openaccountants-mcp`) is unch
 |----------|---------|-------------|
 | `OPENACCOUNTANTS_ROOT` | Auto-detected repo root (parent of `mcp/`) | Path to your OpenAccountants checkout. The server reads `$OPENACCOUNTANTS_ROOT/packages/`. |
 | `MCP_TRANSPORT` | `stdio` | `stdio`, `streamable-http`, or `sse`. HTTP transports let remote MCP clients connect via a reverse proxy. |
-| `MCP_HOST` | `127.0.0.1` (stdio) / `0.0.0.0` (HTTP) | Bind host for HTTP transports. |
+| `MCP_HOST` | `127.0.0.1` | Bind host for HTTP transports. Set explicitly, for example to `0.0.0.0`, only when an authenticated reverse proxy or equivalent network boundary is intentionally exposing the service. |
 | `MCP_PORT` | `8000` | Bind port for HTTP transports. |
 | `MCP_STREAMABLE_HTTP_PATH` | `/mcp` | Path the Streamable-HTTP endpoint is mounted at. Set to `/` when behind a proxy that strips the upstream prefix. |
 

--- a/mcp/openaccountants_mcp/server.py
+++ b/mcp/openaccountants_mcp/server.py
@@ -25,8 +25,9 @@ MCP_TRANSPORT             ``stdio`` (default), ``streamable-http``, or ``sse``.
                           HTTP transports let remote MCP clients connect via a
                           reverse proxy (Caddy, nginx, ngrok…).
 MCP_HOST                  Bind host for HTTP transports.  Defaults to
-                          ``0.0.0.0`` when an HTTP transport is selected,
-                          ``127.0.0.1`` otherwise.
+                          ``127.0.0.1``.  Set this explicitly (for example,
+                          ``MCP_HOST=0.0.0.0``) only when a reverse proxy or
+                          other network boundary is intentionally exposing it.
 MCP_PORT                  Bind port for HTTP transports.  Defaults to ``8000``.
 MCP_STREAMABLE_HTTP_PATH  Path the Streamable-HTTP endpoint is mounted at.
                           Defaults to ``/mcp``.  Set to ``/`` when fronted by a
@@ -359,8 +360,9 @@ if _TRANSPORT not in _VALID_TRANSPORTS:
 # Env-driven HTTP wiring.  For stdio these values are unused; for HTTP transports
 # they're plumbed into the FastMCP constructor so the wrapped Settings pick them
 # up (FastMCP overrides env-driven Settings with its own kwargs, so we read the
-# environment here ourselves).
-_HTTP_HOST = os.environ.get("MCP_HOST", "0.0.0.0" if _TRANSPORT != "stdio" else "127.0.0.1")
+# environment here ourselves).  HTTP is loopback-only unless an operator
+# deliberately sets MCP_HOST for a reverse-proxy or other controlled deployment.
+_HTTP_HOST = os.environ.get("MCP_HOST") or "127.0.0.1"
 _HTTP_PORT = int(os.environ.get("MCP_PORT", "8000"))
 _STREAMABLE_HTTP_PATH = os.environ.get("MCP_STREAMABLE_HTTP_PATH", "/mcp")
 

--- a/mcp/tests/test_http_binding.py
+++ b/mcp/tests/test_http_binding.py
@@ -1,0 +1,47 @@
+"""Regression tests for the MCP HTTP listener's safe default binding."""
+
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+import unittest
+from pathlib import Path
+
+
+MCP_DIR = Path(__file__).resolve().parents[1]
+REPO_ROOT = MCP_DIR.parent
+_PRINT_HOST = "from openaccountants_mcp import server; print(server._HTTP_HOST)"
+
+
+def _configured_host(host: str | None) -> str:
+    """Import the server in a fresh process so its environment is re-read."""
+    env = os.environ.copy()
+    env["MCP_TRANSPORT"] = "streamable-http"
+    env["OPENACCOUNTANTS_ROOT"] = str(REPO_ROOT)
+    if host is None:
+        env.pop("MCP_HOST", None)
+    else:
+        env["MCP_HOST"] = host
+
+    completed = subprocess.run(
+        [sys.executable, "-c", _PRINT_HOST],
+        cwd=MCP_DIR,
+        env=env,
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    return completed.stdout.strip()
+
+
+class HttpBindingTests(unittest.TestCase):
+    def test_http_transport_defaults_to_loopback(self) -> None:
+        self.assertEqual(_configured_host(None), "127.0.0.1")
+
+    def test_operator_can_explicitly_configure_remote_binding(self) -> None:
+        self.assertEqual(_configured_host("0.0.0.0"), "0.0.0.0")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## What this PR does

The MCP server binds its HTTP transports to `0.0.0.0` by default; this changes the default to `127.0.0.1` and makes remote exposure an explicit operator choice.

## Country/jurisdiction affected

None - this is a change to the MCP server package, not to a guide.

## The problem

`mcp/openaccountants_mcp/server.py` currently resolves the bind host as:

```python
_HTTP_HOST = os.environ.get("MCP_HOST", "0.0.0.0" if _TRANSPORT != "stdio" else "127.0.0.1")
```

So `MCP_TRANSPORT=streamable-http` alone is enough to listen on every interface. The package ships no authentication layer, so anyone who starts an HTTP transport on a laptop on shared Wi-Fi, a jump box, or a cloud VM with a permissive security group is serving the tool surface to that whole network without being told. `EXPOSE 8000` plus `docker run -p 8000:8000` in the Dockerfile publishes it to every host interface too.

`stdio`, the default transport, is unaffected either way.

## The change

- `_HTTP_HOST` defaults to `127.0.0.1` for every transport. An empty `MCP_HOST` is treated as unset rather than binding to all interfaces.
- Dockerfile `ENV MCP_HOST` set to `127.0.0.1`, and the documented `docker run` line publishes to `127.0.0.1:8000` with an explicit in-container `MCP_HOST=0.0.0.0`. Docker's port forwarder reaches the container over its own interface, so the container-side override is required; the host-side `127.0.0.1` publish is what keeps the endpoint local.
- `mcp/README.md` documents the loopback default, the explicit opt-in for remote binding, and states plainly that this package adds no authentication, so a non-loopback `MCP_HOST` belongs behind an authenticated TLS-terminating proxy.
- `mcp/tests/test_http_binding.py` pins both directions: unset `MCP_HOST` on an HTTP transport resolves to `127.0.0.1`, and `MCP_HOST=0.0.0.0` is still honoured.

## Compatibility

Breaking for one case only: a deployment that relied on the implicit all-interfaces bind now needs `MCP_HOST=0.0.0.0` set. Anyone already setting `MCP_HOST` is unaffected, and stdio is unchanged. The Dockerfile and README carry the new invocation.

## Validation

- `mcp/tests/test_http_binding.py`: 2 passed. Each case imports the server in a fresh subprocess so the environment is re-read.
- Confirmed the test fails on current `main` before the fix: it reports `- 0.0.0.0` against the expected `+ 127.0.0.1`.
- `uv lock --check` passes. `uv sync --locked` currently fails on `main` for an unrelated reason, an obsolete `License :: OSI Approved :: GNU Affero General Public License (AGPLv3)` trove classifier in `mcp/pyproject.toml` that current Hatchling rejects; I installed with `--no-install-project` to run the tests. That is a separate defect from this change.
- `git diff --check` clean. No generated trees touched: nothing under `index.json`, `llms-full.txt` or `packages/`.

## Checklist

### Repo & sync

- [x] I only edited files outside the generated trees (`Dockerfile`, `mcp/README.md`, `mcp/openaccountants_mcp/server.py`, `mcp/tests/test_http_binding.py`)
- Not applicable: this is a software fix, so the `skills/` and jurisdiction items do not apply.

### Content quality

Not applicable - no guide content in this PR.

## Legal - Contributor License Agreement

- [x] **I have read [CLA.md](https://github.com/openaccountants/openaccountants/blob/main/CLA.md) and agree to the Contributor License Agreement** for everything included in this pull request.

