### PR TITLE
fix(au): correct FRCGW, HELP repayment and GIC guidance to current law

### DIFF
--- a/skills/international/australia/au-capital-gains.md
+++ b/skills/international/australia/au-capital-gains.md
@@ -1,10 +1,11 @@
 ---
 name: au-capital-gains
 description: "Use this skill for any Australian resident's capital gains tax question. Trigger on: \"CGT Australia\", \"capital gains Australia\", \"sell shares Australia\", \"50% CGT discount\", \"cost base Australia\", \"small business CGT concessions\", \"SBCGT\", \"active asset test\", \"15-year exemption\", \"retirement exemption CGT\", \"CGT rollover\", \"CGT event A1\", \"main residence exemption\", \"Australian CGT\", \"sell my Australian company\", \"dispose of property Australia\". Covers CGT events, cost base, 50% discount, SBCGT concessions, main residence exemption. For non-residents selling Australian assets see au-nonresident-cgt."
-version: 1.0
+version: 1.1
 jurisdiction: AU
 tax_year: 2025
-last_updated: 2026-07-13
+tax_year_notes: "2025-26; includes 1 July 2027 CGT reform alert (Tax Reform No. 1 Act 2026)"
+last_updated: 2026-08-20
 review_status: pending_review
 depends_on: - au-individual-return
 category: international
@@ -13,6 +14,8 @@ license: AGPL-3.0-or-later (code) / OpenAccountants Guide License v1.0 (content)
 ---
 
 # AU Capital Gains
+
+> **Law-change alert (passed June 2026, applies from 1 July 2027).** The *Treasury Laws Amendment (Tax Reform No. 1) Act 2026* replaces the 50% CGT discount for individuals, trusts and partnerships with **cost-base indexation plus a 30% minimum tax rate** for capital gains **accruing from 1 July 2027**. Assets held on 30 June 2027 (including pre-CGT assets) are deemed sold and re-acquired on 1 July 2027, splitting every later disposal into pre- and post-1-July-2027 gain components across four asset-based categories (residential vs non-residential × pre vs post). The 50% discount is retained for **new residential dwellings**; the small business 50% active-asset reduction is being expanded (announced: turnover test $2m → $10m). Everything below describes the law that still applies to gains accruing **up to 30 June 2027** — for disposals after that date, or timing decisions straddling it, escalate to a qualified adviser and check the current ATO guidance.
 
 ## Section 1 — Quick Reference
 

--- a/skills/international/australia/au-gst-bas.md
+++ b/skills/international/australia/au-gst-bas.md
@@ -15,7 +15,7 @@ license: AGPL-3.0-or-later (code) / OpenAccountants Guide License v1.0 (content)
 
 ## AU GST Bas
 
-## Australia BAS — Non-GST Sections v1.1
+## Australia BAS — Non-GST Sections v1.2
 
 ## What this file is
 

--- a/skills/international/australia/au-gst-bas.md
+++ b/skills/international/australia/au-gst-bas.md
@@ -1,10 +1,10 @@
 ---
 name: au-gst-bas
 description: Australian Business Activity Statement (BAS) — non-GST sections. Covers PAYG withholding (labels W1-W5), PAYG income tax instalments (labels T1-T9), FBT instalments (label F1), and PAYG withholding reconciliation. Complements australia-gst.md which covers GST labels (1A-9).
-version: 1.1
+version: 1.2
 jurisdiction: AU
 tax_year: 2025
-last_updated: 2026-08-11
+last_updated: 2026-08-20
 review_status: pending_review
 category: international
 tier: 2
@@ -143,7 +143,7 @@ Two methods are available:
 
 ### 5.1 Variation of PAYG instalments
 
-- **PAYG instalment variation and GIC exposure** — A taxpayer may vary their instalment amount or rate downward if they expect lower income. **GIC exposure:** If the varied amount is less than 85% of the correct instalment, a general interest charge applies on the shortfall. The GIC rate is updated quarterly by the ATO (base rate = 90-day bank bill rate + 7%). **Variation uplift factor:** If the taxpayer varies for two or more consecutive quarters, the ATO may apply a higher GDP uplift factor in the following year.  _(TAA 1953 Sch 1 s 45-205)_
+- **PAYG instalment variation and GIC exposure** — A taxpayer may vary their instalment amount or rate downward if they expect lower income. **GIC exposure:** If the varied amount is less than 85% of the correct instalment, a general interest charge applies on the shortfall. The GIC rate is updated quarterly by the ATO (base rate = 90-day bank bill rate + 7%). **GIC incurred on or after 1 July 2025 is not tax-deductible** (Treasury Laws Amendment (Tax Incentives and Integrity) Act 2025 Sch 2), which makes under-variation materially more expensive. **Variation uplift factor:** If the taxpayer varies for two or more consecutive quarters, the ATO may apply a higher GDP uplift factor in the following year.  _(TAA 1953 Sch 1 s 45-205)_
 
 ### 5.2 First year of business
 

