### PR TITLE
ci: pin actions and scope checkout credentials

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,13 @@
+version: 2
+updates:
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 5
+
+  - package-ecosystem: pip
+    directory: /mcp
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 5

--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -40,7 +40,7 @@ jobs:
     steps:
       - name: "CLA Assistant"
         if: (github.event.comment.body == 'recheck' || github.event.comment.body == 'I have read the CLA Document and I hereby sign the CLA') || github.event_name == 'pull_request_target'
-        uses: contributor-assistant/github-action@v2.6.1
+        uses: contributor-assistant/github-action@ca4a40a7d1004f18d9960b404b97e5f30a505a08 # v2.6.1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           PERSONAL_ACCESS_TOKEN: ${{ secrets.CLA_SIGNATURES_TOKEN }}

--- a/.github/workflows/sync-integrity.yml
+++ b/.github/workflows/sync-integrity.yml
@@ -12,10 +12,10 @@ jobs:
   unit-tests:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
         with:
           persist-credentials: false
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
         with:
           python-version: "3.11"
       - name: Run sync-integrity tests
@@ -24,11 +24,11 @@ jobs:
   compare:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
         with:
           fetch-depth: 0
           persist-credentials: false
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
         with:
           python-version: "3.11"
       - name: Audit source-guide changes

--- a/.github/workflows/sync-mcp.yml
+++ b/.github/workflows/sync-mcp.yml
@@ -31,12 +31,13 @@ jobs:
       contents: read
     steps:
       - name: Checkout source (openaccountants)
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
         with:
           path: source
+          persist-credentials: false
 
       - name: Checkout destination (openaccountants-mcp)
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
         with:
           repository: openaccountants/openaccountants-mcp
           ssh-key: ${{ secrets.MCP_SYNC_DEPLOY_KEY }}

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -29,14 +29,17 @@ jobs:
       contents: read
       issues: write # the "Explain in a comment" step below
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
         with:
           fetch-depth: 0
+          persist-credentials: false
       - name: Fail if the PR edits generated files
         id: guard
+        env:
+          BASE_REF: ${{ github.base_ref }}
         run: |
-          BASE="origin/${{ github.base_ref }}"
-          git fetch origin "${{ github.base_ref }}" --depth 50
+          BASE="origin/$BASE_REF"
+          git fetch origin "$BASE_REF" --depth 50
           BAD=$(git diff --name-only "$BASE"...HEAD -- \
             'index.json' 'llms-full.txt' 'packages/**' \
             ':(exclude)packages/us-federal/**' | head -20)
@@ -50,7 +53,7 @@ jobs:
           echo "clean"
       - name: Explain in a comment
         if: failure() && steps.guard.outputs.generated_files_touched != ''
-        uses: actions/github-script@v7
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7
         env:
           # Filenames come from the PR's diff, so they are attacker-controlled.
           # Interpolating them straight into the script body would let a crafted
@@ -72,16 +75,20 @@ jobs:
   validate:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
         with:
           fetch-depth: 0
-      - uses: actions/setup-python@v5
+          persist-credentials: false
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
         with:
           python-version: "3.11"
       - name: Validate changed guides (PR) / all guides (main)
+        env:
+          BASE_REF: ${{ github.base_ref }}
+          EVENT_NAME: ${{ github.event_name }}
         run: |
-          if [ "${{ github.event_name }}" = "pull_request" ]; then
-            git fetch origin "${{ github.base_ref }}" --depth 50
+          if [ "$EVENT_NAME" = "pull_request" ]; then
+            git fetch origin "$BASE_REF" --depth 50
             python3 scripts/validate-guides.py --changed-only --no-index-check
           else
             python3 scripts/validate-guides.py --no-index-check


### PR DESCRIPTION
## What

- replace every third-party workflow tag with the exact current commit behind that tag
- prevent checkout from persisting credentials in every read-only source checkout
- retain persisted deploy-key credentials only for the destination checkout that actually pushes the generated MCP mirror
- move attacker-controlled PR base names out of shell source and into environment variables
- add weekly Dependabot coverage for GitHub Actions and the MCP Python project

## Why

Mutable action tags can change without a repository commit. The source checkout in the cross-repository sync also retained credentials it never uses, and `github.base_ref` was expanded directly into shell code in the validation workflow.

The full-SHA pins were resolved from the live tag refs immediately before this commit:

- `actions/checkout@v4` → `11d5960a326750d5838078e36cf38b85af677262`
- `actions/setup-python@v5` → `a26af69be951a213d495a4c3e4e4022e16d87065`
- `actions/github-script@v7` → `f28e40c7f34bde8b3046d885e986cb6290c5673b`
- `contributor-assistant/github-action@v2.6.1` → `ca4a40a7d1004f18d9960b404b97e5f30a505a08`

## Impact

- workflow behaviour and declared permissions are otherwise unchanged
- the deploy-key checkout still persists its credentials because the final job step pushes that repository
- Dependabot can now propose reviewed updates rather than silently following mutable tags
- this PR overlaps `validate.yml` with #101 and should be rebased after whichever PR merges first

## Checks

- actionlint 1.7.12 passed across all four workflows
- strict PyYAML parse passed for all workflows and `.github/dependabot.yml`
- `git diff --check` passed
- zizmor no longer reports the three `github.base_ref` template-injection findings

## Residual CLA workflow decision

Zizmor still identifies the existing `pull_request_target` CLA workflow and notes that `contributor-assistant/github-action` is archived. This PR reduces its supply-chain exposure by pinning the exact existing action but does not pretend that an archived CLA implementation has been modernised. Replacing that stateful signature workflow needs a separate migration with historical-signature compatibility and is deliberately not mixed into these mechanical changes.
