### PR TITLE
fix(scripts): validate and encode workbook filters

### DIFF
--- a/scripts/build-verification-workbook.py
+++ b/scripts/build-verification-workbook.py
@@ -31,34 +31,85 @@ import os
 import re
 import sys
 import urllib.error
+import urllib.parse
 import urllib.request
 from datetime import date
-
-from openpyxl import Workbook
-from openpyxl.styles import Alignment, Border, Font, PatternFill, Side
-from openpyxl.utils import get_column_letter
-from openpyxl.worksheet.datavalidation import DataValidation
 
 
 # ---------------------------------------------------------------------------
 # Args + env
 # ---------------------------------------------------------------------------
 
-ap = argparse.ArgumentParser()
-ap.add_argument("--slugs", help="Comma-separated skill slugs to include.")
-ap.add_argument("--jurisdiction", help="Jurisdiction code (e.g. US-ND, MT).")
-ap.add_argument("--verifier", required=True, help="Verifier display name (goes on cover sheet + per-skill sign-off rows).")
-ap.add_argument("--credential", default="", help="Verifier credential (e.g. 'CPA', 'CA(SA)').")
-ap.add_argument("--title", default="OpenAccountants — Skill Verification Workbook", help="Workbook title shown on the cover.")
-ap.add_argument("--output", required=True, help="Output .xlsx path.")
-args = ap.parse_args()
+SKILL_SLUG_RE = re.compile(r"[a-z0-9]+(?:-[a-z0-9]+)*\Z")
+JURISDICTION_RE = re.compile(r"(?:general|[A-Z0-9]+(?:[-/][A-Z0-9]+)*)\Z")
 
-if not args.slugs and not args.jurisdiction:
-    sys.exit("Provide --slugs OR --jurisdiction.")
+args = None
+URL = ""
+HEADERS = {}
 
-URL = os.environ["NEXT_PUBLIC_SUPABASE_URL"]
-KEY = os.environ["SUPABASE_SERVICE_ROLE_KEY"]
-HEADERS = {"apikey": KEY, "Authorization": f"Bearer {KEY}"}
+
+def validate_skill_slug(value: str) -> str:
+    """Validate the slug grammar used by the repository inventory."""
+    if not SKILL_SLUG_RE.fullmatch(value):
+        raise ValueError(
+            f"invalid skill slug {value!r}; expected lowercase letters and digits "
+            "separated by single hyphens"
+        )
+    return value
+
+
+def parse_slug_list(value: str) -> list[str]:
+    """Parse a comma-separated list without treating commas as slug content."""
+    slugs = [part.strip() for part in value.split(",")]
+    if not slugs or any(not slug for slug in slugs):
+        raise ValueError("--slugs must contain one or more non-empty slugs")
+    return [validate_skill_slug(slug) for slug in slugs]
+
+
+def validate_jurisdiction(value: str) -> str:
+    """Validate current jurisdiction-code syntax, including grouped regions."""
+    if not JURISDICTION_RE.fullmatch(value):
+        raise ValueError(
+            f"invalid jurisdiction {value!r}; expected uppercase alphanumeric "
+            "components separated by hyphens or slashes (or 'general')"
+        )
+    return value
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser()
+    selector = parser.add_mutually_exclusive_group(required=True)
+    selector.add_argument("--slugs", help="Comma-separated skill slugs to include.")
+    selector.add_argument("--jurisdiction", help="Jurisdiction code (e.g. US-ND, MT).")
+    parser.add_argument(
+        "--verifier",
+        required=True,
+        help="Verifier display name (goes on cover sheet + per-skill sign-off rows).",
+    )
+    parser.add_argument(
+        "--credential", default="", help="Verifier credential (e.g. 'CPA', 'CA(SA)')."
+    )
+    parser.add_argument(
+        "--title",
+        default="OpenAccountants — Skill Verification Workbook",
+        help="Workbook title shown on the cover.",
+    )
+    parser.add_argument("--output", required=True, help="Output .xlsx path.")
+    return parser
+
+
+def parse_arguments(argv=None):
+    parser = build_parser()
+    parsed = parser.parse_args(argv)
+    try:
+        if parsed.slugs is not None:
+            parsed.slug_list = parse_slug_list(parsed.slugs)
+        else:
+            parsed.slug_list = None
+            parsed.jurisdiction = validate_jurisdiction(parsed.jurisdiction)
+    except ValueError as exc:
+        parser.error(str(exc))
+    return parsed
 
 
 # ---------------------------------------------------------------------------