--- a/skills/international/australia/au-individual-return.md
+++ b/skills/international/australia/au-individual-return.md
@@ -1,10 +1,11 @@
 ---
 name: au-individual-return
 description: Use this skill whenever asked about Australian individual income tax for sole traders. Trigger on phrases like "how much tax do I pay in Australia", "Australian tax return", "sole trader tax", "ABN tax", "Medicare levy", "LITO", "PAYG", "tax brackets Australia", "BAS", "instant asset write-off", "home office deduction", "HELP repayment", "HECS debt", "small business income tax offset", "motor vehicle deduction", or any question about filing or computing income tax for an Australian sole trader. Covers 2024-25 Stage 3 tax rates, Medicare levy and surcharge, LITO, business income computation, allowable deductions, depreciation, instant asset write-off, small business income tax offset, HELP/HECS repayments, and final tax computation. ALWAYS read this skill before touching any Australian income tax work.
-version: 2.0
+version: 2.1
 jurisdiction: AU
 tax_year: 2024
-last_updated: 2026-07-13
+tax_year_notes: "2024-25 computation base; HELP repayment tables updated for 2025-26 and 2026-27 (marginal system)"
+last_updated: 2026-08-20
 review_status: pending_review
 depends_on: - income-tax-workflow-base
 category: international
@@ -269,16 +270,26 @@ license: AGPL-3.0-or-later (code) / OpenAccountants Guide License v1.0 (content)
 
 **5.5 HELP/HECS Repayment [T1]**
 
-| Repayment Income (2024-25) | Rate |
-| --- | --- |
-| Below $54,435 | 0% |
-| $54,435 -- $62,850 | 1% |
-| $62,851 -- $66,620 | 2% |
-| $66,621 -- $70,618 | 2.5% |
-| ... (progressive to) | ... |
-| $151,201+ | 10% |
+> **Regime change from 1 July 2025.** Compulsory repayments moved from a percentage of TOTAL repayment income to a **marginal system** — the repayment is calculated only on income above the minimum threshold. The old sliding-scale table (1%–10% from $54,435) applies to 2024-25 and earlier returns only. _(Student loan reforms passed November 2025; ATO QC 59241)_
 
-- **Repayment income** — Repayment income = taxable income + reportable fringe benefits + net investment losses + reportable super. HELP repayments are NOT deductible.  _(Higher Education Support Act 2003)_
+| Repayment Income (2025-26) | Repayment on this income |
+| --- | --- |
+| $0 – $67,000 | Nil |
+| $67,001 – $125,000 | 15c for each $1 over $67,000 |
+| $125,001 – $179,285 | $8,700 plus 17c for each $1 over $125,000 |
+| $179,286 and over | 10% of TOTAL repayment income |
+
+| Repayment Income (2026-27) | Repayment on this income |
+| --- | --- |
+| $0 – $69,528 | Nil |
+| $69,529 – $129,717 | 15c for each $1 over $69,528 |
+| $129,718 – $186,050 | $9,028 plus 17c for each $1 over $129,717 |
+| $186,051 and over | 10% of TOTAL repayment income |
+
+- **Repayment income** — Repayment income = taxable income (excluding assessable FHSS released amounts) + reportable fringe benefits + total net investment loss + reportable super contributions + exempt foreign employment income. HELP repayments are NOT deductible.  _(Higher Education Support Act 2003; ATO QC 16176)_
+- **Worked check (2025-26)** — repayment income $80,000 → 15% × ($80,000 − $67,000) = **$1,950** (old system would have been $2,800 at 3.5%).
+- **One-off 20% debt reduction** — HELP/study loan balances outstanding at 1 June 2025 were automatically reduced by 20% (applied by the ATO from late 2025, processing completed by mid-2026; no action required). Confirm the client's current balance from ATO online services rather than an old statement.  _(studyassist.gov.au; ATO "Study and training loans – what's new", 30 June 2026)_
+- **Indexation** — study loan indexation is now the LOWER of CPI and Wage Price Index (backdated to 1 June 2023 by the Universities Accord (Student Support and Other Measures) Act 2024).
 
 ### 5.6 Filing and Penalties [T1]
 
@@ -291,7 +302,7 @@ license: AGPL-3.0-or-later (code) / OpenAccountants Guide License v1.0 (content)
 | Failure to lodge on time | $313 per 28-day period, up to 5 periods ($1,565 max) |
 | Shortfall penalty (reasonable care not taken) | 25% of shortfall |
 | Shortfall penalty (recklessness) | 50% of shortfall |
