### PR TITLE
fix(mcp): report truncated search results

### DIFF
--- a/mcp/README.md
+++ b/mcp/README.md
@@ -51,7 +51,7 @@ The self-hosted server exposes 6 read-only tools below. The hosted server at `ht
 | `list_skills` | List published skills with quality tier and reviewing accountant. Optional `jurisdiction` (ISO code, e.g. `MT`, `GB`, `US-CA`) and `category` filters. |
 | `get_skill` | Given a skill `slug`, returns the full markdown plus a provenance/attribution footer. |
 | `get_skill_sections` | Given a `slug`, returns the skill parsed into sections (`heading`, `content`, `level`) for step-by-step application. |
-| `search_skills` | Keyword search across skill markdown (`query`, optional `jurisdiction`). Returns the matched section heading and a snippet. |
+| `search_skills` | Keyword search across skill markdown (`query`, optional `jurisdiction`). Returns at most 25 matched section headings and snippets, with `returned`, `limit`, and `truncated` metadata. The legacy `total` field is the returned count, not an exact corpus-wide count when `truncated` is true. |
 | `submit_feedback` | Build a pre-filled GitHub New Issue URL the user opens to submit feedback (skill problem, missing jurisdiction, bug, etc.). Takes `summary` plus optional `title`, `skill_slug`, `jurisdiction`, `rating`. Returns `github_url`, `title`, `body`, `labels`. No server-side auth — user submits under their own account. |
 
 Skill access is **read-only** and **path-sandboxed** to the `packages/` directory; `submit_feedback` does not call GitHub itself, it only constructs a URL.

--- a/mcp/README.md
+++ b/mcp/README.md
@@ -51,7 +51,7 @@ The self-hosted server exposes 6 read-only tools below. The hosted server at `ht
 | `list_skills` | List published skills with quality tier and reviewing accountant. Optional `jurisdiction` (ISO code, e.g. `MT`, `GB`, `US-CA`) and `category` filters. |
 | `get_skill` | Given a skill `slug`, returns the full markdown plus a provenance/attribution footer. |
 | `get_skill_sections` | Given a `slug`, returns the skill parsed into sections (`heading`, `content`, `level`) for step-by-step application. |
-| `search_skills` | Keyword search across skill markdown (`query`, optional `jurisdiction`). Returns at most 25 matched section headings and snippets, with `returned`, `limit`, and `truncated` metadata. The legacy `total` field is the returned count, not an exact corpus-wide count when `truncated` is true. |
+| `search_skills` | Keyword search across skill markdown (`query`, optional `jurisdiction`). Returns at most 25 matched section headings and snippets, with `returned`, `limit`, `truncated` and `unreadable_skipped` metadata. There is no `total`: a capped count under that name would assert an exact corpus-wide figure it does not have. |
 | `submit_feedback` | Build a pre-filled GitHub New Issue URL the user opens to submit feedback (skill problem, missing jurisdiction, bug, etc.). Takes `summary` plus optional `title`, `skill_slug`, `jurisdiction`, `rating`. Returns `github_url`, `title`, `body`, `labels`. No server-side auth — user submits under their own account. |
 
 Skill access is **read-only** and **path-sandboxed** to the `packages/` directory; `submit_feedback` does not call GitHub itself, it only constructs a URL.

