### PR TITLE
Let the CLA gate record a signature

### DIFF
--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -1,19 +1,24 @@
 # Contributor License Agreement check.
 #
-# SETUP REQUIRED before this becomes a reliable gate:
-#   1. Create a fine-grained PAT with `contents: write` on a signatures store
-#      (this repo, or a private one) and add it as the repo secret
-#      `CLA_SIGNATURES_TOKEN`.
-#   2. Point `path-to-signatures` / `remote-repository-name` below at where you
-#      want signatures recorded.
-#   3. In Settings → Branches, add a branch-protection rule on `main` that makes
-#      the "CLA Assistant" status check REQUIRED. (Not enabled automatically —
-#      that would also block direct pushes to main.)
+# Signatures are stored in THIS repository, on the `cla-signatures` branch, at
+# `signatures/cla.json`. The action creates that branch on the first signature.
+# Keep it unprotected: the action commits to it on every signature, and branch
+# protection makes the write fail.
 #
-# Until the secret is set, this workflow will fail on PRs; that is intentional,
-# so the gate is visible. Contributors accept the CLA by commenting
-# "I have read the CLA Document and I hereby sign the CLA" on their PR, or by
-# ticking the CLA box in the pull request template (see CLA.md).
+# `CLA_SIGNATURES_TOKEN` is NOT required for this setup. Per the action's
+# documentation a PAT is only needed when signatures live in a different
+# repository or organisation, which needs `remote-repository-name` to be set
+# below. It is not set, so the built-in GITHUB_TOKEN is sufficient, provided
+# this workflow grants `contents: write` (see permissions).
+#
+# Optional hardening: in Settings → Branches, add a branch-protection rule on
+# `main` making the "CLA Assistant" status check REQUIRED. Verify a signature
+# comment on an open PR turns the check green BEFORE doing that, or outside
+# contributions become unmergeable.
+#
+# Contributors accept the CLA by commenting "I have read the CLA Document and I
+# hereby sign the CLA" on their PR, or by ticking the CLA box in the pull
+# request template (see CLA.md).
 
 name: "CLA Assistant"
 
@@ -25,7 +30,7 @@ on:
 
 permissions:
   actions: write
-  contents: read
+  contents: write # the action commits signatures/cla.json to the cla-signatures branch
   pull-requests: write
   statuses: write
 


### PR DESCRIPTION
Fixes #91.

The `cla` check has never passed for an outside contributor. It fails on repository configuration, not on anything the contributor does, and no wording of the signature comment can clear it.

`contributor-assistant/github-action` records a signature by committing `signatures/cla.json` to the `cla-signatures` branch. The workflow granted `contents: read`, so that write returns `Resource not accessible by integration` and the action then reports the committer as unsigned. The `cla-signatures` branch does not exist and could not be created either, since creating a branch is also a contents write.

This grants `contents: write`.

The header comment is also corrected. It told the next maintainer that setting `CLA_SIGNATURES_TOKEN` was the fix. It is not: per the action's documentation a PAT is only needed when signatures live in another repository, which requires `remote-repository-name`. That is not set here, so signatures are stored in this repo and the built-in `GITHUB_TOKEN` is sufficient once it can write. Verified in the file: no `remote-repository-name`, `branch: cla-signatures`, `path-to-signatures: signatures/cla.json`.

The comment's step 3 also suggested promoting the check to required in branch protection. That is now marked as something to do only after a signature comment is observed turning the check green, since doing it first would make outside contributions unmergeable.

### Why this went unnoticed

`michaelcutajar1995` and the bot accounts are on the allowlist, so maintainer and sync pull requests never exercise this path. The green `cla` runs in history are `pull_request_target: closed` runs fired at merge time. Every run that evaluated an open pull request failed, and PRs #77, #78, #79, #84 and #85 all merged with the check red.

### Verification

- YAML parses; permissions block reads `contents: write`.
- `GET /repos/openaccountants/openaccountants/branches/cla-signatures` returns 404, confirming no signature store exists yet.

After merge, the real test is a signature comment on an open PR (#89 or #90) flipping the check to green. That path has not succeeded once, so it should be watched rather than assumed.

Reported by @ryanduguid in #91, with the diagnosis and the fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)