-| General Interest Charge (GIC) | Varies quarterly; 2025 annual rates include 11.42%, 11.17%, 10.78%, and 10.61%; calculated daily and compounded |
+| General Interest Charge (GIC) | Updated quarterly (TAA 1953 s 8AAD): 2025-26 quarters were 10.78%, 10.61%, 10.65%, 10.96%; Jul–Sep 2026 is 11.43%; calculated daily and compounded. **GIC and SIC incurred on or after 1 July 2025 are NOT tax-deductible** (Treasury Laws Amendment (Tax Incentives and Integrity) Act 2025 Sch 2); remitted post-1-July-2025 GIC is not assessable, but remitted pre-1-July-2025 GIC that was deducted IS assessable |
 
 ## Section 6 -- Tier 2 Catalogue (Reviewer Judgement Required)
 

--- a/skills/international/australia/au-individual-return.md
+++ b/skills/international/australia/au-individual-return.md
@@ -299,7 +299,7 @@ license: AGPL-3.0-or-later (code) / OpenAccountants Guide License v1.0 (content)
 | --- | --- |
 | Self-lodge deadline | 31 October 2025 |
 | Tax agent deadline | Varies (typically March-May 2026) |
-| Failure to lodge on time | $313 per 28-day period, up to 5 periods ($1,565 max) |
+| Failure to lodge on time | 1 penalty unit per 28-day period, up to 5 periods. Penalty unit: $364 from 1 Jul 2026; $330 for 7 Nov 2024 – 30 Jun 2026 (max $1,820 / $1,650) |
 | Shortfall penalty (reasonable care not taken) | 25% of shortfall |
 | Shortfall penalty (recklessness) | 50% of shortfall |
 | General Interest Charge (GIC) | Updated quarterly (TAA 1953 s 8AAD): 2025-26 quarters were 10.78%, 10.61%, 10.65%, 10.96%; Jul–Sep 2026 is 11.43%; calculated daily and compounded. **GIC and SIC incurred on or after 1 July 2025 are NOT tax-deductible** (Treasury Laws Amendment (Tax Incentives and Integrity) Act 2025 Sch 2); remitted post-1-July-2025 GIC is not assessable, but remitted pre-1-July-2025 GIC that was deducted IS assessable |

--- a/skills/international/australia/au-nonresident-cgt.md
+++ b/skills/international/australia/au-nonresident-cgt.md
@@ -1,10 +1,11 @@
 ---
 name: au-nonresident-cgt
-description: "Use this skill for any non-resident selling Australian assets. Trigger on: \"non-resident CGT Australia\", \"TAP test Australia\", \"taxable Australian property\", \"FRCGW\", \"foreign resident capital gains withholding\", \"12.5% withholding Australia\", \"clearance certificate ATO\", \"sell Australian shares non-resident\", \"sell Australian property non-resident\", \"Australian CGT non-resident seller\", \"no CGT discount non-resident Australia\". Covers the TAP test, 30% flat rate, FRCGW withholding, clearance certificates. For Australian residents see au-capital-gains."
-version: 1.0
+description: "Use this skill for any non-resident selling Australian assets. Trigger on: \"non-resident CGT Australia\", \"TAP test Australia\", \"taxable Australian property\", \"FRCGW\", \"foreign resident capital gains withholding\", \"15% withholding Australia\", \"12.5% withholding Australia\", \"clearance certificate ATO\", \"sell Australian shares non-resident\", \"sell Australian property non-resident\", \"Australian CGT non-resident seller\", \"no CGT discount non-resident Australia\". Covers the TAP test, 30% flat rate, FRCGW withholding (15%, no threshold, from 1 January 2025), clearance certificates. For Australian residents see au-capital-gains."
+version: 1.1
 jurisdiction: AU
 tax_year: 2025
-last_updated: 2026-07-13
+tax_year_notes: "2025-26; FRCGW figures apply to contracts signed from 1 January 2025"
+last_updated: 2026-08-20
 review_status: pending_review
 category: international
 tier: 2
@@ -23,7 +24,7 @@ license: AGPL-3.0-or-later (code) / OpenAccountants Guide License v1.0 (content)
 | Applies to | Non-residents of Australia disposing of Australian assets |
 | CGT rate (non-resident) | **30% flat rate** on net gain (no 50% discount available) |
 | Key test | Taxable Australian Property (TAP) test |
-| Withholding | 12.5% of gross proceeds on TAP transactions > AUD $750,000 |
+| Withholding | 15% of the market value (usually sale price) on ALL Australian real property sales from 1 Jan 2025 — no minimum threshold |
 | Primary legislation | ITAA 1997 Div 855; TAA 1953 Sch 1 Subdiv 14-D |
 | Tax authority | ATO (ato.gov.au) |
 | Verified by | Pending — Australian CPA/CA sign-off required |
@@ -63,25 +64,29 @@ Non-residents are only subject to Australian CGT on **Taxable Australian Propert
 
 ## Section 5 — Foreign Resident Capital Gains Withholding (FRCGW)
 
