### PR TITLE
fix(reports): remove duplicate jurisdiction heading

### DIFF
--- a/scripts/detect-contradictions.py
+++ b/scripts/detect-contradictions.py
@@ -1006,8 +1006,6 @@ def render_report(results):
     for jur, (claims, candidates, drift, stats) in results.items():
         highs = [(k, c) for k, c in candidates if rank_candidate(c) == "HIGH"]
         meds = [(k, c) for k, c in candidates if rank_candidate(c) == "MEDIUM"]
-        lines.append(f"## {jur}")
-        lines.append("")
         lines.append(f"## {jur} — HIGH confidence ({len(highs)})")
         lines.append("")
         if not highs:

--- a/tests/test_contradiction_report.py
+++ b/tests/test_contradiction_report.py
@@ -1,0 +1,32 @@
+from __future__ import annotations
+
+import importlib.util
+import unittest
+from pathlib import Path
+
+
+SCRIPT_PATH = Path(__file__).resolve().parents[1] / "scripts" / "detect-contradictions.py"
+SPEC = importlib.util.spec_from_file_location("detect_contradictions", SCRIPT_PATH)
+assert SPEC and SPEC.loader
+detect_contradictions = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(detect_contradictions)
+
+
+class ContradictionReportTests(unittest.TestCase):
+    def test_jurisdiction_has_no_empty_duplicate_heading(self) -> None:
+        report = detect_contradictions.render_report({"US": ([], [], [], {})})
+        headings = [line for line in report.splitlines() if line.startswith("## ")]
+
+        self.assertEqual(
+            headings,
+            [
+                "## US — HIGH confidence (0)",
+                "## US — MEDIUM confidence (0)",
+                "## US — Copy drift (skills/ vs packages/) (0)",
+                "## US — Stats",
+            ],
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## What

- remove the empty bare jurisdiction heading emitted immediately before the first confidence heading
- add a regression that asserts the complete jurisdiction-heading sequence

## Why

Each jurisdiction currently renders an empty `## US`/`## UK`/`## DE` section followed immediately by `## … — HIGH confidence`. The bare heading has no content and duplicates the real report structure.

## Impact

- report calculations, rankings, claims and values are unchanged
- only the redundant Markdown heading is removed
- this touches the same script as #98 and should be rebased after #98 merges; it does not change #98's tax-year logic

## Checks

- `python -m unittest tests.test_contradiction_report -v` (1 passed)
- Python compileall passed
- `git diff --check` passed
