### PR TITLE
fix(mcp): drop obsolete license trove classifier that breaks the package build

### DIFF
--- a/mcp/pyproject.toml
+++ b/mcp/pyproject.toml
@@ -14,7 +14,6 @@ keywords = [
 classifiers = [
     "Development Status :: 4 - Beta",
     "Topic :: Office/Business :: Financial :: Accounting",
-    "License :: OSI Approved :: GNU Affero General Public License v3 (AGPLv3)",
     "Programming Language :: Python :: 3",
     "Intended Audience :: Financial and Insurance Industry",
     "Intended Audience :: Developers",


### PR DESCRIPTION
## What this PR does

Removes one obsolete trove classifier from `mcp/pyproject.toml`, which currently makes every build of the `openaccountants-mcp` package fail on `main`.

## Country/jurisdiction affected

None. This is packaging metadata only, no guide content is touched.

## The problem

Hatchling validates `project.classifiers` against the `trove-classifiers` package. Following PEP 639, `trove-classifiers` no longer carries any `License ::` entry, so the AGPLv3 classifier is now an unknown value and metadata validation aborts the build.

Reproduced against `main` at `a8ac0a1`, hatchling as resolved by `uv build`:

```
ValueError: Unknown classifier in field `project.classifiers`: License :: OSI Approved :: GNU Affero General Public License v3 (AGPLv3)
error: Failed to build
  Caused by: The build backend returned an error
  Caused by: Call to `hatchling.build.build_sdist` failed (exit code: 1)
```

This fires before any dependency resolution, so it also takes out `uv sync` and anything else that has to build the project.

## The fix

Delete the classifier line. Nothing else changes.

The licensing is not weakened: `project.license = "AGPL-3.0-only"` is already declared four lines above, and under PEP 639 that SPDX expression is the replacement for the classifier. It is what build backends and PyPI now read for the licence, and it is already the authoritative field in this file.

## Verification

Against `main` at `a8ac0a1`, on Python 3.12:

- Before: `uv build` fails with the `ValueError` quoted above.
- After: `uv build` succeeds, producing `openaccountants_mcp-0.3.0.tar.gz` and `openaccountants_mcp-0.3.0-py3-none-any.whl`.
- Every remaining classifier checked against the installed `trove_classifiers.classifiers` set: all five are recognised.
- Diff is a single deleted line, LF endings preserved.

## Legal - Contributor License Agreement (CLA)

- [x] **I have read [CLA.md](https://github.com/openaccountants/openaccountants/blob/main/CLA.md) and agree to the Contributor License Agreement** for everything included in this pull request. *(Checking this box is your explicit opt-in.)*

Accepted. Also confirmed by comment on this PR in the exact wording the CLA Assistant expects. The same applies to #89.

## Checklist

### Repo & sync

- [x] I only edited files under `mcp/**`, so no generated tree is affected. `.github/workflows/validate.yml` guards `index.json`, `llms-full.txt` and `packages/**`, none of which are touched.
- [x] **Name for attribution**: Ryan Duguid
- [x] My OpenAccountants profile GitHub username matches this account
- [ ] ~~File is in `skills/`~~ - not applicable, this is a packaging fix, not a guide
- [ ] ~~Jurisdiction is clear~~ - not applicable

### Content quality

Not applicable: no guide content, rates, thresholds, examples or disclaimers are added or changed by this PR.