-- **FRCGW obligation** — When a non-resident sells TAP with gross proceeds ≥ AUD $750,000, the buyer is required to withhold 12.5% of the gross proceeds and remit to the ATO.
+- **FRCGW obligation** — For contracts signed on or after 1 January 2025, the purchaser must withhold **15% of the market value (usually the sale price)** on **every** Australian real property sale — the previous AUD $750,000 de-minimis threshold was removed — unless the vendor produces an ATO clearance certificate (residents) or a variation notice (non-residents). _(TAA 1953 Sch 1 Subdiv 14-D, as amended by Treasury Laws Amendment (2024 Tax and Other Measures No. 1) Act 2024 (No. 135, 2024) Sch 1)_
+- **Prior regimes (for older contracts)** — Contracts signed 1 July 2017 – 31 December 2024: 12.5% where the property was valued at AUD $750,000 or more. Contracts signed 1 July 2016 – 30 June 2017: 10% at AUD $2,000,000 and above. The **contract date**, not settlement date, picks the regime.
 - **FRCGW nature** — This is a payment on account (not a final tax). Actual tax liability is computed in the non-resident's Australian tax return.
+- **Scope note** — FRCGW attaches to taxable Australian real property and indirect Australian real property (IARP) interests (and options/leases over them). Transactions on an approved stock exchange are excluded. Vendor declarations can apply for non-listed share/unit transactions.
 
-**FRCGW threshold table**
+**FRCGW rate table (contracts signed from 1 January 2025)**
 
-| FRCGW threshold | AUD $750,000 |
+| Item | Value |
 | --- | --- |
-| Withholding rate | 12.5% of gross proceeds |
+| Threshold | **None** — applies to all in-scope property regardless of value |
+| Withholding rate | **15%** of market value (usually the sale price) |
 | Who withholds | The buyer (purchaser) |
-| Remittance deadline | Day of settlement |
+| Remittance deadline | At or before settlement |
 
-**Example**: Non-resident sells shares (TAP) for AUD $10M. Buyer withholds AUD $1.25M (12.5%). Net gain is, say, AUD $8M. Australian tax at 30% = AUD $2.4M. The $1.25M already withheld is applied — balance payable AUD $1.15M via Australian tax return.
+**Example**: Non-resident signs a contract in March 2026 to sell shares that are an indirect Australian real property interest (TAP) for AUD $10M. Buyer withholds AUD $1.5M (15%). Net gain is, say, AUD $8M. Australian tax at 30% = AUD $2.4M. The $1.5M already withheld is applied — balance payable AUD $0.9M via Australian tax return.
 
 ## Section 6 — Clearance Certificate
 
-- **Clearance certificate for resident sellers** — If the seller is an Australian resident (not a foreign resident), the seller can apply for a clearance certificate from the ATO to confirm residency, relieving the buyer of the withholding obligation.
-- **Variation for non-resident sellers** — If the seller IS a non-resident but believes no tax is payable (e.g. asset is not TAP, or gain is nil due to losses), the seller can apply for a variation to reduce the withholding amount.
+- **Clearance certificate for resident sellers** — If the seller is an Australian resident (not a foreign resident), the seller must apply for a clearance certificate from the ATO to confirm residency, relieving the buyer of the withholding obligation. Because the $750,000 threshold was removed for contracts from 1 January 2025, **every Australian resident selling real property needs a clearance certificate** — including on the sale of a family home — or the buyer must withhold 15% at settlement and the seller waits for the next tax return to recover it.
+- **Timing** — Certificates are valid for 12 months, so vendors should apply early (before listing). Most issue quickly, but the ATO advises some can take up to 28 days.
+- **Variation for non-resident sellers** — If the seller IS a non-resident but believes 15% over-collects (e.g. the gain is small or nil, losses apply, or the asset is not TAP), the seller can apply for a variation notice specifying a reduced rate. The variation must be given to the purchaser before settlement.
 
-Applications: via ATO online portal (myGov / Tax Agent portal). Processing time: 14-28 days typically.
+Applications: via ATO online services (individuals) or the Tax/BAS Agent portal.
 
 ## Section 7 — Filing Obligations for Non-Residents
 
@@ -99,8 +104,9 @@ Always check the saving clause and specific treaty wording.
 
 - ITAA 1997 Division 855 (non-resident CGT)
 - Tax Administration Act 1953, Schedule 1, Subdivision 14-D (FRCGW)
