### PR TITLE
feat(au): add Australia sole trader guided workflow and expand references

### DIFF
--- a/skills/international/australia/references.md
+++ b/skills/international/australia/references.md
@@ -2,8 +2,8 @@
 name: australia-references
 jurisdiction: AU
 tier: 2
-last_updated: 2026-06-12
-version: 1.0
+last_updated: 2026-08-20
+version: 1.1
 description: Primary source references and related open-source projects for this jurisdiction.
 ---
 
@@ -46,3 +46,39 @@ OpenAccountants is AGPL-3.0. MIT, Apache-2.0, GPL-3.0, and AGPL-3.0 content can 
 - Integration approach:
   - Reference for tax bracket calculations and rate verification against ATO published tables.
   - Treat as reference-only until the license is confirmed.
+
+## AU Tax Legislation Corpus
+
+- Repository: [ryanduguid/au-tax-legislation-corpus](https://github.com/ryanduguid/au-tax-legislation-corpus)
+- License: MIT
+- Language: English
+- Scope: Builds a provenance-rich corpus of in-force Commonwealth tax legislation (ITAA 1936/1997, GST Act, TAA 1953, FBTAA and related Acts) from the Federal Register of Legislation, with exact compilation identifiers attached to every extract.
+- Why it matters: Guides in this pack cite sections of the ITAA 1997/1936 and TAA 1953 — this corpus lets a retrieval system verify each citation against the in-force compilation text rather than trusting secondary summaries.
+- Integration approach:
+  - MIT permits incorporation with attribution.
+  - Use as the primary-source verification layer when reviewing or updating any Australian guide's legislative citations.
+- Disclosure: maintained by an OpenAccountants contributor (ryanduguid).
+
+## Payday Super Checker
+
+- Repository: [ryanduguid/payday-super-checker](https://github.com/ryanduguid/payday-super-checker)
+- License: MIT
+- Language: English
+- Scope: Checks Australian super contributions against the payday-super deadlines (7 business days from payday, from 1 July 2026) and estimates SG charge exposure on late contributions.
+- Why it matters: Direct validation companion to `au-super-guarantee` — the payday-super regime change is the highest-stakes AU payroll change of 2026 and deadline arithmetic (business days, fund-receipt basis) is easy to get wrong.
+- Integration approach:
+  - MIT permits incorporation with attribution.
+  - Use to sanity-check worked examples in `au-super-guarantee` and `australia-payroll`.
+- Disclosure: maintained by an OpenAccountants contributor (ryanduguid).
+
+## ATO Benchmark Compare
+
+- Repository: [ryanduguid/ato-benchmark-compare](https://github.com/ryanduguid/ato-benchmark-compare)
+- License: MIT
+- Language: English
+- Scope: Compares profit and loss figures against the ATO small business benchmarks locally, with the working shown.
+- Why it matters: The ATO uses industry benchmarks to select small businesses for review; comparing a sole trader's expense ratios before lodgment is a practical risk screen that complements `au-sole-trader-schedule`.
+- Integration approach:
+  - MIT permits incorporation with attribution.
+  - Reference for adding a benchmark-screen step to sole trader workflows.
+- Disclosure: maintained by an OpenAccountants contributor (ryanduguid).

--- a/skills/international/australia/references.md
+++ b/skills/international/australia/references.md
@@ -53,7 +53,7 @@ OpenAccountants is AGPL-3.0. MIT, Apache-2.0, GPL-3.0, and AGPL-3.0 content can 
 - License: MIT
 - Language: English
 - Scope: Builds a provenance-rich corpus of in-force Commonwealth tax legislation (ITAA 1936/1997, GST Act, TAA 1953, FBTAA and related Acts) from the Federal Register of Legislation, with exact compilation identifiers attached to every extract.
-- Why it matters: Guides in this pack cite sections of the ITAA 1997/1936 and TAA 1953 — this corpus lets a retrieval system verify each citation against the in-force compilation text rather than trusting secondary summaries.
+- Why it matters: Guides in this pack cite sections of the ITAA 1997/1936 and TAA 1953. This corpus lets a retrieval system verify each citation against the in-force compilation text rather than trusting secondary summaries.
 - Integration approach:
   - MIT permits incorporation with attribution.
   - Use as the primary-source verification layer when reviewing or updating any Australian guide's legislative citations.
@@ -65,7 +65,7 @@ OpenAccountants is AGPL-3.0. MIT, Apache-2.0, GPL-3.0, and AGPL-3.0 content can 
 - License: MIT
 - Language: English
 - Scope: Checks Australian super contributions against the payday-super deadlines (7 business days from payday, from 1 July 2026) and estimates SG charge exposure on late contributions.
-- Why it matters: Direct validation companion to `au-super-guarantee` — the payday-super regime change is the highest-stakes AU payroll change of 2026 and deadline arithmetic (business days, fund-receipt basis) is easy to get wrong.
+- Why it matters: Direct validation companion to `au-super-guarantee`. The payday-super regime change is the highest-stakes AU payroll change of 2026, and deadline arithmetic (business days, fund-receipt basis) is easy to get wrong.
 - Integration approach:
   - MIT permits incorporation with attribution.
   - Use to sanity-check worked examples in `au-super-guarantee` and `australia-payroll`.

--- a/workflows/README.md
+++ b/workflows/README.md
@@ -7,6 +7,7 @@ When a user's situation matches a trigger, fetch the relevant jurisdiction bundl
 | Workflow | File | Trigger |
 |---|---|---|
 | Cross-border / multi-jurisdiction | [cross-border-intake.md](cross-border-intake.md) | Any two-country situation, relocation, exit |
+| Australia sole trader | [australia-sole-trader.md](australia-sole-trader.md) | AU freelancer / ABN / sole trader |
 | UK self-employed | [uk-self-employed.md](uk-self-employed.md) | UK freelancer / sole trader |
 | US self-employed (Schedule C) | [us-schedule-c.md](us-schedule-c.md) | US 1099 / gig worker / sole prop |
 | South Africa income tax | [south-africa-income-tax.md](south-africa-income-tax.md) | SA taxpayer, SARS, ITR12 |

--- a/workflows/australia-sole-trader.md
+++ b/workflows/australia-sole-trader.md
@@ -44,10 +44,10 @@ From the AU bundle:
 ## 6-phase structure
 
 ### Phase 1 — Intake
-Run `au-freelance-intake` in full. Confirm: full-year Australian tax residency, sole trader status (not company/trust/partnership), income year, GST registration status, uploaded documents (bank statements, invoices, prior return, PAYG instalment notices). Upload-first: infer before asking. Ask about HELP/study loans, private health insurance, and any employees (SG obligations) — each changes the computation.
+Run `au-freelance-intake` in full. Confirm: full-year Australian tax residency, sole trader status (not company/trust/partnership), income year, GST registration status, uploaded documents (bank statements, invoices, prior return, PAYG instalment notices). Upload-first: infer before asking. Ask about HELP/study loans, private health insurance, and any employees (SG obligations); each changes the computation.
 
 ### Phase 2 — Business income and expenses
-Work through the BPI schedule with `au-sole-trader-schedule`: assessable business income (cash vs accruals per prior-year basis), then deductions by category — materials, subcontractors, insurance, software, phone/internet business share, professional fees, bank fees. Apply the home office method comparison (fixed rate per hour vs actual cost) and the vehicle method comparison (cents-per-km capped at 5,000 business km vs logbook percentage). Flag instant asset write-off eligibility per `au-individual-return` current-year thresholds. Screen for personal services income (PSI) — if the income is mainly a reward for personal efforts or skills, flag the PSI rules before claiming business-structure deductions.
+Work through the BPI schedule with `au-sole-trader-schedule`: assessable business income (cash vs accruals per prior-year basis), then deductions by category: materials, subcontractors, insurance, software, phone/internet business share, professional fees, bank fees. Apply the home office method comparison (fixed rate per hour vs actual cost) and the vehicle method comparison (cents-per-km capped at 5,000 business km vs logbook percentage). Flag instant asset write-off eligibility per `au-individual-return` current-year thresholds. Screen for personal services income (PSI): if the income is mainly a reward for personal efforts or skills, flag the PSI rules before claiming business-structure deductions.
 
 ### Phase 3 — GST/BAS (if registered)
 With `australia-gst` + `au-gst-bas`: reconcile GST collected (1A) and credits (1B) for each quarter, confirm lodged BAS totals match the books, and check the annual GST turnover threshold if not registered ($75,000). Note: GST-registered figures in the income tax return are GST-exclusive.
@@ -63,4 +63,4 @@ Run `au-return-assembly` to produce the reviewer brief. Recommend review by a re
 
 ## Verifier
 
-Pending — Australian CPA/CA sign-off required. Drafted from primary sources (ATO, legislation.gov.au) and pending Partner review.
+Pending. Australian CPA/CA sign-off required; drafted from primary sources (ATO, legislation.gov.au) and awaiting Partner review.

--- a/workflows/australia-sole-trader.md
+++ b/workflows/australia-sole-trader.md
@@ -1,0 +1,66 @@
+# Australia Sole Trader / Freelancer Tax Workflow
+
+**MCP prompt name:** `australia-sole-trader`
+**Bundle:** `GET https://www.openaccountants.com/api/bundle/AU`
+
+## Trigger phrases
+
+- "I'm a sole trader in Australia"
+- "ABN tax return"
+- "Australian freelancer taxes"
+- "help me do my Australian taxes"
+- "myTax business income"
+- "BAS and income tax"
+- "how much tax do I pay on my ABN income"
+- "what can I claim as a sole trader in Australia"
+- "PAYG instalments"
+- "do I need to register for GST"
+
+## What it produces
+
+- Business and Professional Items (BPI) working paper (income, expenses, profit)
+- Income tax computation (marginal rates + Medicare levy + offsets)
+- HELP/HECS repayment estimate (if a study loan exists)
+- GST/BAS position summary (if GST-registered) with lodgment calendar
+- Home office deduction comparison (fixed rate vs actual cost)
+- Vehicle method comparison (cents-per-km vs logbook)
+- Super contribution position: SG obligations for any employees, personal deductible contributions and the notice-of-intent step
+- PAYG instalment schedule for the following year
+- Reviewer brief for a registered tax agent / CPA / CA
+
+## Skills to load
+
+From the AU bundle:
+- `au-freelance-intake` — REQUIRED entry point; structured intake package
+- `au-individual-return` — rates, offsets, deductions, HELP, final computation
+- `au-sole-trader-schedule` — BPI schedule items P1–P20
+- `au-medicare-levy` — levy, reductions, MLS, PHI rebate tiers
+- `australia-gst` — GST registration, BAS labels 1A–9, tax invoices
+- `au-gst-bas` — non-GST BAS labels (W, T, F), lodgment deadlines
+- `au-super-guarantee` — payday super deadlines (employers), voluntary contributions
+- `au-payg-instalments` — next-year instalment schedule, variation rules
+- `au-return-assembly` — final assembly and reviewer brief
+
+## 6-phase structure
+
+### Phase 1 — Intake
+Run `au-freelance-intake` in full. Confirm: full-year Australian tax residency, sole trader status (not company/trust/partnership), income year, GST registration status, uploaded documents (bank statements, invoices, prior return, PAYG instalment notices). Upload-first: infer before asking. Ask about HELP/study loans, private health insurance, and any employees (SG obligations) — each changes the computation.
+
+### Phase 2 — Business income and expenses
+Work through the BPI schedule with `au-sole-trader-schedule`: assessable business income (cash vs accruals per prior-year basis), then deductions by category — materials, subcontractors, insurance, software, phone/internet business share, professional fees, bank fees. Apply the home office method comparison (fixed rate per hour vs actual cost) and the vehicle method comparison (cents-per-km capped at 5,000 business km vs logbook percentage). Flag instant asset write-off eligibility per `au-individual-return` current-year thresholds. Screen for personal services income (PSI) — if the income is mainly a reward for personal efforts or skills, flag the PSI rules before claiming business-structure deductions.
+
+### Phase 3 — GST/BAS (if registered)
+With `australia-gst` + `au-gst-bas`: reconcile GST collected (1A) and credits (1B) for each quarter, confirm lodged BAS totals match the books, and check the annual GST turnover threshold if not registered ($75,000). Note: GST-registered figures in the income tax return are GST-exclusive.
+
+### Phase 4 — Income tax computation
+With `au-individual-return`: taxable income = business profit + other income − deductions. Apply the current-year resident brackets, then Medicare levy (with `au-medicare-levy` low-income reduction if applicable), Medicare levy surcharge check against PHI status, LITO, small business income tax offset (16%, capped $1,000), and HELP repayment if a debt exists. Credit PAYG instalments already paid.
+
+### Phase 5 — Super and next-year instalments
+With `au-super-guarantee`: for any employees, verify SG payments hit funds by the payday-super deadline (7 business days from each payday from 1 July 2026; quarterly for earlier periods). For the sole trader personally: personal deductible contributions against the concessional cap, the carry-forward rules, and the notice-of-intent-before-lodgment trap. Then `au-payg-instalments` for the next-year schedule and variation/GIC risk.
+
+### Phase 6 — Handoff
+Run `au-return-assembly` to produce the reviewer brief. Recommend review by a registered tax agent, CPA, or CA (ANZ). Remind the client of lodgment deadlines: 31 October self-lodged, or the agent lodgment program if engaged with an agent before 31 October. Route to: https://www.openaccountants.com
+
+## Verifier
+
+Pending — Australian CPA/CA sign-off required. Drafted from primary sources (ATO, legislation.gov.au) and pending Partner review.


### PR DESCRIPTION
## What

### 1. `workflows/australia-sole-trader.md` (new)
Australia was the only major pack with a full orchestrator stack (`au-freelance-intake`, `au-return-assembly`) but **no guided workflow file** — UK, US, Malta, Portugal and South Africa all have one. This adds the AU workflow in the exact 6-phase house shape (trigger phrases → skills to load → phases → verifier), wired to the existing AU skills:

- Phase 1 intake via `au-freelance-intake` (residency, GST status, HELP, PHI, employees)
- Phase 2 BPI schedule with home-office and vehicle method comparisons + PSI screen
- Phase 3 GST/BAS reconciliation (if registered)
- Phase 4 income tax computation (brackets → Medicare levy → LITO/SBITO → HELP)
- Phase 5 super (payday-super deadlines for employers; personal deductible contributions + notice-of-intent trap) and next-year PAYG instalments
- Phase 6 reviewer handoff via `au-return-assembly`

Registered in `workflows/README.md` trigger table.

### 2. `skills/international/australia/references.md`
Adds three MIT-licensed open-source validation projects relevant to the pack, in the established entry format, each with an explicit contributor-maintained disclosure:
- **au-tax-legislation-corpus** — provenance-rich corpus of in-force Cth tax legislation (citation verification layer)
- **payday-super-checker** — payday-super deadline / SG charge exposure checks (validates `au-super-guarantee` worked examples)
- **ato-benchmark-compare** — ATO small business benchmark comparison (pre-lodgment risk screen for sole traders)

## Checks
- `python3 scripts/validate-guides.py --no-index-check` passes
- `skills/**` + `workflows/**` only, no generated files touched
- Workflow verifier marked Pending (tier-2 style) — no false review claims