@@ -71,25 +122,59 @@ def http_get(path: str):
         return json.load(r)
 
 
+SKILL_COLUMNS = "id,slug,name,description,tier,category,jurisdiction,tax_year"
+
+
+def rest_query_path(resource: str, **params: str) -> str:
+    """Build an encoded PostgREST path from filter values, never expressions."""
+    query = urllib.parse.urlencode(
+        params,
+        quote_via=urllib.parse.quote,
+        safe="",
+    )
+    return f"/rest/v1/{resource}?{query}"
+
+
+def skills_query_path(*, slugs=None, jurisdiction=None) -> str:
+    """Build the published-skills query after validating its one selector."""
+    if (slugs is None) == (jurisdiction is None):
+        raise ValueError("provide exactly one of slugs or jurisdiction")
+    if slugs is not None:
+        valid_slugs = [validate_skill_slug(slug) for slug in slugs]
+        if not valid_slugs:
+            raise ValueError("provide at least one slug")
+        in_clause = "(" + ",".join(f'"{slug}"' for slug in valid_slugs) + ")"
+        return rest_query_path(
+            "skills",
+            slug=f"in.{in_clause}",
+            is_published="eq.true",
+            select=SKILL_COLUMNS,
+            order="slug",
+        )
+    return rest_query_path(
+        "skills",
+        jurisdiction=f"eq.{validate_jurisdiction(jurisdiction)}",
+        is_published="eq.true",
+        select=SKILL_COLUMNS,
+        order="slug",
+    )
+
+
 def fetch_skills():
     """Return list of skill rows with markdown_content joined from current version."""
-    if args.slugs:
-        slug_list = [s.strip() for s in args.slugs.split(",") if s.strip()]
-        in_clause = "(" + ",".join(f'"{s}"' for s in slug_list) + ")"
-        skills = http_get(
-            f"/rest/v1/skills?slug=in.{in_clause}&is_published=eq.true"
-            "&select=id,slug,name,description,tier,category,jurisdiction,tax_year&order=slug"
-        )
-    else:
-        skills = http_get(
-            f"/rest/v1/skills?jurisdiction=eq.{args.jurisdiction}&is_published=eq.true"
-            "&select=id,slug,name,description,tier,category,jurisdiction,tax_year&order=slug"
-        )
+    skills = http_get(
+        skills_query_path(slugs=args.slug_list, jurisdiction=args.jurisdiction)
+    )
 
     for s in skills:
         versions = http_get(
-            f"/rest/v1/skill_versions?skill_id=eq.{s['id']}&is_current=eq.true"
-            "&select=markdown_content,version&limit=1"
+            rest_query_path(
+                "skill_versions",
+                skill_id=f"eq.{s['id']}",
+                is_current="eq.true",
+                select="markdown_content,version",
+                limit="1",
+            )
         )
         s["markdown"] = versions[0]["markdown_content"] if versions else ""
         s["version"] = versions[0]["version"] if versions else None
@@ -131,23 +216,54 @@ def parse_sections(md: str):
 # xlsx styling helpers
 # ---------------------------------------------------------------------------
 