-- ATO: ato.gov.au/individuals-and-families/investments-and-assets/capital-gains-tax/foreign-residents-and-capital-gains-tax
-- ATO: Foreign resident capital gains withholding (ato.gov.au/FRCGW)
+- Treasury Laws Amendment (2024 Tax and Other Measures No. 1) Act 2024 (No. 135, 2024), Schedule 1 — FRCGW rate to 15% and threshold removed for acquisitions from 1 January 2025
+- ATO: ato.gov.au/individuals-and-families/investments-and-assets/capital-gains-tax/foreign-residents-and-capital-gains-tax/foreign-resident-capital-gains-withholding/foreign-resident-capital-gains-withholding-overview (QC 48972, updated 22 June 2026)
+- ATO: Australian residents and clearance certificates (same section)
 
 > **Working paper only.** The TAP classification requires analysis of the company's asset composition by market value — not book value. Engage a qualified Australian tax adviser for transaction-specific advice.
 

--- a/skills/international/australia/au-payg-instalments.md
+++ b/skills/international/australia/au-payg-instalments.md
@@ -1,10 +1,10 @@
 ---
 name: au-payg-instalments
 description: Use this skill whenever asked about Australian PAYG Instalments for sole traders. Trigger on phrases like "PAYG instalments", "BAS T1 T2 T7 T9", "instalment rate", "instalment amount", "ATO instalment", "GDP uplift", "GIC", "variation of instalments", or any question about income tax prepayments through the Business Activity Statement. Covers entry/exit thresholds, instalment rate method (T1/T2), instalment amount method (T7), GDP uplift factor, voluntary variation, GIC exposure on under-estimation, and quarterly/annual election. ALWAYS read this skill before touching any PAYG instalment work for Australia.
-version: 2.0
+version: 2.1
 jurisdiction: AU
 tax_year: 2025
-last_updated: 2026-07-13
+last_updated: 2026-08-20
 review_status: pending_review
 depends_on: - income-tax-workflow-base
 category: international
@@ -187,6 +187,8 @@ No income calculation needed. ATO pre-fills the amount.
 ### 6.1 General Interest Charge (GIC)
 
 - **GIC rate** — base rate (90-day bank bill rate) + 7%  _(Updated quarterly. Applies from instalment due date if variation results in < 85% of correct amount.)_
+- **GIC not deductible from 1 July 2025** — GIC (and shortfall interest charge) incurred on or after 1 July 2025 is denied as an income tax deduction. GIC incurred up to 30 June 2025 remains deductible under the old law; if such deducted GIC is later remitted, the remitted amount is assessable. Post-1-July-2025 GIC that is remitted is not assessable.  _(Treasury Laws Amendment (Tax Incentives and Integrity) Act 2025 (No. 29, 2025) Sch 2; ATO QC 73746)_
+- **Quarterly GIC annual rates (recent)** — 2025-26: Jul–Sep 10.78%, Oct–Dec 10.61%, Jan–Mar 10.65%, Apr–Jun 10.96%. 2026-27: Jul–Sep 11.43%.  _(ATO GIC rates page, QC 16145)_
 
 ### 6.2 Late BAS lodgement penalty
 

--- a/skills/international/australia/au-payg-instalments.md
+++ b/skills/international/australia/au-payg-instalments.md
@@ -192,7 +192,7 @@ No income calculation needed. ATO pre-fills the amount.
 
 ### 6.2 Late BAS lodgement penalty
 
-- **Late BAS lodgement penalty** — $313 per 28-day period, up to 5 periods ($1,565 max for small entities)  _(Failure to lodge BAS)_
+- **Late BAS lodgement penalty** — 1 penalty unit per 28-day period, up to 5 periods, for small entities. Penalty unit: $364 from 1 Jul 2026; $330 for 7 Nov 2024 – 30 Jun 2026 (so max $1,820 / $1,650)  _(Failure to lodge BAS; ATO QC 71196)_
 
 ### 6.3 Safe harbour
 

--- a/skills/international/australia/au-rental-property.md
+++ b/skills/international/australia/au-rental-property.md
@@ -1,10 +1,10 @@
 ---
 name: au-rental-property
 description: Use this skill whenever asked about Australian rental property income and deductions. Trigger on phrases like "rental income Australia", "negative gearing", "rental deductions", "investment property tax", "Division 40", "Division 43", "capital works deduction", "depreciation schedule", "rental property CGT", "rental withholding", "body corporate fees", "strata levy deduction", "repairs vs improvements", "TR 97/23", or any question about completing the rental property schedule in an Australian individual tax return. This skill covers rental income reporting, deductible expenses, depreciation (Div 40 plant and Div 43 building), negative gearing, CGT on disposal, non-resident withholding, and common transaction classifications. ALWAYS read this skill before touching any Australian rental property work.
-version: "1.0"
+version: "1.1"
 jurisdiction: AU
 tax_year: 2025
-last_updated: 2026-07-13
+last_updated: 2026-08-20
 review_status: pending_review
 category: international
 tier: 2
@@ -13,7 +13,9 @@ license: AGPL-3.0-or-later (code) / OpenAccountants Guide License v1.0 (content)
 
 # AU Rental Property
 