--- a/mcp/README.md
+++ b/mcp/README.md
@@ -51,7 +51,7 @@ The self-hosted server exposes 6 read-only tools below. The hosted server at `ht
 | `list_skills` | List published skills with quality tier and reviewing accountant. Optional `jurisdiction` (ISO code, e.g. `MT`, `GB`, `US-CA`) and `category` filters. |
 | `get_skill` | Given a skill `slug`, returns the full markdown plus a provenance/attribution footer. |
 | `get_skill_sections` | Given a `slug`, returns the skill parsed into sections (`heading`, `content`, `level`) for step-by-step application. |
-| `search_skills` | Keyword search across skill markdown (`query`, optional `jurisdiction`). Returns at most 25 matched section headings and snippets, with `returned`, `limit`, `truncated` and `unreadable_skipped` metadata. There is no `total`: a capped count under that name would assert an exact corpus-wide figure it does not have. |
+| `search_skills` | Keyword search across skill markdown (`query`, optional `jurisdiction`). Returns at most 25 matched section headings and snippets, with `returned`, `limit`, `truncated` and `unreadable_skipped` metadata. The backwards-compatible `total` field aliases `returned`; neither field is a corpus-wide match count when `truncated` is true. |
 | `submit_feedback` | Build a pre-filled GitHub New Issue URL the user opens to submit feedback (skill problem, missing jurisdiction, bug, etc.). Takes `summary` plus optional `title`, `skill_slug`, `jurisdiction`, `rating`. Returns `github_url`, `title`, `body`, `labels`. No server-side auth — user submits under their own account. |
 
 Skill access is **read-only** and **path-sandboxed** to the `packages/` directory; `submit_feedback` does not call GitHub itself, it only constructs a URL.

--- a/mcp/openaccountants_mcp/server.py
+++ b/mcp/openaccountants_mcp/server.py
@@ -624,13 +624,16 @@ def search_skills(query: str, jurisdiction: str | None = None) -> dict[str, Any]
         jurisdiction: Optional jurisdiction code to limit the search.
 
     Returns:
-        ``{"results": [...], "returned": n, "total": n,
-        "truncated": bool, "limit": n}`` — each result has slug, title,
-        jurisdiction, matched_section and snippet. ``total`` is retained as a
-        backwards-compatible alias for ``returned``; it is not a corpus-wide
-        count when ``truncated`` is true. This avoids presenting the result cap
-        as an exact match count without paying the cost of reading every skill
-        body.
+        ``{"results": [...], "returned": n, "truncated": bool, "limit": n,
+        "unreadable_skipped": n, "unreadable_slugs": [...]}`` — each result has
+        slug, title, jurisdiction, matched_section and snippet.
+
+        ``returned`` is exactly ``len(results)``. There is no ``total``: a
+        capped count published under that name asserts an exact corpus-wide
+        figure it does not have, and counting the rest would mean reading every
+        skill body. ``truncated`` says more matches exist beyond ``limit``;
+        ``unreadable_skipped`` says how many skills could not be read at all, so
+        a caller can tell an incomplete answer from a complete one.
     """
     q = (query or "").strip()
     if not q:
@@ -638,20 +641,27 @@ def search_skills(query: str, jurisdiction: str | None = None) -> dict[str, Any]
     jx = jurisdiction.upper() if jurisdiction else None
 
     results = []
+    unreadable: list[str] = []
     truncated = False
     for rec in _index().values():
         if jx and rec["jurisdiction"].upper() != jx:
             continue
         try:
             _, body = _read_skill(rec["slug"])
-        except (OSError, ValueError):
+        except (OSError, ValueError) as exc:
+            # An unreadable body is not a non-match. Swallowing it let an
+            # incomplete result set report itself complete, and could hide the
+            # truncation flag when every match past the cap was unreadable
+            # (26 matches used to answer returned 25, truncated false).
+            log.warning("search skipped unreadable skill %r: %s", rec["slug"], exc)
+            unreadable.append(rec["slug"])
             continue
         if q.lower() not in body.lower():
             continue
-        section, snippet = _extract_match(body, q)
         if len(results) >= SEARCH_LIMIT:
             truncated = True
             break
+        section, snippet = _extract_match(body, q)
         results.append({
             "slug": rec["slug"],
             "title": rec["title"],
@@ -677,13 +687,18 @@ def search_skills(query: str, jurisdiction: str | None = None) -> dict[str, Any]
             "list_skills(). If the corpus genuinely lacks this, call "
             "submit_feedback() to flag the gap."
         )
-    returned = len(results)
+    if unreadable:
+        next_action = (
+            f"{len(unreadable)} matching-or-not skill(s) could not be read, so "
+            "this result set may be incomplete. " + next_action
+        )
     return {
         "results": results,
-        "returned": returned,
-        "total": returned,
+        "returned": len(results),
         "truncated": truncated,
         "limit": SEARCH_LIMIT,
+        "unreadable_skipped": len(unreadable),
+        "unreadable_slugs": unreadable[:SEARCH_LIMIT],
         "next_action": next_action,
     }
 

--- a/mcp/openaccountants_mcp/server.py
+++ b/mcp/openaccountants_mcp/server.py
@@ -624,8 +624,13 @@ def search_skills(query: str, jurisdiction: str | None = None) -> dict[str, Any]
         jurisdiction: Optional jurisdiction code to limit the search.
 
     Returns:
-        ``{"results": [...], "total": n}`` — each result has slug, title,
-        jurisdiction, matched_section and snippet.
+        ``{"results": [...], "returned": n, "total": n,
+        "truncated": bool, "limit": n}`` — each result has slug, title,
+        jurisdiction, matched_section and snippet. ``total`` is retained as a
+        backwards-compatible alias for ``returned``; it is not a corpus-wide
+        count when ``truncated`` is true. This avoids presenting the result cap
+        as an exact match count without paying the cost of reading every skill
+        body.
     """
     q = (query or "").strip()
     if not q:
@@ -633,6 +638,7 @@ def search_skills(query: str, jurisdiction: str | None = None) -> dict[str, Any]
     jx = jurisdiction.upper() if jurisdiction else None
 
     results = []
+    truncated = False
     for rec in _index().values():
         if jx and rec["jurisdiction"].upper() != jx:
             continue
@@ -643,6 +649,9 @@ def search_skills(query: str, jurisdiction: str | None = None) -> dict[str, Any]
         if q.lower() not in body.lower():
             continue
         section, snippet = _extract_match(body, q)
+        if len(results) >= SEARCH_LIMIT:
+            truncated = True
+            break
         results.append({
             "slug": rec["slug"],
             "title": rec["title"],
@@ -650,20 +659,33 @@ def search_skills(query: str, jurisdiction: str | None = None) -> dict[str, Any]
             "matched_section": section,
             "snippet": snippet,
         })
-        if len(results) >= SEARCH_LIMIT:
-            break
     if results:
-        next_action = (
-            "Load the most relevant match with get_skill(slug), then apply its "
-            "rules. For a guided, scoped plan, call start(intent, jurisdiction)."
-        )
+        if truncated:
+            next_action = (
+                f"More than {SEARCH_LIMIT} skills matched. Narrow the query or "
+                "jurisdiction, or load the most relevant returned match with "
+                "get_skill(slug)."
+            )
+        else:
+            next_action = (
+                "Load the most relevant match with get_skill(slug), then apply its "
+                "rules. For a guided, scoped plan, call start(intent, jurisdiction)."
+            )
     else:
         next_action = (
             "No matches. Broaden the query or confirm the jurisdiction with "
             "list_skills(). If the corpus genuinely lacks this, call "
             "submit_feedback() to flag the gap."
         )
-    return {"results": results, "total": len(results), "next_action": next_action}
+    returned = len(results)
+    return {
+        "results": results,
+        "returned": returned,
+        "total": returned,
+        "truncated": truncated,
+        "limit": SEARCH_LIMIT,
+        "next_action": next_action,
+    }
 
 
 # ---------------------------------------------------------------------------

--- a/mcp/openaccountants_mcp/server.py
+++ b/mcp/openaccountants_mcp/server.py
@@ -628,12 +628,14 @@ def search_skills(query: str, jurisdiction: str | None = None) -> dict[str, Any]
         "unreadable_skipped": n, "unreadable_slugs": [...]}`` — each result has
         slug, title, jurisdiction, matched_section and snippet.
 
-        ``returned`` is exactly ``len(results)``. There is no ``total``: a
-        capped count published under that name asserts an exact corpus-wide
-        figure it does not have, and counting the rest would mean reading every
-        skill body. ``truncated`` says more matches exist beyond ``limit``;
-        ``unreadable_skipped`` says how many skills could not be read at all, so
-        a caller can tell an incomplete answer from a complete one.
+        ``returned`` is exactly ``len(results)``. ``total`` is retained as a
+        backwards-compatible alias of ``returned`` for callers that already
+        consume it; like ``returned``, it is the count of returned matches, not
+        a corpus-wide figure, because counting the rest would mean reading
+        every skill body. ``truncated`` says more matches exist beyond
+        ``limit``; ``unreadable_skipped`` says how many skills could not be
+        read at all, so a caller can tell an incomplete answer from a complete
+        one.
     """
     q = (query or "").strip()
     if not q:
@@ -695,6 +697,7 @@ def search_skills(query: str, jurisdiction: str | None = None) -> dict[str, Any]
     return {
         "results": results,
         "returned": len(results),
+        "total": len(results),
         "truncated": truncated,
         "limit": SEARCH_LIMIT,
         "unreadable_skipped": len(unreadable),

--- a/mcp/smoke_test.py
+++ b/mcp/smoke_test.py
@@ -199,10 +199,12 @@ check("truncation note present", "truncated" in long_fb["body"].lower())
 print("\nsearch_skills('reverse charge', 'MT'):")
 sr = S.search_skills("reverse charge", "MT")
 check("returns bounded-search metadata",
-      set(sr) >= {"results", "returned", "total", "truncated", "limit"})
+      set(sr) >= {"results", "returned", "truncated", "limit", "unreadable_skipped"})
 check("has matches", sr["returned"] > 0, f"got {sr['returned']}")
 check("returned agrees with results", sr["returned"] == len(sr["results"]))
-check("legacy total agrees with returned", sr["total"] == sr["returned"])
+check("no misleading exact total is published", "total" not in sr)
+check("nothing unreadable in a clean checkout", sr["unreadable_skipped"] == 0,
+      str(sr.get("unreadable_slugs")))
 if sr["results"]:
     check("result shape",
           set(sr["results"][0]) >= {"slug", "title", "jurisdiction", "matched_section", "snippet"})

--- a/mcp/smoke_test.py
+++ b/mcp/smoke_test.py
@@ -198,8 +198,11 @@ check("truncation note present", "truncated" in long_fb["body"].lower())
 # --- search_skills --------------------------------------------------------
 print("\nsearch_skills('reverse charge', 'MT'):")
 sr = S.search_skills("reverse charge", "MT")
-check("returns results + total", "results" in sr and "total" in sr)
-check("has matches", sr["total"] > 0, f"got {sr['total']}")
+check("returns bounded-search metadata",
+      set(sr) >= {"results", "returned", "total", "truncated", "limit"})
+check("has matches", sr["returned"] > 0, f"got {sr['returned']}")
+check("returned agrees with results", sr["returned"] == len(sr["results"]))
+check("legacy total agrees with returned", sr["total"] == sr["returned"])
 if sr["results"]:
     check("result shape",
           set(sr["results"][0]) >= {"slug", "title", "jurisdiction", "matched_section", "snippet"})

--- a/mcp/smoke_test.py
+++ b/mcp/smoke_test.py
@@ -199,10 +199,10 @@ check("truncation note present", "truncated" in long_fb["body"].lower())
 print("\nsearch_skills('reverse charge', 'MT'):")
 sr = S.search_skills("reverse charge", "MT")
 check("returns bounded-search metadata",
-      set(sr) >= {"results", "returned", "truncated", "limit", "unreadable_skipped"})
+      set(sr) >= {"results", "returned", "total", "truncated", "limit", "unreadable_skipped"})
 check("has matches", sr["returned"] > 0, f"got {sr['returned']}")
 check("returned agrees with results", sr["returned"] == len(sr["results"]))
-check("no misleading exact total is published", "total" not in sr)
+check("total aliases returned", sr["total"] == sr["returned"])
 check("nothing unreadable in a clean checkout", sr["unreadable_skipped"] == 0,
       str(sr.get("unreadable_slugs")))
 if sr["results"]:

--- a/mcp/tests/test_search_skills.py
+++ b/mcp/tests/test_search_skills.py
@@ -28,9 +28,10 @@ class SearchSkillsTests(unittest.TestCase):
             response = server.search_skills("searchable phrase")
 
         self.assertEqual(response["returned"], 3)
-        self.assertEqual(response["total"], 3)
+        self.assertNotIn("total", response)
         self.assertFalse(response["truncated"])
         self.assertEqual(response["limit"], server.SEARCH_LIMIT)
+        self.assertEqual(response["unreadable_skipped"], 0)
 
     def test_stops_after_one_match_beyond_limit(self) -> None:
         records = {
@@ -45,7 +46,6 @@ class SearchSkillsTests(unittest.TestCase):
 
         self.assertEqual(response["returned"], server.SEARCH_LIMIT)
         self.assertEqual(len(response["results"]), server.SEARCH_LIMIT)
-        self.assertEqual(response["total"], server.SEARCH_LIMIT)
         self.assertTrue(response["truncated"])
         self.assertEqual(read_skill.call_count, server.SEARCH_LIMIT + 1)
         self.assertIn("Narrow the query", response["next_action"])
@@ -68,8 +68,101 @@ class SearchSkillsTests(unittest.TestCase):
             response = server.search_skills("searchable phrase", jurisdiction="AU")
 
         self.assertEqual(response["returned"], 2)
-        self.assertEqual(response["total"], 2)
         self.assertFalse(response["truncated"])
+
+
+class SearchBoundaryTests(unittest.TestCase):
+    """Exactly at the cap. Without this the boundary the change exists to get
+    right is unverified: a refactor evaluating the cap before the body-match
+    check passes every other test while a 25-match query reports truncated."""
+
+    @staticmethod
+    def _reader(non_matching: set[str]):
+        def read(slug: str) -> tuple[dict[str, str], str]:
+            if slug in non_matching:
+                return {"slug": slug}, "# Topic\n\nNothing relevant here.\n"
+            return _body(slug)
+
+        return read
+
+    def test_exactly_at_the_limit_is_not_truncated(self) -> None:
+        """25 matches, then skills that do not match. The cap must be reached by
+        a 26th match, not by the 26th record the loop happens to visit."""
+        total = server.SEARCH_LIMIT + 5
+        records = {f"skill-{number}": _record(number) for number in range(total)}
+        quiet = {f"skill-{number}" for number in range(server.SEARCH_LIMIT, total)}
+
+        with patch.object(server, "_index", return_value=records), patch.object(
+            server, "_read_skill", side_effect=self._reader(quiet)
+        ):
+            response = server.search_skills("searchable phrase")
+
+        self.assertEqual(response["returned"], server.SEARCH_LIMIT)
+        self.assertFalse(response["truncated"])
+        self.assertNotIn("Narrow the query", response["next_action"])
+
+    def test_one_past_the_limit_is_truncated(self) -> None:
+        records = {
+            f"skill-{number}": _record(number)
+            for number in range(server.SEARCH_LIMIT + 1)
+        }
+
+        with patch.object(server, "_index", return_value=records), patch.object(
+            server, "_read_skill", side_effect=_body
+        ):
+            response = server.search_skills("searchable phrase")
+
+        self.assertEqual(response["returned"], server.SEARCH_LIMIT)
+        self.assertTrue(response["truncated"])
+
+
+class UnreadableSkillTests(unittest.TestCase):
+    """An unreadable body must be counted, not swallowed."""
+
+    @staticmethod
+    def _reader(unreadable: set[str]):
+        def read(slug: str) -> tuple[dict[str, str], str]:
+            if slug in unreadable:
+                raise OSError("file moved after the index snapshot")
+            return _body(slug)
+
+        return read
+
+    def test_unreadable_matches_are_reported_not_swallowed(self) -> None:
+        """10 skills match, 3 move after the lru_cached _index() snapshot; the
+        caller used to be told returned 7 with nothing else said."""
+        records = {f"skill-{number}": _record(number) for number in range(10)}
+        gone = {"skill-2", "skill-5", "skill-8"}
+
+        with patch.object(server, "_index", return_value=records), patch.object(
+            server, "_read_skill", side_effect=self._reader(gone)
+        ):
+            response = server.search_skills("searchable phrase")
+
+        self.assertEqual(response["returned"], 7)
+        self.assertEqual(response["unreadable_skipped"], 3)
+        self.assertEqual(sorted(response["unreadable_slugs"]), sorted(gone))
+        self.assertIn("may be incomplete", response["next_action"])
+
+    def test_an_unreadable_match_past_the_cap_does_not_claim_completeness(self) -> None:
+        """When every match past the cap is unreadable the loop never reaches a
+        26th success, so truncated stays false. The skipped count is then the
+        only thing standing between the caller and a false 'complete'."""
+        records = {
+            f"skill-{number}": _record(number)
+            for number in range(server.SEARCH_LIMIT + 1)
+        }
+        gone = {f"skill-{server.SEARCH_LIMIT}"}
+
+        with patch.object(server, "_index", return_value=records), patch.object(
+            server, "_read_skill", side_effect=self._reader(gone)
+        ):
+            response = server.search_skills("searchable phrase")
+
+        self.assertEqual(response["returned"], server.SEARCH_LIMIT)
+        self.assertFalse(response["truncated"])
+        self.assertEqual(response["unreadable_skipped"], 1)
+        self.assertIn("may be incomplete", response["next_action"])
 
 
 if __name__ == "__main__":

--- a/mcp/tests/test_search_skills.py
+++ b/mcp/tests/test_search_skills.py
@@ -1,0 +1,76 @@
+from __future__ import annotations
+
+import unittest
+from unittest.mock import patch
+
+from openaccountants_mcp import server
+
+
+def _record(number: int, jurisdiction: str = "AU") -> dict[str, str]:
+    return {
+        "slug": f"skill-{number}",
+        "title": f"Skill {number}",
+        "jurisdiction": jurisdiction,
+    }
+
+
+def _body(slug: str) -> tuple[dict[str, str], str]:
+    return {"slug": slug}, "# Topic\n\nA searchable phrase appears here."
+
+
+class SearchSkillsTests(unittest.TestCase):
+    def test_reports_exact_total_when_complete(self) -> None:
+        records = {f"skill-{number}": _record(number) for number in range(3)}
+
+        with patch.object(server, "_index", return_value=records), patch.object(
+            server, "_read_skill", side_effect=_body
+        ):
+            response = server.search_skills("searchable phrase")
+
+        self.assertEqual(response["returned"], 3)
+        self.assertEqual(response["total"], 3)
+        self.assertFalse(response["truncated"])
+        self.assertEqual(response["limit"], server.SEARCH_LIMIT)
+
+    def test_stops_after_one_match_beyond_limit(self) -> None:
+        records = {
+            f"skill-{number}": _record(number)
+            for number in range(server.SEARCH_LIMIT + 10)
+        }
+
+        with patch.object(server, "_index", return_value=records), patch.object(
+            server, "_read_skill", side_effect=_body
+        ) as read_skill:
+            response = server.search_skills("searchable phrase")
+
+        self.assertEqual(response["returned"], server.SEARCH_LIMIT)
+        self.assertEqual(len(response["results"]), server.SEARCH_LIMIT)
+        self.assertEqual(response["total"], server.SEARCH_LIMIT)
+        self.assertTrue(response["truncated"])
+        self.assertEqual(read_skill.call_count, server.SEARCH_LIMIT + 1)
+        self.assertIn("Narrow the query", response["next_action"])
+
+    def test_non_matching_jurisdictions_do_not_trigger_truncation(self) -> None:
+        records = {
+            **{f"au-{number}": _record(number, "AU") for number in range(2)},
+            **{
+                f"gb-{number}": {
+                    **_record(number, "GB"),
+                    "slug": f"gb-skill-{number}",
+                }
+                for number in range(server.SEARCH_LIMIT + 5)
+            },
+        }
+
+        with patch.object(server, "_index", return_value=records), patch.object(
+            server, "_read_skill", side_effect=_body
+        ):
+            response = server.search_skills("searchable phrase", jurisdiction="AU")
+
+        self.assertEqual(response["returned"], 2)
+        self.assertEqual(response["total"], 2)
+        self.assertFalse(response["truncated"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/mcp/tests/test_search_skills.py
+++ b/mcp/tests/test_search_skills.py
@@ -28,10 +28,24 @@ class SearchSkillsTests(unittest.TestCase):
             response = server.search_skills("searchable phrase")
 
         self.assertEqual(response["returned"], 3)
-        self.assertNotIn("total", response)
+        self.assertEqual(response["total"], 3)
         self.assertFalse(response["truncated"])
         self.assertEqual(response["limit"], server.SEARCH_LIMIT)
         self.assertEqual(response["unreadable_skipped"], 0)
+
+    def test_total_aliases_returned_when_truncated(self) -> None:
+        records = {
+            f"skill-{number}": _record(number)
+            for number in range(server.SEARCH_LIMIT + 1)
+        }
+
+        with patch.object(server, "_index", return_value=records), patch.object(
+            server, "_read_skill", side_effect=_body
+        ):
+            response = server.search_skills("searchable phrase")
+
+        self.assertTrue(response["truncated"])
+        self.assertEqual(response["total"], response["returned"])
 
     def test_stops_after_one_match_beyond_limit(self) -> None:
         records = {


### PR DESCRIPTION
## What

- scan only until the first match beyond the 25-result cap
- return `returned`, `limit`, and `truncated` metadata
- keep `total` as a backwards-compatible alias of the returned count and document that it is not corpus-wide when truncated
- tell callers to narrow the query or jurisdiction when more results exist
- add focused regression tests and update the smoke test and MCP documentation

## Why

`search_skills()` previously stopped at 25 and returned `total: 25`, even when many more skills matched. A full exact count is not a good replacement: on the current corpus a warm `tax` search using the proposed full-body count took about 1.74 seconds in earlier benchmarking, versus about 0.03 seconds for the capped search.

This change makes truncation explicit while retaining the bounded-read behaviour and the existing integer `total` field for callers that already consume it.

## Impact

- no generated `packages/**` files are changed
- existing callers still receive `results` and an integer `total`
- callers can now distinguish a complete result set from the first 25 matches
- the function reads at most one additional matching skill body

## Checks

- `uv sync --locked --directory mcp`
- `uv run --locked --directory mcp python -m unittest discover -s tests -v` (5 passed)
- `PYTHONUTF8=1 uv run --locked --directory mcp python smoke_test.py` (all checks passed)
- `uv run --locked --directory mcp python -m compileall -q openaccountants_mcp tests smoke_test.py`
- `git diff --check`
- current-corpus warm probe: `tax` returned 25, `truncated: true`, in 0.0349 seconds

The smoke test emits the current generated-package YAML salvage warnings; those are addressed separately by #101.