-THICK = Side(border_style="medium", color="000000")
-THIN = Side(border_style="thin", color="999999")
-HEADER_FILL = PatternFill("solid", fgColor="047857")
-SUBHEAD_FILL = PatternFill("solid", fgColor="ECFDF5")
-SIGNOFF_FILL = PatternFill("solid", fgColor="FFF7ED")
-ZEBRA_FILL = PatternFill("solid", fgColor="F9FAFB")
-HEADER_FONT = Font(bold=True, color="FFFFFF", size=11)
-TITLE_FONT = Font(bold=True, size=18)
-H2_FONT = Font(bold=True, size=13)
-WRAP = Alignment(wrap_text=True, vertical="top")
-TOP = Alignment(vertical="top")
-
 STATUS_OPTIONS = '"correct,needs-correction,wrong,needs-context,skip"'
-STATUS_DV = DataValidation(type="list", formula1=STATUS_OPTIONS, allow_blank=True)
-STATUS_DV.error = "Pick one of: correct / needs-correction / wrong / needs-context / skip"
-STATUS_DV.prompt = "correct = fact is right • needs-correction = small fix (write it in the next column) • wrong = section is misleading • needs-context = unclear / add detail • skip = not in your scope"
-STATUS_DV.promptTitle = "Section status"
+
+
+def initialise_workbook_support():
+    """Import the optional workbook dependency after CLI validation."""
+    global Workbook, Alignment, Font, PatternFill, Side
+    global get_column_letter, DataValidation
+    global THICK, THIN, HEADER_FILL, SUBHEAD_FILL, SIGNOFF_FILL, ZEBRA_FILL
+    global HEADER_FONT, TITLE_FONT, H2_FONT, WRAP, TOP, STATUS_DV
+
+    from openpyxl import Workbook as _Workbook
+    from openpyxl.styles import Alignment as _Alignment
+    from openpyxl.styles import Font as _Font
+    from openpyxl.styles import PatternFill as _PatternFill
+    from openpyxl.styles import Side as _Side
+    from openpyxl.utils import get_column_letter as _get_column_letter
+    from openpyxl.worksheet.datavalidation import DataValidation as _DataValidation
+
+    Workbook = _Workbook
+    Alignment = _Alignment
+    Font = _Font
+    PatternFill = _PatternFill
+    Side = _Side
+    get_column_letter = _get_column_letter
+    DataValidation = _DataValidation
+
+    THICK = Side(border_style="medium", color="000000")
+    THIN = Side(border_style="thin", color="999999")
+    HEADER_FILL = PatternFill("solid", fgColor="047857")
+    SUBHEAD_FILL = PatternFill("solid", fgColor="ECFDF5")
+    SIGNOFF_FILL = PatternFill("solid", fgColor="FFF7ED")
+    ZEBRA_FILL = PatternFill("solid", fgColor="F9FAFB")
+    HEADER_FONT = Font(bold=True, color="FFFFFF", size=11)
+    TITLE_FONT = Font(bold=True, size=18)
+    H2_FONT = Font(bold=True, size=13)
+    WRAP = Alignment(wrap_text=True, vertical="top")
+    TOP = Alignment(vertical="top")
+
+    STATUS_DV = DataValidation(type="list", formula1=STATUS_OPTIONS, allow_blank=True)
+    STATUS_DV.error = (
+        "Pick one of: correct / needs-correction / wrong / needs-context / skip"
+    )
+    STATUS_DV.prompt = (
+        "correct = fact is right • needs-correction = small fix (write it in the next "
+        "column) • wrong = section is misleading • needs-context = unclear / add "
+        "detail • skip = not in your scope"
+    )
+    STATUS_DV.promptTitle = "Section status"
 
 
 def sheet_name(slug: str) -> str:
@@ -171,7 +287,15 @@ def sheet_name(slug: str) -> str:
 # Build workbook
 # ---------------------------------------------------------------------------
 
-def main():
+def main(argv=None):
+    global args, URL, HEADERS
+
+    args = parse_arguments(argv)
+    URL = os.environ["NEXT_PUBLIC_SUPABASE_URL"]
+    key = os.environ["SUPABASE_SERVICE_ROLE_KEY"]
+    HEADERS = {"apikey": key, "Authorization": f"Bearer {key}"}
+    initialise_workbook_support()
+
     skills = fetch_skills()
     if not skills:
         sys.exit("No skills returned. Check slug list or jurisdiction.")