-## Australia Rental Property -- Income & Deductions Skill v1.0
+> **Law-change alert — negative gearing (passed June 2026, applies from 1 July 2027).** The *Treasury Laws Amendment (Tax Reform No. 1) Act 2026* limits negative gearing of residential property to **new builds** from **1 July 2027**. Existing properties acquired on or before Budget night (**12 May 2026**) are fully grandfathered. Residential property acquired **after 12 May 2026** that is not a new dwelling can still be negatively geared up to 30 June 2027, but from 1 July 2027 its net rental losses are **quarantined** — usable only against future residential-property income, not salary or business income. The same Act replaces the 50% CGT discount with indexation + a 30% minimum rate for gains accruing from 1 July 2027 (see au-capital-gains). Acquisition date and new-build status are now mandatory intake facts for every rental client.
+
+## Australia Rental Property -- Income & Deductions Skill v1.1
 
 ## Section 1 -- Quick Reference
 
@@ -89,7 +91,7 @@ license: AGPL-3.0-or-later (code) / OpenAccountants Guide License v1.0 (content)
 
 ### 2.2 Negative Gearing
 
-- **Negative gearing** — Where total deductions exceed gross rental income, the net rental loss reduces other assessable income (salary, business income). There is no cap on negative gearing for existing or new properties (as of 2025 law).
+- **Negative gearing** — Where total deductions exceed gross rental income, the net rental loss reduces other assessable income (salary, business income). This remains the law for all properties through 30 June 2027, and permanently for grandfathered properties (acquired on or before 12 May 2026) and new builds. **From 1 July 2027**, losses on residential property acquired after 12 May 2026 that is not a new dwelling are quarantined to future residential-property income (Tax Reform No. 1 Act 2026 — see the alert at the top of this skill).
 
 ### 2.3 Deductible Expenses (Immediate)
 
@@ -200,7 +202,7 @@ Applies to the structural elements (building itself, fixed improvements).
 | --- | --- |
 | Applies to | Non-resident landlords receiving Australian rental income |
 | Rate | Payer (tenant/agent) must withhold amounts as directed by ATO |
-| FRCGW (foreign resident CGT withholding) | 12.5% of sale price if property value ≥ $750,000 (buyer withholds) |
+| FRCGW (foreign resident CGT withholding) | 15% of market value (usually sale price), no threshold, for contracts signed from 1 Jan 2025 (12.5% ≥ $750,000 for contracts signed 1 Jul 2017 – 31 Dec 2024); buyer withholds |
 | Clearance certificate | Resident vendor obtains to avoid FRCGW at settlement |
 
 ## Section 3 -- Transaction Pattern Library

--- a/skills/international/australia/australia-gst.md
+++ b/skills/international/australia/australia-gst.md
@@ -1,10 +1,10 @@
 ---
 name: australia-gst
 description: Use this skill whenever asked to prepare, review, or classify transactions for an Australian GST return (Business Activity Statement / BAS) for any client. Trigger on phrases like "prepare BAS", "do the GST", "fill in BAS", "create the return", "GST return", "Activity Statement", or any request involving Australian GST filing. Also trigger when classifying transactions for GST purposes from bank statements, invoices, or other source data. This skill covers Australia only and covers both Simpler BAS and full BAS reporting. GST groups, margin scheme, partial exemption complex, and going concern are all in the refusal catalogue. ALWAYS read this skill before touching any GST-related work.
-version: 2.0
+version: 2.1
 jurisdiction: AU
 tax_year: 2025
-last_updated: 2026-07-13
+last_updated: 2026-08-20
 review_status: pending_review
 tier: 2
 license: AGPL-3.0-or-later (code) / OpenAccountants Guide License v1.0 (content)
@@ -481,7 +481,7 @@ Each rule states the legal source and the BAS label mapping. Apply silently if t
 
 - **Entitlement conditions** — A registered entity is entitled to an input tax credit if ALL conditions are met (s 11-5): 1. Acquisition is for a creditable purpose (related to taxable or GST-free supplies); 2. Supply was a taxable supply (GST in the price); 3. Entity provides consideration; 4. Entity is registered for GST; AND 5. Entity holds a valid tax invoice (or can obtain one within 4 years).  _(s 11-5)_
 - **Blocked credits** — No credit for acquisitions relating to input taxed supplies (s 11-15), private/domestic use (s 11-15), entertainment where FBT exempt (s 69-5), non-deductible fines/penalties (s 69-5).  _(s 11-15, s 69-5)_
-- **Car limit** — Input tax credit for a car is capped at car limit / 11. For 2024-25: $69,674 / 11 = ~$6,334 maximum credit. No outright block on cars (unlike Malta).  _(s 69-10)_
+- **Car limit** — Input tax credit for a car is capped at car limit / 11. For 2026-27: $69,883 / 11 = $6,353 maximum credit (2025-26: $69,674 / 11 = ~$6,334). No outright block on cars (unlike Malta).  _(s 69-10; ATO car thresholds)_
 
 ### 5.7 Tax invoices (Division 29)
 
