### PR TITLE
fix(mcp): bundle skills in built distributions

### DIFF
--- a/.github/workflows/mcp-package.yml
+++ b/.github/workflows/mcp-package.yml
@@ -1,0 +1,46 @@
+name: MCP package
+
+on:
+  pull_request:
+    paths:
+      - "mcp/**"
+      - "packages/**"
+      - ".github/workflows/mcp-package.yml"
+  push:
+    branches: [main]
+    paths:
+      - "mcp/**"
+      - "packages/**"
+      - ".github/workflows/mcp-package.yml"
+
+permissions:
+  contents: read
+
+jobs:
+  build-install-test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+        with:
+          persist-credentials: false
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
+        with:
+          python-version: "3.11"
+      - name: Build sdist and wheel
+        run: |
+          python -m pip install --disable-pip-version-check "build==1.5.0"
+          python -m build mcp --outdir dist
+      - name: Install and exercise the wheel outside the checkout
+        run: |
+          TEST_ROOT="$(mktemp -d)"
+          python -m venv "$TEST_ROOT/venv"
+          "$TEST_ROOT/venv/bin/pip" install dist/*.whl
+          cd "$TEST_ROOT"
+          "$TEST_ROOT/venv/bin/python" - <<'PY'
+          from openaccountants_mcp import server
+
+          result = server.list_skills()
+          assert result["total"] > 300, result
+          assert server.PACKAGES_DIR.is_relative_to(server._MODULE_DIR), server.PACKAGES_DIR
+          print(f"installed wheel exposes {result['total']} bundled skills")
+          PY

--- a/Dockerfile
+++ b/Dockerfile
@@ -26,12 +26,14 @@ FROM python:3.11-slim
 
 WORKDIR /app
 
-# Install the MCP server package first so the dependency layer caches well.
+# Skill content the server reads from $OPENACCOUNTANTS_ROOT/packages. It has to
+# land before the install: mcp/hatch_build.py bundles this tree into the wheel
+# and fails closed without it, so installing first aborted the whole build.
+COPY packages ./packages
+
+# Install the MCP server package.
 COPY mcp ./mcp
 RUN pip install --no-cache-dir ./mcp
-
-# Skill content the server reads from $OPENACCOUNTANTS_ROOT/packages.
-COPY packages ./packages
 
 ENV OPENACCOUNTANTS_ROOT=/app \
     MCP_TRANSPORT=streamable-http \

--- a/mcp/README.md
+++ b/mcp/README.md
@@ -132,20 +132,18 @@ For contributors, or if you want the server to read your local, editable checkou
 ```bash
 git clone https://github.com/openaccountants/openaccountants.git
 cd openaccountants
-pip install ./mcp
+pip install -e ./mcp
 ```
 
 Or with `uv`:
 
 ```bash
-uv pip install ./mcp
+uv pip install -e ./mcp
 ```
 
-The server reads `packages/` from the repo root (override with `OPENACCOUNTANTS_ROOT`, see environment variables below).
+The `-e` matters. Without it both commands are ordinary non-editable installs: the build hook bundles a **snapshot** of `packages/` into the installed package and the server prefers that snapshot, so editing a guide in your checkout changes nothing until you reinstall. With `-e` the server resolves `packages/` from the repo root and picks up edits immediately. Either way `OPENACCOUNTANTS_ROOT` overrides the choice (see environment variables below).
 
-Published wheels and source distributions bundle the generated skill packages.
-Development installs continue to read the checkout's top-level `packages/`
-tree, so local source edits are visible without rebuilding the package.
+Published wheels and source distributions bundle the generated skill packages, which is what lets a plain `pip install openaccountants-mcp` work with no checkout at all.
 
 ### Connect to your AI client
 
@@ -245,7 +243,7 @@ docker run --rm -p 127.0.0.1:8000:8000 \
   openaccountants-mcp
 ```
 
-The default stdio transport (`pip install ./mcp && openaccountants-mcp`) is unchanged.
+The default stdio transport (`pip install -e ./mcp && openaccountants-mcp`) is unchanged.
 
 ## Environment variables
 

--- a/mcp/README.md
+++ b/mcp/README.md
@@ -143,6 +143,10 @@ uv pip install ./mcp
 
 The server reads `packages/` from the repo root (override with `OPENACCOUNTANTS_ROOT`, see environment variables below).
 
+Published wheels and source distributions bundle the generated skill packages.
+Development installs continue to read the checkout's top-level `packages/`
+tree, so local source edits are visible without rebuilding the package.
+
 ### Connect to your AI client
 
 Pick **one** of the following.
@@ -247,7 +251,7 @@ The default stdio transport (`pip install ./mcp && openaccountants-mcp`) is unch
 
 | Variable | Default | Description |
 |----------|---------|-------------|
-| `OPENACCOUNTANTS_ROOT` | Auto-detected repo root (parent of `mcp/`) | Path to your OpenAccountants checkout. The server reads `$OPENACCOUNTANTS_ROOT/packages/`. |
+| `OPENACCOUNTANTS_ROOT` | Auto-detected checkout root, or bundled package data in a distribution | Optional path to a directory containing `packages/`. Set it to override the bundled or checkout data. |
 | `MCP_TRANSPORT` | `stdio` | `stdio`, `streamable-http`, or `sse`. HTTP transports let remote MCP clients connect via a reverse proxy. |
 | `MCP_HOST` | `127.0.0.1` | Bind host for HTTP transports. Set explicitly, for example to `0.0.0.0`, only when an authenticated reverse proxy or equivalent network boundary is intentionally exposing the service. |
 | `MCP_PORT` | `8000` | Bind port for HTTP transports. |

--- a/mcp/hatch_build.py
+++ b/mcp/hatch_build.py
@@ -1,0 +1,35 @@
+"""Bundle the generated skill packages into MCP sdists and wheels."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from hatchling.builders.hooks.plugin.interface import BuildHookInterface
+
+
+class CustomBuildHook(BuildHookInterface):
+    """Include external repo data without copying it into the working tree."""
+
+    def initialize(self, version: str, build_data: dict) -> None:
+        project_root = Path(self.root)
+        source_packages = project_root.parent / "packages"
+        sdist_packages = project_root / "_bundled_packages"
+
+        if source_packages.is_dir():
+            packages = source_packages
+        elif sdist_packages.is_dir():
+            packages = sdist_packages
+        else:
+            raise RuntimeError(
+                "Cannot build openaccountants-mcp without the generated packages/ tree"
+            )
+
+        if not any(packages.rglob("*.md")):
+            raise RuntimeError(f"No skill markdown found under {packages}")
+
+        destination = (
+            "_bundled_packages"
+            if self.target_name == "sdist"
+            else "openaccountants_mcp/packages"
+        )
+        build_data["force_include"][str(packages)] = destination

--- a/mcp/openaccountants_mcp/server.py
+++ b/mcp/openaccountants_mcp/server.py
@@ -263,15 +263,17 @@ def _catalogue() -> tuple[
     """Build the index, unresolved slug map, and duplicate inventory."""
     out: dict[str, dict[str, Any]] = {}
     if not PACKAGES_DIR.is_dir():
-        return out, {}, {
-            "skill_files": 0,
-            "slugs": 0,
-            "duplicate_slugs": 0,
-            "identical_aliases": 0,
-            "federal_precedence": 0,
-            "ambiguous_slugs": 0,
-            "rejected_paths": [],
-        }
+        # Absence is a misconfiguration, not an empty corpus. Returning an
+        # empty catalogue here answered OPENACCOUNTANTS_ROOT=/nonexistent with
+        # a confident "0 skills" and logged nothing, which is the same silent
+        # data-absence failure this package's bundling is meant to end.
+        message = (
+            f"No skill corpus at {PACKAGES_DIR}. Point OPENACCOUNTANTS_ROOT at a "
+            "directory containing packages/, or install a distribution that "
+            "bundles it."
+        )
+        log.error(message)
+        raise RuntimeError(message)
 
     # Pass 1: parse every skill file; tally each directory's declared codes.
     rows: list[dict[str, Any]] = []

--- a/mcp/openaccountants_mcp/server.py
+++ b/mcp/openaccountants_mcp/server.py
@@ -18,9 +18,10 @@ checkout you point it at.
 
 Environment
 -----------
-OPENACCOUNTANTS_ROOT      Path to the repo checkout.  Defaults to two directories
-                          above this file (i.e. the repo root when this package
-                          lives at ``mcp/openaccountants_mcp/``).
+OPENACCOUNTANTS_ROOT      Optional path to a repo checkout or other directory
+                          containing ``packages/``. Development installs default
+                          to the repo root; built distributions default to the
+                          skill packages bundled inside the Python package.
 MCP_TRANSPORT             ``stdio`` (default), ``streamable-http``, or ``sse``.
                           HTTP transports let remote MCP clients connect via a
                           reverse proxy (Caddy, nginx, ngrok…).
@@ -57,9 +58,19 @@ log = logging.getLogger(__name__)
 # Resolve repo root + packages directory
 # ---------------------------------------------------------------------------
 
-_DEFAULT_ROOT = Path(__file__).resolve().parents[2]  # mcp/openaccountants_mcp/ -> mcp/ -> repo
-REPO_ROOT = Path(os.environ.get("OPENACCOUNTANTS_ROOT", str(_DEFAULT_ROOT))).resolve()
-PACKAGES_DIR = REPO_ROOT / "packages"
+_MODULE_DIR = Path(__file__).resolve().parent
+_SOURCE_ROOT = _MODULE_DIR.parents[1]  # mcp/openaccountants_mcp/ -> mcp/ -> repo
+_BUNDLED_PACKAGES_DIR = _MODULE_DIR / "packages"
+
+if configured_root := os.environ.get("OPENACCOUNTANTS_ROOT"):
+    REPO_ROOT = Path(configured_root).resolve()
+    PACKAGES_DIR = REPO_ROOT / "packages"
+elif _BUNDLED_PACKAGES_DIR.is_dir():
+    REPO_ROOT = _MODULE_DIR
+    PACKAGES_DIR = _BUNDLED_PACKAGES_DIR
+else:
+    REPO_ROOT = _SOURCE_ROOT
+    PACKAGES_DIR = REPO_ROOT / "packages"
 
 MAX_FILE_BYTES = 2 * 1024 * 1024  # 2 MB safety cap
 SEARCH_LIMIT = 25

--- a/mcp/pyproject.toml
+++ b/mcp/pyproject.toml
@@ -32,5 +32,8 @@ Documentation = "https://github.com/openaccountants/openaccountants/tree/main/mc
 openaccountants-mcp = "openaccountants_mcp.server:main"
 
 [build-system]
-requires = ["hatchling"]
+requires = ["hatchling==1.32.0"]
 build-backend = "hatchling.build"
+
+[tool.hatch.build.hooks.custom]
+path = "hatch_build.py"


### PR DESCRIPTION
## What

- bundle the generated `packages/` tree into both the MCP sdist and wheel through a Hatch build hook
- prefer bundled data in installed distributions while retaining checkout data for development installs and `OPENACCOUNTANTS_ROOT` overrides
- pin the isolated Hatchling backend exactly
- add a least-privilege package workflow that builds the sdist and wheel, installs the wheel in a clean environment outside the checkout, and requires more than 300 discoverable skills
- document the installed-versus-development data selection

## Why

The documented no-clone installation did not contain a corpus. A fresh build from current `main` produced a wheel with only three Python modules; the current public PyPI `openaccountants-mcp==0.1.1` wheel is likewise about 5 KB and contains no skill files. It can import, but `list_skills()`/the equivalent old discovery surface sees no packages unless an external checkout is supplied through `OPENACCOUNTANTS_ROOT`.

An import-only CI check would therefore repeat the false pass. This workflow exercises discovery from the installed wheel with no checkout path override.

## Impact

- built artefacts are intentionally larger because they now contain the advertised corpus
- source checkouts still read the top-level `packages/` tree, so normal development remains unchanged
- the build fails closed if the generated package tree is absent or has no Markdown skills
- no generated package file is edited in this PR

## Checks

- `python -m build mcp --outdir dist-test`
  - sdist built successfully from the checkout
  - wheel built successfully from that sdist
- clean Windows virtual environment installed the wheel outside the checkout
- installed-wheel `list_skills()` returned 1,826 skills and resolved data inside `site-packages/openaccountants_mcp/packages`
- wheel: 61,585,307 bytes and 5,740 Markdown files
- sdist: 55,474,220 bytes and 5,740 Markdown files
- Python compileall passed
- workflow YAML parse and actionlint 1.7.12 passed
- `git diff --check` passed

The current generated package tree still emits the malformed-frontmatter salvage warnings already addressed by #101. This PR should be merged after the repaired source is ingested and packages are regenerated, so the first corrected artefact does not preserve that legacy warning baseline.
