### PR TITLE
ci: scope validation workflow permissions

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -24,7 +24,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-      pull-requests: write
+      issues: write
     steps:
       - uses: actions/checkout@v4
         with:
@@ -48,9 +48,11 @@ jobs:
       - name: Explain in a comment
         if: failure() && steps.guard.outputs.generated_files_touched != ''
         uses: actions/github-script@v7
+        env:
+          GENERATED_FILES_TOUCHED: ${{ steps.guard.outputs.generated_files_touched }}
         with:
           script: |
-            const files = `${{ steps.guard.outputs.generated_files_touched }}`.trim();
+            const files = process.env.GENERATED_FILES_TOUCHED.trim();
             await github.rest.issues.createComment({
               ...context.repo,
               issue_number: context.issue.number,

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -15,10 +15,16 @@ on:
   push:
     branches: [main]
 
+permissions:
+  contents: read
+
 jobs:
   guard-derived-trees:
     if: github.event_name == 'pull_request'
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
     steps:
       - uses: actions/checkout@v4
         with:

--- a/tests/test_validate_workflow_security.py
+++ b/tests/test_validate_workflow_security.py
@@ -1,0 +1,35 @@
+from __future__ import annotations
+
+import unittest
+from pathlib import Path
+
+
+WORKFLOW = (
+    Path(__file__).resolve().parents[1] / ".github" / "workflows" / "validate.yml"
+)
+
+
+class ValidateWorkflowSecurityTests(unittest.TestCase):
+    def test_comment_uses_the_minimum_issue_permission(self) -> None:
+        workflow = WORKFLOW.read_text(encoding="utf-8")
+
+        self.assertIn("      issues: write\n", workflow)
+        self.assertNotIn("      pull-requests: write\n", workflow)
+
+    def test_filenames_reach_javascript_through_the_environment(self) -> None:
+        workflow = WORKFLOW.read_text(encoding="utf-8")
+
+        self.assertIn(
+            "GENERATED_FILES_TOUCHED: "
+            "${{ steps.guard.outputs.generated_files_touched }}",
+            workflow,
+        )
+        self.assertIn("process.env.GENERATED_FILES_TOUCHED.trim()", workflow)
+        self.assertNotIn(
+            "`${{ steps.guard.outputs.generated_files_touched }}`",
+            workflow,
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## What this PR does

Declares the validation workflow's GitHub token permissions explicitly and keeps untrusted filenames out of executable JavaScript:

- all jobs default to read-only repository contents;
- only `guard-derived-trees` receives `issues: write`, the permission used by its existing contributor-comment path;
- the ordinary validation job receives no write permission;
- generated filenames pass to `actions/github-script` through an environment variable instead of direct template interpolation.

This preserves the existing checkout, validation and contributor-comment behaviour while removing reliance on repository-wide default token permissions and preventing a crafted generated-file name from changing the script.

## Verification

- `actionlint .github/workflows/validate.yml`: passed
- `python -m unittest discover -s tests -v`: 32/32 passed, including two workflow-security regressions
- `git diff --check`: passed
- exact head: `a5c09ea5413cc55a86ea5cf4df37630f172c332d`

No source guide, generated-tree or dependency file changed. No CLA or other legal acceptance is made by this PR body.