@@ -643,7 +643,7 @@ Infer the client profile from the data first. Only ask questions the data could 
 
 ### Penalties
 
-- **Failure to lodge (FTL)** — 1 penalty unit per 28-day period for small entities (turnover < $1M), up to 5 periods. Penalty unit: $330 (2024-25, indexed annually).
+- **Failure to lodge (FTL)** — 1 penalty unit per 28-day period for small entities (turnover < $1M), up to 5 periods. Penalty unit: $364 from 1 July 2026; $330 for infringements 7 Nov 2024 – 30 Jun 2026 (ATO QC 71196).
 - **General Interest Charge (GIC)** — 90-day Bank Accepted Bill rate + 7% per annum. Calculated daily, compounded. Tax deductible.
 - **Shortfall penalties** — Reasonable care not taken: 25%. Recklessness: 50%. Intentional disregard: 75%. Reduced 20% for voluntary disclosure before audit.
 
@@ -679,7 +679,7 @@ Infer the client profile from the data first. Only ask questions the data could 
 | GST registration | $75,000 | s 23-5 |
 | Simpler BAS eligibility | Turnover < $10M | TAA 1953 |
 | Cash basis eligibility | Turnover < $2M (or $10M SBE) | s 29-40 |
-| Car limit (2024-25) | $69,674 | s 69-10 |
+| Car limit (2026-27) | $69,883 (2025-26: $69,674) | s 69-10 |
 | LCT threshold (2025-26, general / other vehicles) | $80,567 | LCT Act / ATO car thresholds |
 | LCT threshold (2024-25, fuel-efficient) | $91,387 | LCT Act |
 | No ABN withholding exemption | Supplies < $75 excl GST | TAA Schedule 1 |

--- a/skills/international/australia/australia-gst.md
+++ b/skills/international/australia/australia-gst.md
@@ -733,7 +733,7 @@ This skill is v2.0, rewritten in April 2026 to align with the Malta v2.0 structu
 - **v2.0 (April 2026):** Full rewrite to align with Malta v2.0 structure. Ten sections: quick reference (1), inputs and refusals (2), supplier pattern library with 12 sub-tables (3), six worked examples from CBA NetBank format (4), Tier 1 rules compressed (5), Tier 2 catalogue with 7 items (6), Excel template (7), bank statement reading guide (8), onboarding fallback with inference rules (9), reference material (10). Five Australia-specific refusals (R-AU-1 through R-AU-5).
 - **v1.1 (April 2026):** Monolithic skill with classification rules, BAS labels, reverse charge, thresholds, edge cases, and test suite. Comprehensive but not aligned with v2.0 architecture.
 
-### Self-check (v2.0)
+### Self-check (v2.1)
 
 1. Quick reference at top with BAS label table and conservative defaults: yes (Section 1).
 2. Supplier library as literal lookup tables: yes (Section 3, 12 sub-tables).
@@ -751,7 +751,7 @@ This skill is v2.0, rewritten in April 2026 to align with the Malta v2.0 structu
 14. Payment processor fees as financial supply explicit: yes (Section 3.8 + Example 6).
 15. Supermarket split (GST-free food vs taxable items) explicit: yes (Section 3.6 + Example 3).
 
-## End of Australia GST Return Preparation Skill v2.0
+## End of Australia GST Return Preparation Skill v2.1
 
 ## Disclaimer
 

--- a/skills/international/australia/australia-tax-optimization.md
+++ b/skills/international/australia/australia-tax-optimization.md
@@ -1,10 +1,11 @@
 ---
 name: australia-tax-optimization
 description: Use this skill when advising on LEGAL tax minimization strategies for Australian taxpayers — individuals, sole traders, and small business owners. Trigger on phrases like "reduce my tax", "tax planning Australia", "salary vs dividends", "negative gearing", "instant asset write-off", "superannuation strategy", "CGT discount", "trust distribution", "income splitting", "GAAR", "Part IVA", or any question about structuring affairs to legally minimize Australian tax. Covers entity selection, deduction optimization, capital allowances, loss utilization, timing strategies, GST planning, superannuation, and red lines. ALWAYS read this skill before giving Australian tax optimization advice.
-version: 1.0
+version: 1.1
 jurisdiction: AU
 tax_year: 2025
-last_updated: 2026-07-13
+tax_year_notes: "2025-26; includes 1 July 2026/2027 reform alerts (Tax Reform No. 1 Act 2026)"
+last_updated: 2026-08-20
 review_status: pending_review
 depends_on: - bookkeeping-workflow-base
 category: tax-optimization