--- a/tests/test_sync_integrity.py
+++ b/tests/test_sync_integrity.py
@@ -1,11 +1,14 @@
 from __future__ import annotations
 
+import contextlib
 import importlib.util
+import io
 import json
 import subprocess
 import sys
 import tempfile
 import unittest
+import urllib.parse
 from pathlib import Path
 
 
@@ -15,6 +18,17 @@ assert SPEC is not None and SPEC.loader is not None
 sync_integrity = importlib.util.module_from_spec(SPEC)
 sys.modules[SPEC.name] = sync_integrity
 SPEC.loader.exec_module(sync_integrity)
+
+WORKBOOK_SCRIPT_PATH = (
+    Path(__file__).resolve().parents[1] / "scripts" / "build-verification-workbook.py"
+)
+WORKBOOK_SPEC = importlib.util.spec_from_file_location(
+    "build_verification_workbook", WORKBOOK_SCRIPT_PATH
+)
+assert WORKBOOK_SPEC is not None and WORKBOOK_SPEC.loader is not None
+build_workbook = importlib.util.module_from_spec(WORKBOOK_SPEC)
+sys.modules[WORKBOOK_SPEC.name] = build_workbook
+WORKBOOK_SPEC.loader.exec_module(build_workbook)
 
 
 def guide(
@@ -501,6 +515,121 @@ class GitBackedIntegrityTests(unittest.TestCase):
             self.path: {"expected_repo_blob": expected_blob, "content_revision": 1}
         }
         self.assertEqual(payload, json.loads(json.dumps(payload)))