@@ -13,6 +14,8 @@ license: AGPL-3.0-or-later (code) / OpenAccountants Guide License v1.0 (content)
 ---
 
 # Australia Tax Optimization
+
+> **Law-change alert (Tax Reform No. 1 Act 2026 — passed June 2026, applies from 1 July 2027).** Three strategies in this skill change fundamentally from 1 July 2027: (1) the **50% CGT discount** for individuals/trusts/partnerships is replaced by cost-base indexation + a 30% minimum rate on gains accruing from 1 July 2027 (assets deemed re-acquired 1 July 2027; new residential dwellings keep the discount); (2) **negative gearing** on residential property is limited to new builds — properties acquired on or before Budget night 12 May 2026 are grandfathered, later non-new-build acquisitions have losses quarantined from 1 July 2027; (3) from 1 July 2026 a **$1,000 standard deduction** for work-related expenses applies to labour income (excluding PSI), and from 2027-28 a $250 **Working Australians Tax Offset**. Timing advice that straddles 30 June 2027 must model both regimes — escalate.
 
 ## Section 1 — Quick Reference
 
@@ -185,8 +188,8 @@ Discretionary (family) trusts allow income distribution to adult family members 
 
 | Strategy | Detail |
 | --- | --- |
-| CGT 50% discount | Individuals and trusts — hold assets >12 months for 50% discount on net capital gain |
-| Negative gearing | Investment property/share portfolio borrowing costs exceed income → net loss offsets other income. No cap in Australia |
+| CGT 50% discount | Individuals and trusts — hold assets >12 months for 50% discount on net capital gain. **Ends for gains accruing from 1 July 2027** (indexation + 30% minimum rate instead — see alert at top) |
+| Negative gearing | Investment property/share portfolio borrowing costs exceed income → net loss offsets other income. Uncapped through 30 June 2027; from 1 July 2027 residential-property losses are quarantined unless the property is a new build or was acquired on or before 12 May 2026 (see alert at top) |
 | Franking credits | Australian company dividends carry franking credits. Excess credits refundable for individuals and super funds |
 | Super in pension phase | Earnings on assets supporting income streams in pension phase are tax-free (up to transfer balance cap of $1.9m, indexed) |
 | Transition to retirement (TTR) | Access super as income stream from preservation age while still working. Earnings in TTR taxed at 15% (not tax-free) |


### PR DESCRIPTION
## What

Three statements of law in the Australia pack were superseded and are now wrong for anyone relying on them in 2026, plus alert banners for the June 2026 CGT/negative-gearing reform. All figures verified against ATO / legislation.gov.au / aph.gov.au primary sources on 2026-08-20.

### 1. FRCGW — `au-nonresident-cgt`, `au-rental-property`
The guides said 12.5% over a $750,000 threshold. For contracts signed on or after **1 January 2025** the rate is **15% with no threshold** (Treasury Laws Amendment (2024 Tax and Other Measures No. 1) Act 2024, Sch 1; ATO QC 48972, page updated 22 June 2026). Old rates kept as contract-date transitional guidance; clearance-certificate section reworked (every resident vendor now needs one); worked example recalculated at 15%.

### 2. HELP/HECS — `au-individual-return`
The guide described the pre-2025 sliding-scale system (1%–10% of total repayment income from $54,435). From **1 July 2025** repayments are **marginal**: nil to $67,000, 15c/17c bands, 10% of total repayment income at the top (2025-26); indexed 2026-27 table included (ATO QC 16176). Also documents the one-off 20% debt reduction applied to balances at 1 June 2025 (ATO completed processing June 2026) and CPI/WPI-lower indexation. This is live now for 2025-26 lodgments.

### 3. GIC deductibility — `au-individual-return`, `au-payg-instalments`, `au-gst-bas`
GIC/SIC incurred on or after **1 July 2025 is not deductible** (Treasury Laws Amendment (Tax Incentives and Integrity) Act 2025, Sch 2; ATO QC 73746) — materially changes PAYG-instalment variation risk advice. Actual quarterly rates for 2025-26 (10.78/10.61/10.65/10.96) and Jul–Sep 2026 (11.43%) replace stale figures.

### 4. Law-change alert banners — `au-capital-gains`, `au-rental-property`, `australia-tax-optimization`
Treasury Laws Amendment (Tax Reform No. 1) Act 2026 (passed June 2026): 50% CGT discount replaced by indexation + 30% minimum rate for gains accruing from 1 July 2027 (deemed re-acquisition at 30 June 2027), negative gearing limited to new builds with 12 May 2026 grandfathering, $1,000 standard deduction from 1 July 2026. Banner style follows au-div7a / au-fbt.

## Why now
2025-26 lodgment season is live — these are the figures agents are applying today.

## Checks
- `python3 scripts/validate-guides.py --no-index-check` passes
- `skills/**` only, no generated files touched
- last_updated/version bumped monotonically on every edited guide