+
+
+class VerificationWorkbookQueryTests(unittest.TestCase):
+    base_args = ["--verifier", "Test Verifier", "--output", "test.xlsx"]
+
+    def test_repository_inventory_matches_validated_selector_grammar(self) -> None:
+        index_path = Path(__file__).resolve().parents[1] / "index.json"
+        guides = json.loads(index_path.read_text(encoding="utf-8"))["guides"]
+
+        for slug in {guide["slug"] for guide in guides}:
+            self.assertEqual(slug, build_workbook.validate_skill_slug(slug))
+        for jurisdiction in {
+            guide["jurisdiction"] for guide in guides if guide.get("jurisdiction")
+        }:
+            self.assertEqual(
+                jurisdiction,
+                build_workbook.validate_jurisdiction(jurisdiction),
+            )
+
+    def test_valid_selectors_include_grouped_and_multi_part_jurisdictions(self) -> None:
+        self.assertEqual(
+            ["us-1099-k-and-payment-processors", "ifrs15-revenue"],
+            build_workbook.parse_slug_list(
+                "us-1099-k-and-payment-processors, ifrs15-revenue"
+            ),
+        )
+        for jurisdiction in ("US-NY-NYC", "EU-27", "EU/EEA/CH/UK", "GLOBAL", "general"):
+            self.assertEqual(
+                jurisdiction,
+                build_workbook.validate_jurisdiction(jurisdiction),
+            )
+
+    def test_hostile_or_malformed_slug_components_fail_before_query_build(self) -> None:
+        for slug in (
+            "valid&select=*",
+            "valid#fragment",
+            "valid+slug",
+            "valid slug",
+            'valid"slug',
+            "valid,slug",
+            "valid/slug",
+        ):
+            with self.subTest(slug=slug), self.assertRaises(ValueError):
+                build_workbook.skills_query_path(slugs=[slug])
+
+        for slug_list in ("", "valid,", ",valid", "valid,,other"):
+            with self.subTest(slug_list=slug_list), self.assertRaises(ValueError):
+                build_workbook.parse_slug_list(slug_list)
+
+    def test_hostile_jurisdictions_fail_before_query_build(self) -> None:
+        for jurisdiction in (
+            "US-ND&select=*",
+            "US#fragment",
+            "US+CA",
+            "US CA",
+            "US,CA",
+            '"US"',
+            "General",
+        ):
+            with self.subTest(jurisdiction=jurisdiction), self.assertRaises(ValueError):
+                build_workbook.skills_query_path(jurisdiction=jurisdiction)
+
+    def test_selectors_are_mutually_exclusive_and_required(self) -> None:
+        with contextlib.redirect_stderr(io.StringIO()), self.assertRaises(SystemExit):
+            build_workbook.parse_arguments(self.base_args)
+        with contextlib.redirect_stderr(io.StringIO()), self.assertRaises(SystemExit):
+            build_workbook.parse_arguments(
+                [
+                    "--slugs",
+                    "ifrs15-revenue",
+                    "--jurisdiction",
+                    "US-ND",
+                    *self.base_args,
+                ]
+            )
+
+    def test_postgrest_filters_are_percent_encoded_as_single_values(self) -> None:
+        path = build_workbook.skills_query_path(
+            slugs=["ifrs15-revenue", "us-1099-k-and-payment-processors"]
+        )
+        self.assertIn("%28%22ifrs15-revenue%22%2C%22us-1099", path)
+        query = urllib.parse.parse_qs(urllib.parse.urlsplit(path).query)
+        self.assertEqual(
+            ['in.("ifrs15-revenue","us-1099-k-and-payment-processors")'],
+            query["slug"],
+        )
+        self.assertEqual(["eq.true"], query["is_published"])
+        self.assertEqual([build_workbook.SKILL_COLUMNS], query["select"])
+
+        grouped = build_workbook.skills_query_path(jurisdiction="EU/EEA/CH/UK")
+        self.assertIn("EU%2FEEA%2FCH%2FUK", grouped)
+        self.assertEqual(
+            ["eq.EU/EEA/CH/UK"],
+            urllib.parse.parse_qs(urllib.parse.urlsplit(grouped).query)["jurisdiction"],
+        )
+
+    def test_database_values_cannot_add_query_parameters(self) -> None:
+        path = build_workbook.rest_query_path(
+            "skill_versions",
+            skill_id="eq.id&select=*#fragment +space",
+            is_current="eq.true",
+            select="markdown_content,version",
+            limit="1",
+        )
+        query = urllib.parse.parse_qs(urllib.parse.urlsplit(path).query)
+        self.assertEqual(
+            {
+                "skill_id": ["eq.id&select=*#fragment +space"],
+                "is_current": ["eq.true"],
+                "select": ["markdown_content,version"],
+                "limit": ["1"],
+            },
+            query,
+        )
+        self.assertIn("%26select%3D%2A%23fragment%20%2Bspace", path)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## What

- require exactly one of `--slugs` and `--jurisdiction`
- validate selectors against the grammar used by the current repository inventory before constructing a PostgREST expression
- percent-encode every PostgREST query value, including current-version lookups
- keep OpenPyXL loading behind argument validation so the query helpers can run in the dependency-light maintenance test job
- add regression coverage for the full current inventory and hostile `&`, `#`, `+`, quote, comma, slash and whitespace inputs

## Why

The workbook generator interpolated command-line values directly into its URL. Reserved characters could split the query, create a fragment, or change the PostgREST filter expression. Encoding alone protects the URL boundary, but validation is also needed because PostgREST operators have their own expression grammar.

## Impact

Valid current selectors remain supported, including `US-NY-NYC`, `EU-27`, `EU/EEA/CH/UK`, `GLOBAL` and the repository's lowercase `general` exception. Malformed selectors now fail before environment access, network access or workbook creation. This PR does not touch the contradiction scanner or overlap with the open tax-year work in #98.

## Checks

- `python -m py_compile scripts/build-verification-workbook.py scripts/detect-contradictions.py tests/test_sync_integrity.py`
- `python -m unittest discover -s tests -p "test_*.py" -v` (40 passed)
- `python scripts/validate-guides.py --changed-only --no-index-check`
- mocked end-to-end workbook build (valid `.xlsx`, encoded skill and version queries)
- `git diff --check`