### PR TITLE
fix(au): roll indexed figures forward to 2025-26/2026-27

### DIFF
--- a/skills/international/australia/au-capital-gains.md
+++ b/skills/international/australia/au-capital-gains.md
@@ -1,10 +1,11 @@
 ---
 name: au-capital-gains
 description: "Use this skill for any Australian resident's capital gains tax question. Trigger on: \"CGT Australia\", \"capital gains Australia\", \"sell shares Australia\", \"50% CGT discount\", \"cost base Australia\", \"small business CGT concessions\", \"SBCGT\", \"active asset test\", \"15-year exemption\", \"retirement exemption CGT\", \"CGT rollover\", \"CGT event A1\", \"main residence exemption\", \"Australian CGT\", \"sell my Australian company\", \"dispose of property Australia\". Covers CGT events, cost base, 50% discount, SBCGT concessions, main residence exemption. For non-residents selling Australian assets see au-nonresident-cgt."
-version: 1.0
+version: 1.1
 jurisdiction: AU
 tax_year: 2025
-last_updated: 2026-07-13
+tax_year_notes: "2025-26; includes 1 July 2027 CGT reform alert (Tax Reform No. 1 Act 2026)"
+last_updated: 2026-08-20
 review_status: pending_review
 depends_on: - au-individual-return
 category: international
@@ -13,6 +14,8 @@ license: AGPL-3.0-or-later (code) / OpenAccountants Guide License v1.0 (content)
 ---
 
 # AU Capital Gains
+
+> **Law-change alert (passed June 2026, applies from 1 July 2027).** The *Treasury Laws Amendment (Tax Reform No. 1) Act 2026* replaces the 50% CGT discount for individuals, trusts and partnerships with **cost-base indexation plus a 30% minimum tax rate** for capital gains **accruing from 1 July 2027**. Assets held on 30 June 2027 (including pre-CGT assets) are deemed sold and re-acquired on 1 July 2027, splitting every later disposal into pre- and post-1-July-2027 gain components across four asset-based categories (residential vs non-residential × pre vs post). The 50% discount is retained for **new residential dwellings**; the small business 50% active-asset reduction is being expanded (announced: turnover test $2m → $10m). Everything below describes the law that still applies to gains accruing **up to 30 June 2027** — for disposals after that date, or timing decisions straddling it, escalate to a qualified adviser and check the current ATO guidance.
 
 ## Section 1 — Quick Reference
 

--- a/skills/international/australia/au-gst-bas.md
+++ b/skills/international/australia/au-gst-bas.md
@@ -15,7 +15,7 @@ license: AGPL-3.0-or-later (code) / OpenAccountants Guide License v1.0 (content)
 
 ## AU GST Bas
 
-## Australia BAS — Non-GST Sections v1.1
+## Australia BAS — Non-GST Sections v1.2
 
 ## What this file is
 

--- a/skills/international/australia/au-gst-bas.md
+++ b/skills/international/australia/au-gst-bas.md
@@ -1,10 +1,10 @@
 ---
 name: au-gst-bas
 description: Australian Business Activity Statement (BAS) — non-GST sections. Covers PAYG withholding (labels W1-W5), PAYG income tax instalments (labels T1-T9), FBT instalments (label F1), and PAYG withholding reconciliation. Complements australia-gst.md which covers GST labels (1A-9).
-version: 1.1
+version: 1.2
 jurisdiction: AU
 tax_year: 2025
-last_updated: 2026-08-11
+last_updated: 2026-08-20
 review_status: pending_review
 category: international
 tier: 2
@@ -143,7 +143,7 @@ Two methods are available:
 
 ### 5.1 Variation of PAYG instalments
 
-- **PAYG instalment variation and GIC exposure** — A taxpayer may vary their instalment amount or rate downward if they expect lower income. **GIC exposure:** If the varied amount is less than 85% of the correct instalment, a general interest charge applies on the shortfall. The GIC rate is updated quarterly by the ATO (base rate = 90-day bank bill rate + 7%). **Variation uplift factor:** If the taxpayer varies for two or more consecutive quarters, the ATO may apply a higher GDP uplift factor in the following year.  _(TAA 1953 Sch 1 s 45-205)_
+- **PAYG instalment variation and GIC exposure** — A taxpayer may vary their instalment amount or rate downward if they expect lower income. **GIC exposure:** If the varied amount is less than 85% of the correct instalment, a general interest charge applies on the shortfall. The GIC rate is updated quarterly by the ATO (base rate = 90-day bank bill rate + 7%). **GIC incurred on or after 1 July 2025 is not tax-deductible** (Treasury Laws Amendment (Tax Incentives and Integrity) Act 2025 Sch 2), which makes under-variation materially more expensive. **Variation uplift factor:** If the taxpayer varies for two or more consecutive quarters, the ATO may apply a higher GDP uplift factor in the following year.  _(TAA 1953 Sch 1 s 45-205)_
 
 ### 5.2 First year of business
 

--- a/skills/international/australia/au-individual-return.md
+++ b/skills/international/australia/au-individual-return.md
@@ -1,10 +1,11 @@
 ---
 name: au-individual-return
 description: Use this skill whenever asked about Australian individual income tax for sole traders. Trigger on phrases like "how much tax do I pay in Australia", "Australian tax return", "sole trader tax", "ABN tax", "Medicare levy", "LITO", "PAYG", "tax brackets Australia", "BAS", "instant asset write-off", "home office deduction", "HELP repayment", "HECS debt", "small business income tax offset", "motor vehicle deduction", or any question about filing or computing income tax for an Australian sole trader. Covers 2024-25 Stage 3 tax rates, Medicare levy and surcharge, LITO, business income computation, allowable deductions, depreciation, instant asset write-off, small business income tax offset, HELP/HECS repayments, and final tax computation. ALWAYS read this skill before touching any Australian income tax work.
-version: 2.0
+version: 2.1
 jurisdiction: AU
 tax_year: 2024
-last_updated: 2026-07-13
+tax_year_notes: "2024-25 computation base; HELP repayment tables updated for 2025-26 and 2026-27 (marginal system)"
+last_updated: 2026-08-20
 review_status: pending_review
 depends_on: - income-tax-workflow-base
 category: international
@@ -269,16 +270,26 @@ license: AGPL-3.0-or-later (code) / OpenAccountants Guide License v1.0 (content)
 
 **5.5 HELP/HECS Repayment [T1]**
 
-| Repayment Income (2024-25) | Rate |
-| --- | --- |
-| Below $54,435 | 0% |
-| $54,435 -- $62,850 | 1% |
-| $62,851 -- $66,620 | 2% |
-| $66,621 -- $70,618 | 2.5% |
-| ... (progressive to) | ... |
-| $151,201+ | 10% |
+> **Regime change from 1 July 2025.** Compulsory repayments moved from a percentage of TOTAL repayment income to a **marginal system** — the repayment is calculated only on income above the minimum threshold. The old sliding-scale table (1%–10% from $54,435) applies to 2024-25 and earlier returns only. _(Student loan reforms passed November 2025; ATO QC 59241)_
 
-- **Repayment income** — Repayment income = taxable income + reportable fringe benefits + net investment losses + reportable super. HELP repayments are NOT deductible.  _(Higher Education Support Act 2003)_
+| Repayment Income (2025-26) | Repayment on this income |
+| --- | --- |
+| $0 – $67,000 | Nil |
+| $67,001 – $125,000 | 15c for each $1 over $67,000 |
+| $125,001 – $179,285 | $8,700 plus 17c for each $1 over $125,000 |
+| $179,286 and over | 10% of TOTAL repayment income |
+
+| Repayment Income (2026-27) | Repayment on this income |
+| --- | --- |
+| $0 – $69,528 | Nil |
+| $69,529 – $129,717 | 15c for each $1 over $69,528 |
+| $129,718 – $186,050 | $9,028 plus 17c for each $1 over $129,717 |
+| $186,051 and over | 10% of TOTAL repayment income |
+
+- **Repayment income** — Repayment income = taxable income (excluding assessable FHSS released amounts) + reportable fringe benefits + total net investment loss + reportable super contributions + exempt foreign employment income. HELP repayments are NOT deductible.  _(Higher Education Support Act 2003; ATO QC 16176)_
+- **Worked check (2025-26)** — repayment income $80,000 → 15% × ($80,000 − $67,000) = **$1,950** (old system would have been $2,800 at 3.5%).
+- **One-off 20% debt reduction** — HELP/study loan balances outstanding at 1 June 2025 were automatically reduced by 20% (applied by the ATO from late 2025, processing completed by mid-2026; no action required). Confirm the client's current balance from ATO online services rather than an old statement.  _(studyassist.gov.au; ATO "Study and training loans – what's new", 30 June 2026)_
+- **Indexation** — study loan indexation is now the LOWER of CPI and Wage Price Index (backdated to 1 June 2023 by the Universities Accord (Student Support and Other Measures) Act 2024).
 
 ### 5.6 Filing and Penalties [T1]
 
@@ -291,7 +302,7 @@ license: AGPL-3.0-or-later (code) / OpenAccountants Guide License v1.0 (content)
 | Failure to lodge on time | $313 per 28-day period, up to 5 periods ($1,565 max) |
 | Shortfall penalty (reasonable care not taken) | 25% of shortfall |
 | Shortfall penalty (recklessness) | 50% of shortfall |
-| General Interest Charge (GIC) | Varies quarterly; 2025 annual rates include 11.42%, 11.17%, 10.78%, and 10.61%; calculated daily and compounded |
+| General Interest Charge (GIC) | Updated quarterly (TAA 1953 s 8AAD): 2025-26 quarters were 10.78%, 10.61%, 10.65%, 10.96%; Jul–Sep 2026 is 11.43%; calculated daily and compounded. **GIC and SIC incurred on or after 1 July 2025 are NOT tax-deductible** (Treasury Laws Amendment (Tax Incentives and Integrity) Act 2025 Sch 2); remitted post-1-July-2025 GIC is not assessable, but remitted pre-1-July-2025 GIC that was deducted IS assessable |
 
 ## Section 6 -- Tier 2 Catalogue (Reviewer Judgement Required)
 

--- a/skills/international/australia/au-individual-return.md
+++ b/skills/international/australia/au-individual-return.md
@@ -299,7 +299,7 @@ license: AGPL-3.0-or-later (code) / OpenAccountants Guide License v1.0 (content)
 | --- | --- |
 | Self-lodge deadline | 31 October 2025 |
 | Tax agent deadline | Varies (typically March-May 2026) |
-| Failure to lodge on time | $313 per 28-day period, up to 5 periods ($1,565 max) |
+| Failure to lodge on time | 1 penalty unit per 28-day period, up to 5 periods. Penalty unit: $364 from 1 Jul 2026; $330 for 7 Nov 2024 – 30 Jun 2026 (max $1,820 / $1,650) |
 | Shortfall penalty (reasonable care not taken) | 25% of shortfall |
 | Shortfall penalty (recklessness) | 50% of shortfall |
 | General Interest Charge (GIC) | Updated quarterly (TAA 1953 s 8AAD): 2025-26 quarters were 10.78%, 10.61%, 10.65%, 10.96%; Jul–Sep 2026 is 11.43%; calculated daily and compounded. **GIC and SIC incurred on or after 1 July 2025 are NOT tax-deductible** (Treasury Laws Amendment (Tax Incentives and Integrity) Act 2025 Sch 2); remitted post-1-July-2025 GIC is not assessable, but remitted pre-1-July-2025 GIC that was deducted IS assessable |

--- a/skills/international/australia/au-individual-return.md
+++ b/skills/international/australia/au-individual-return.md
@@ -32,7 +32,7 @@ license: AGPL-3.0-or-later (code) / OpenAccountants Guide License v1.0 (content)
 | Filing deadline | 31 October 2025 (self-lodged); May 2026 (tax agent) |
 | Contributor | Open Accountants Community |
 | Validated by | Pending -- Australian CPA/CA sign-off required |
-| Skill version | 2.0 |
+| Skill version | 2.1 |
 
 ### Tax Rates -- Resident Individual (2024-25, Stage 3) [T1]
 

--- a/skills/international/australia/au-individual-return.md
+++ b/skills/international/australia/au-individual-return.md
@@ -46,6 +46,8 @@ license: AGPL-3.0-or-later (code) / OpenAccountants Guide License v1.0 (content)
 | 135,001 -- 190,000 | 37% | Max $20,350 |
 | 190,001+ | 45% |  |
 
+> **Rates apply to 2024-25 AND 2025-26 (identical).** From **1 July 2026** the 16% rate drops to **15%** (2026-27: tax on $45,000 = $4,020; on $135,000 = $31,020; on $190,000 = $51,370), and from **1 July 2027** to **14%**. _(ATO QC 73320, updated 13 Aug 2026; Treasury Laws Amendment (More Cost of Living Relief) Act 2025.)_
+
 ### Medicare Levy [T1]
 
 **Medicare Levy [T1]**
@@ -53,9 +55,9 @@ license: AGPL-3.0-or-later (code) / OpenAccountants Guide License v1.0 (content)
 | Item | Value |
 | --- | --- |
 | Rate | 2% of taxable income |
-| Low-income threshold (single) | $27,222 (no levy below; phase-in $27,223-$34,027) |
-| Low-income threshold (family) | $45,907 + $4,216 per dependent child |
-| Surcharge (no private hospital cover) | Additional 1%-1.5% if income over $93,000 (single) |
+| Low-income threshold (single, 2025-26) | $28,011 (no levy below; phase-in $28,012-$35,013). 2024-25: $27,222 / $34,027 |
+| Low-income threshold (family, 2025-26) | $47,238 + $4,338 per dependent child. 2024-25: $45,907 + $4,216 |
+| Surcharge (no private hospital cover) | Additional 1%-1.5% if income for MLS purposes over $101,000 single / $202,000 family (2025-26; 2024-25: $97,000 / $194,000) |
 
 ### Low Income Tax Offset (LITO) [T1]
 
@@ -63,9 +65,12 @@ license: AGPL-3.0-or-later (code) / OpenAccountants Guide License v1.0 (content)
 
 | Taxable Income (AUD) | LITO |
 | --- | --- |
-| Up to $45,000 | $700 |
-| $45,001 -- $66,667 | Reduces by 5c per $1 over $45,000 |
+| Up to $37,500 | $700 |
+| $37,501 -- $45,000 | $700 minus 5c per $1 over $37,500 |
+| $45,001 -- $66,667 | $325 minus 1.5c per $1 over $45,000 |
 | $66,668+ | $0 |
+
+_(ATO "Low income tax offset"; unchanged for 2024-25 through 2026-27.)_
 
 ### Small Business Income Tax Offset (SBITO) [T1]
 
@@ -83,8 +88,8 @@ license: AGPL-3.0-or-later (code) / OpenAccountants Guide License v1.0 (content)
 
 | Item | Rate/threshold | Claim handling |
 | --- | --- | --- |
-| Home office -- fixed rate method | 70 cents per hour (2024-25 and 2025-26) | T2 -- method choice, hours, and records/substantiation required |
-| Motor vehicle -- cents per km method | 88 cents per km (max 5,000 km) | T2 -- method choice and business-km support required |
+| Home office -- fixed rate method | 70 cents per hour (2024-25 through 2026-27, PCG 2023/1) | T2 -- method choice, hours, and records/substantiation required |
+| Motor vehicle -- cents per km method | 88c/km for 2024-25 and 2025-26; **91c/km for 2026-27** (max 5,000 km) | T2 -- method choice and business-km support required |
 | Instant asset write-off (small business) | $20,000 threshold (assets under $20,000 immediately deductible) | T1 if small-business eligibility and asset cost are clear; otherwise escalate |
 | Superannuation (deductible personal contribution) | Up to $30,000 concessional cap | T1 rate-cap lookup; notice of intent must be lodged before claiming |
 
@@ -149,8 +154,8 @@ license: AGPL-3.0-or-later (code) / OpenAccountants Guide License v1.0 (content)
 | Pattern | Deduction Category | Tier | Treatment |
 | --- | --- | --- | --- |
 | RENT, OFFICE RENT, SERVICED OFFICE | Business expense -- occupancy | T1 | Fully deductible if dedicated business premises |
-| HOME OFFICE, WORK FROM HOME | Home office deduction (D5) | T2 | Fixed rate 70c/hr (2024-25 and 2025-26) OR actual cost method. See Tier 2. |
-| PETROL, FUEL, CALTEX, BP, SHELL, AMPOL | Motor vehicle (D1) | T2 | Cents/km (88c, max 5,000 km) OR logbook method |
+| HOME OFFICE, WORK FROM HOME | Home office deduction (D5) | T2 | Fixed rate 70c/hr (2024-25 through 2026-27) OR actual cost method. See Tier 2. |
+| PETROL, FUEL, CALTEX, BP, SHELL, AMPOL | Motor vehicle (D1) | T2 | Cents/km (88c 2024-25/2025-26; 91c 2026-27; max 5,000 km) OR logbook method |
 | CAR INSURANCE, REGO, SERVICE | Motor vehicle | T2 | Only under logbook method (not cents/km) |
 | TOLL, CITYLINK, LINKT | Motor vehicle or travel | T1 | Business travel tolls: deductible under either method |
 | FLIGHT, QANTAS, VIRGIN, JETSTAR | Travel (D2) | T1 | Fully deductible if business travel |
@@ -260,7 +265,7 @@ license: AGPL-3.0-or-later (code) / OpenAccountants Guide License v1.0 (content)
 - **Diminishing value** — Base value x (days held / 365) x (200% / effective life)  _(ITAA 1997 Div 40)_
 - **Prime cost (straight line)** — Cost x (days held / 365) x (100% / effective life)  _(ITAA 1997 Div 40)_
 - **Small business entity simplified depreciation** — Small business entity (turnover < $10M): can use simplified depreciation -- pool all assets over $20,000 at 15% first year, 30% thereafter.  _(ITAA 1997 Div 40)_
-- **Instant asset write-off** — Assets costing less than $20,000 (2024-25) can be immediately deducted by small business entities. This threshold may change each year -- confirm for current year.  _(ITAA 1997 Div 40)_
+- **Instant asset write-off** — Assets costing less than $20,000 can be immediately deducted by small business entities (aggregated turnover < $10m). The $20,000 limit is law for 2024-25 and 2025-26 (extended by the Treasury Laws Amendment (Strengthening Financial Systems and Other Measures) Act 2025), and the 2026-27 Budget announced it becomes **permanent from 1 July 2026** — confirm enactment before relying on it for 2026-27 purchases.  _(ITAA 1997 Div 328; ATO QC 103578)_
 
 ### 5.4 Superannuation [T1]
 
@@ -312,7 +317,7 @@ license: AGPL-3.0-or-later (code) / OpenAccountants Guide License v1.0 (content)
 
 | Method | What It Covers | Additional Claims |
 | --- | --- | --- |
-| Fixed rate (70c/hr, 2024-25 and 2025-26) | Electricity, gas, phone, internet, stationery, computer consumables | Separately claim: technology depreciation (computer, monitor), occupancy costs (if dedicated room), cleaning |
+| Fixed rate (70c/hr, 2024-25 through 2026-27) | Electricity, gas, phone, internet, stationery, computer consumables | Separately claim: technology depreciation (computer, monitor), occupancy costs (if dedicated room), cleaning |
 | Actual cost | Each expense claimed individually at actual business % | No fixed rate component |
 
 - **Home office record keeping and occupancy expenses** — Under either method: must have records of hours worked from home. Fixed rate: can use any reasonable record. Actual: need receipts and usage records. Occupancy expenses (rent, mortgage interest, rates, home insurance, land tax) are ONLY deductible if you have a dedicated area set aside exclusively as a place of business. These are separate from running expenses.
@@ -325,7 +330,7 @@ Confirm method, hours, and whether occupancy expenses apply.
 
 | Method | How It Works | Records |
 | --- | --- | --- |
-| Cents per km (88c) | Max 5,000 business km. No receipts needed. | Reasonable estimate of business km |
+| Cents per km (88c in 2024-25/2025-26; 91c in 2026-27) | Max 5,000 business km. No receipts needed. | Reasonable estimate of business km |
 | Logbook | Business % of actual costs including depreciation | 12-week continuous logbook, valid for 5 years |
 
 - **Cannot claim both methods** — Cannot claim both. Parking, tolls, and roadside assistance are separate and deductible under either method for business trips.

--- a/skills/international/australia/au-medicare-levy.md
+++ b/skills/international/australia/au-medicare-levy.md
@@ -1,10 +1,11 @@
 ---
 name: au-medicare-levy
 description: Use this skill whenever asked about the Australian Medicare Levy, Medicare Levy Surcharge (MLS), low-income reduction thresholds, family thresholds, surcharge tiers, private health insurance (PHI) rebate interaction, or Medicare levy exemptions. Trigger on phrases like "Medicare levy", "Medicare surcharge", "MLS", "do I pay Medicare levy", "low income Medicare", "Medicare levy reduction", "Medicare levy exemption", "private health insurance rebate", "PHI rebate", "M1", "M2", or any question about Medicare-related levies on an Australian tax return. ALWAYS read this skill before touching any Medicare levy work.
-version: 2.0
+version: 2.1
 jurisdiction: AU
-tax_year: 2024
-last_updated: 2026-07-13
+tax_year: 2025
+tax_year_notes: "2025-26 (current lodgment year); 2024-25 tables retained for prior-year work"
+last_updated: 2026-08-20
 review_status: pending_review
 category: international
 tier: 2
@@ -28,7 +29,7 @@ Read this whole section before computing anything.
 | Primary Legislation | Medicare Levy Act 1986 (MLA 1986); A New Tax System (Medicare Levy Surcharge -- Fringe Benefits) Act 1999 |
 | Supporting Legislation | ITAA 1997 Div 61 (Medicare levy); ITAA 1997 s 8C-8G (MLS); Health Insurance Act 1973; Private Health Insurance Act 2007 |
 | Tax Authority | Australian Taxation Office (ATO) |
-| Tax Year | 2024-25 (1 July 2024 -- 30 June 2025) |
+| Tax Year | 2025-26 (1 July 2025 -- 30 June 2026, current lodgment year); 2024-25 tables retained below |
 | Standard Medicare Levy Rate | 2% of taxable income |
 | MLS Rates | 1.0% / 1.25% / 1.5% (income-dependent, for those without appropriate PHI) |
 | Return Items | Item M1 (Medicare levy reduction or exemption); Item M2 (Medicare levy surcharge) |
@@ -38,7 +39,18 @@ Read this whole section before computing anything.
 | Skill Version | 2.0 |
 | Confidence Coverage | Tier 1: standard levy, low-income reduction, surcharge tiers, family thresholds. Tier 2: half-year exemptions, part-year residents, PHI rebate tier selection. Tier 3: Norfolk Island transitional, diplomatic exemptions, prescribed overseas forces. |
 
-**Low-income reduction thresholds (2024-25)**
+**Low-income reduction thresholds (2025-26)**
+
+| Category | Lower Threshold (no levy) | Upper Threshold (full levy) | Shade-in Rate |
+| --- | --- | --- | --- |
+| Single (general) | $28,011 | $35,013 | 10 cents per $1 |
+| Single (SAPTO-entitled) | $44,268 | $55,335 | 10 cents per $1 |
+| Family (general) | $47,238 (+ $4,338 per child) | $59,047 | See Section 5 |
+| Family (SAPTO-entitled) | $61,623 (+ $4,338 per child) | $77,028 | See Section 5 |
+
+_(ATO QC 27031, updated for 2025-26.)_
+
+**Low-income reduction thresholds (2024-25, prior year)**
 
 | Category | Lower Threshold (no levy) | Upper Threshold (full levy) | Shade-in Rate |
 | --- | --- | --- | --- |
@@ -47,7 +59,25 @@ Read this whole section before computing anything.
 | Family (general) | $45,907 (+ $4,216 per child) | N/A | See Section 5 |
 | Family (SAPTO-entitled) | $63,486 (+ $4,216 per child) | N/A | See Section 5 |
 
-**MLS thresholds (2024-25) -- singles**
+**MLS thresholds (2025-26) -- singles**
+
+| Tier | Income for MLS Purposes | MLS Rate |
+| --- | --- | --- |
+| Base | $101,000 or less | 0.0% |
+| Tier 1 | $101,001 -- $118,000 | 1.0% |
+| Tier 2 | $118,001 -- $158,000 | 1.25% |
+| Tier 3 | $158,001+ | 1.5% |
+
+**MLS thresholds (2025-26) -- families**
+
+| Tier | Family Income for MLS | MLS Rate |
+| --- | --- | --- |
+| Base | $202,000 or less | 0.0% |
+| Tier 1 | $202,001 -- $236,000 | 1.0% |
+| Tier 2 | $236,001 -- $316,000 | 1.25% |
+| Tier 3 | $316,001+ | 1.5% |
+
+**MLS thresholds (2024-25, prior year) -- singles**
 
 | Tier | Income for MLS Purposes | MLS Rate |
 | --- | --- | --- |
@@ -56,7 +86,7 @@ Read this whole section before computing anything.
 | Tier 2 | $113,001 -- $151,000 | 1.25% |
 | Tier 3 | $151,001+ | 1.5% |
 
-**MLS thresholds (2024-25) -- families**
+**MLS thresholds (2024-25, prior year) -- families**
 
 | Tier | Family Income for MLS | MLS Rate |
 | --- | --- | --- |
@@ -67,14 +97,22 @@ Read this whole section before computing anything.
 
 - **Family income threshold increase per additional child** — The family income threshold increases by $1,500 for each MLS dependent child after the first child.
 
-**PHI rebate tiers (2024-25)**
+**PHI rebate tiers (2025-26 income thresholds; rebate percentages by period)**
 
-| Tier | Singles Income | Families Income | Rebate (under 65) | Rebate (65-69) | Rebate (70+) |
-| --- | --- | --- | --- | --- | --- |
-| Base | $97,000 or less | $194,000 or less | 24.608% | 28.710% | 32.812% |
-| Tier 1 | $97,001 -- $113,000 | $194,001 -- $226,000 | 16.405% | 20.507% | 24.608% |
-| Tier 2 | $113,001 -- $151,000 | $226,001 -- $302,000 | 8.202% | 12.303% | 16.405% |
-| Tier 3 | $151,001+ | $302,001+ | 0.000% | 0.000% | 0.000% |
+The income tiers follow the MLS thresholds above. Rebate percentages step down at every 1 April (rebate adjustment factor):
+
+| Period | Tier | Under 65 | 65-69 | 70+ |
+| --- | --- | --- | --- | --- |
+| 1 Jul 2025 – 31 Mar 2026 | Base | 24.288% | 28.337% | 32.385% |
+| 1 Jul 2025 – 31 Mar 2026 | Tier 1 | 16.192% | 20.240% | 24.288% |
+| 1 Jul 2025 – 31 Mar 2026 | Tier 2 | 8.095% | 12.143% | 16.192% |
+| 1 Jul 2025 – 31 Mar 2026 | Tier 3 | 0% | 0% | 0% |
+| From 1 Apr 2026 | Base | 24.118% | 28.139% | 32.158% |
+| From 1 Apr 2026 | Tier 1 | 16.079% | 20.098% | 24.118% |
+| From 1 Apr 2026 | Tier 2 | 8.038% | 12.059% | 16.079% |
+| From 1 Apr 2026 | Tier 3 | 0% | 0% | 0% |
+
+_(privatehealth.gov.au; Department of Health PHI Circular 12/26 — all cells step down by the same rebate adjustment factor each 1 April.)_
 
 **Conservative defaults**
 
@@ -147,14 +185,14 @@ This is the deterministic pre-classifier for bank statement entries related to M
 
 ### 4.2 Low-income reduction -- singles (Tier 1)
 
-- **Low-income reduction formula for singles** — If taxable_income <= $27,222: Medicare levy = $0. If $27,222 < taxable_income <= $34,027: Medicare levy = (taxable_income - $27,222) x 10%. If taxable_income > $34,027: Medicare levy = taxable_income x 2%.  _(Medicare Levy Act 1986 s 7)_
+- **Low-income reduction formula for singles (2025-26)** — If taxable_income <= $28,011: Medicare levy = $0. If $28,011 < taxable_income <= $35,013: Medicare levy = (taxable_income - $28,011) x 10%. If taxable_income > $35,013: Medicare levy = taxable_income x 2%. (2024-25 prior year: $27,222 / $34,027.)  _(Medicare Levy Act 1986 s 7)_
 - **Shade-in rate explanation** — The shade-in rate of 10% means the levy increases by 10 cents for every dollar earned above the lower threshold, until the reduced levy equals the standard 2% levy (which occurs at the upper threshold).  _(Medicare Levy Act 1986 s 7)_
-- **SAPTO substitution for singles** — For SAPTO-entitled singles: substitute $43,020 for $27,222, and $53,775 for $34,027.  _(Medicare Levy Act 1986 s 7)_
+- **SAPTO substitution for singles (2025-26)** — For SAPTO-entitled singles: substitute $44,268 for $28,011, and $55,335 for $35,013. (2024-25 prior year: $43,020 / $53,775.)  _(Medicare Levy Act 1986 s 7)_
 
 ### 4.3 Low-income reduction -- families (Tier 1)
 
-- **Family threshold formula** — Family threshold = $45,907 + ($4,216 x number_of_dependent_children)  _(Medicare Levy Act 1986 s 8)_
-- **SAPTO family threshold formula** — For SAPTO-entitled families: Family threshold = $63,486 + ($4,216 x number_of_dependent_children)  _(Medicare Levy Act 1986 s 8)_
+- **Family threshold formula (2025-26)** — Family threshold = $47,238 + ($4,338 x number_of_dependent_children). (2024-25 prior year: $45,907 + $4,216 per child.)  _(Medicare Levy Act 1986 s 8)_
+- **SAPTO family threshold formula (2025-26)** — For SAPTO-entitled families: Family threshold = $61,623 + ($4,338 x number_of_dependent_children).  _(Medicare Levy Act 1986 s 8; ATO QC 27031)_
 - **Family threshold effect** — Family income at or below the family threshold: no Medicare levy payable for either spouse. Family income above the family threshold: each spouse pays their individual share, subject to individual reduction rules.  _(Medicare Levy Act 1986 s 8)_
 - **Family income for Medicare levy purposes** — Family income for Medicare levy purposes = combined taxable income of both spouses + any exempt foreign employment income + any net financial investment loss + reportable super contributions.  _(Medicare Levy Act 1986 s 8)_
 
@@ -205,7 +243,7 @@ Planning note: For clients in Tier 1 or Tier 2 MLS, holding private hospital cov
 
 ### 6.2 Item M2 -- Medicare levy surcharge
 
-- **When to complete M2** — Complete M2 if: you (or your spouse/dependants) did not have appropriate private hospital cover for any day during the year; your income for MLS purposes exceeds the relevant threshold ($97,000 singles / $194,000 families). If the client held appropriate cover for the full year, M2 does not need to be completed (no MLS is payable).
+- **When to complete M2** — Complete M2 if: you (or your spouse/dependants) did not have appropriate private hospital cover for any day during the year; your income for MLS purposes exceeds the relevant threshold (2025-26: $101,000 singles / $202,000 families; 2024-25: $97,000 / $194,000). If the client held appropriate cover for the full year, M2 does not need to be completed (no MLS is payable).
 
 ## Section 7 -- Edge case registry
 
@@ -222,22 +260,22 @@ Resolution: The MLS applies to BOTH spouses unless ALL family members (including
 ### EC3 -- Client earns just above the low-income threshold (Tier 1)
 
 Situation: Single client with taxable income of $28,000.
-Resolution: Shade-in applies. Medicare levy = ($28,000 - $27,222) x 10% = $77.80. This is less than the full 2% levy of $560.00.
+Resolution (2025-26): Below the lower threshold of $28,011 — Medicare levy = $0. (In 2024-25, the shade-in applied: ($28,000 - $27,222) x 10% = $77.80.)
 
 ### EC4 -- Client has net investment losses inflating MLS income (Tier 2)
 
 Situation: Client's taxable income is $90,000 but has a net rental property loss of $15,000 (deducted from taxable income). Income for MLS purposes = $90,000 + $15,000 = $105,000.
-Resolution: Even though taxable income is below $97,000, income for MLS purposes exceeds $97,000 and MLS applies at 1.0% if no private hospital cover is held. Flag for reviewer -- confirm MLS income calculation.
+Resolution (2025-26): Even though taxable income is below the $101,000 base threshold, income for MLS purposes is $105,000, which exceeds $101,000 — MLS applies at 1.0% if no private hospital cover is held. Flag for reviewer -- confirm MLS income calculation.
 
 ### EC5 -- SAPTO-entitled pensioner with low income (Tier 1)
 
 Situation: Pensioner aged 68, taxable income $45,000, entitled to SAPTO.
-Resolution: SAPTO singles threshold is $43,020 (lower) and $53,775 (upper). At $45,000, the shade-in applies: ($45,000 - $43,020) x 10% = $198.00. Full 2% levy would be $900.00. The reduced amount of $198.00 applies.
+Resolution (2025-26): SAPTO singles threshold is $44,268 (lower) and $55,335 (upper). At $45,000, the shade-in applies: ($45,000 - $44,268) x 10% = $73.20. Full 2% levy would be $900.00. The reduced amount of $73.20 applies.
 
 ### EC6 -- Family with 4 dependent children (Tier 1)
 
 Situation: Family with 4 dependent children, combined family income $55,000.
-Resolution: Family threshold = $45,907 + ($4,216 x 4) = $62,771. Family income of $55,000 is below the threshold. No Medicare levy payable.
+Resolution (2025-26): Family threshold = $47,238 + ($4,338 x 4) = $64,590. Family income of $55,000 is below the threshold. No Medicare levy payable.
 
 ### EC7 -- MLS with private hospital cover held for part of year (Tier 2)
 
@@ -280,12 +318,12 @@ Expected output: Medicare levy = $80,000 x 2% = $1,600.00. No MLS (has PHI).
 ### Test 2 -- Low-income reduction (single)
 
 Input: Single, taxable income $30,000. No spouse.
-Expected output: Shade-in applies. Levy = ($30,000 - $27,222) x 10% = $277.80.
+Expected output (2025-26): Shade-in applies. Levy = ($30,000 - $28,011) x 10% = $198.90.
 
 ### Test 3 -- Below low-income threshold
 
 Input: Single, taxable income $25,000.
-Expected output: Medicare levy = $0. Below $27,222 lower threshold.
+Expected output (2025-26): Medicare levy = $0. Below $28,011 lower threshold.
 
 ### Test 4 -- MLS Tier 1 (single, no PHI)
 
@@ -300,7 +338,7 @@ Expected output: Medicare levy = $200,000 x 2% = $4,000.00. MLS = $200,000 x 1.5
 ### Test 6 -- Family below family threshold
 
 Input: Family, 2 dependent children, combined family income $50,000.
-Expected output: Family threshold = $45,907 + ($4,216 x 2) = $54,339. Family income $50,000 < $54,339. No Medicare levy payable.
+Expected output (2025-26): Family threshold = $47,238 + ($4,338 x 2) = $55,914. Family income $50,000 < $55,914. No Medicare levy payable.
 
 ### Test 7 -- Foreign resident full exemption
 
@@ -310,13 +348,13 @@ Expected output: Full Medicare levy exemption. Levy = $0. Must complete item M1.
 ### Test 8 -- MLS family threshold with children
 
 Input: Family, 3 children, combined income for MLS purposes $200,000. No PHI.
-Expected output: Family MLS threshold = $194,000 + ($1,500 x 2 children after the first) = $197,000. Income $200,000 > $197,000. MLS Tier 1 = 1.0% applies.
+Expected output (2025-26): Family MLS threshold = $202,000 + ($1,500 x 2 children after the first) = $205,000. Income $200,000 < $205,000. No MLS. (Under 2024-25 thresholds the same facts produced Tier 1 MLS — threshold year matters.)
 
 ## Section 10 -- Prohibitions and disclaimer
 
 ### Prohibitions
 
-- **Prohibitions list** — - NEVER apply the Medicare levy to a confirmed full-year foreign resident who is not enrolled in Medicare - NEVER ignore the MLS income definition -- it is NOT the same as taxable income (includes reportable fringe benefits and net investment losses) - NEVER tell a client they avoid MLS simply because their taxable income is below $97,000 -- check income for MLS purposes - NEVER apply the general low-income threshold ($27,222) to a SAPTO-entitled senior -- use the SAPTO thresholds ($43,020 / $53,775) - NEVER assume PHI eliminates MLS unless the cover is "appropriate" (private patient hospital cover with excess no more than $750 singles / $1,500 families) - NEVER present Medicare levy figures as definitive -- always label as estimated and direct client to their ATO assessment for confirmation - NEVER advise on diplomatic or prescribed overseas forces exemptions -- escalate - NEVER confuse the Medicare levy (2% on taxable income) with the Medicare Levy Surcharge (1%-1.5% on MLS income for those without PHI) -- they are separate charges
+- **Prohibitions list** — - NEVER apply the Medicare levy to a confirmed full-year foreign resident who is not enrolled in Medicare - NEVER ignore the MLS income definition -- it is NOT the same as taxable income (includes reportable fringe benefits and net investment losses) - NEVER tell a client they avoid MLS simply because their taxable income is below the base threshold ($101,000 in 2025-26) -- check income for MLS purposes - NEVER apply the general low-income threshold ($28,011 in 2025-26) to a SAPTO-entitled senior -- use the SAPTO thresholds ($44,268 / $55,335 in 2025-26) - NEVER assume PHI eliminates MLS unless the cover is "appropriate" (private patient hospital cover with excess no more than $750 singles / $1,500 families) - NEVER present Medicare levy figures as definitive -- always label as estimated and direct client to their ATO assessment for confirmation - NEVER advise on diplomatic or prescribed overseas forces exemptions -- escalate - NEVER confuse the Medicare levy (2% on taxable income) with the Medicare Levy Surcharge (1%-1.5% on MLS income for those without PHI) -- they are separate charges
 
 ### Disclaimer
 

--- a/skills/international/australia/au-medicare-levy.md
+++ b/skills/international/australia/au-medicare-levy.md
@@ -14,7 +14,7 @@ license: AGPL-3.0-or-later (code) / OpenAccountants Guide License v1.0 (content)
 
 # AU Medicare Levy
 
-## Australia Medicare Levy and Medicare Levy Surcharge Skill v2.0
+## Australia Medicare Levy and Medicare Levy Surcharge Skill v2.1
 
 ## Section 1 -- Quick reference
 
@@ -36,7 +36,7 @@ Read this whole section before computing anything.
 | Currency | AUD only |
 | Contributor | Open Accountants |
 | Validation Date | April 2026 |
-| Skill Version | 2.0 |
+| Skill Version | 2.1 |
 | Confidence Coverage | Tier 1: standard levy, low-income reduction, surcharge tiers, family thresholds. Tier 2: half-year exemptions, part-year residents, PHI rebate tier selection. Tier 3: Norfolk Island transitional, diplomatic exemptions, prescribed overseas forces. |
 
 **Low-income reduction thresholds (2025-26)**

--- a/skills/international/australia/au-nonresident-cgt.md
+++ b/skills/international/australia/au-nonresident-cgt.md
@@ -1,10 +1,11 @@
 ---
 name: au-nonresident-cgt
-description: "Use this skill for any non-resident selling Australian assets. Trigger on: \"non-resident CGT Australia\", \"TAP test Australia\", \"taxable Australian property\", \"FRCGW\", \"foreign resident capital gains withholding\", \"12.5% withholding Australia\", \"clearance certificate ATO\", \"sell Australian shares non-resident\", \"sell Australian property non-resident\", \"Australian CGT non-resident seller\", \"no CGT discount non-resident Australia\". Covers the TAP test, 30% flat rate, FRCGW withholding, clearance certificates. For Australian residents see au-capital-gains."
-version: 1.0
+description: "Use this skill for any non-resident selling Australian assets. Trigger on: \"non-resident CGT Australia\", \"TAP test Australia\", \"taxable Australian property\", \"FRCGW\", \"foreign resident capital gains withholding\", \"15% withholding Australia\", \"12.5% withholding Australia\", \"clearance certificate ATO\", \"sell Australian shares non-resident\", \"sell Australian property non-resident\", \"Australian CGT non-resident seller\", \"no CGT discount non-resident Australia\". Covers the TAP test, 30% flat rate, FRCGW withholding (15%, no threshold, from 1 January 2025), clearance certificates. For Australian residents see au-capital-gains."
+version: 1.1
 jurisdiction: AU
 tax_year: 2025
-last_updated: 2026-07-13
+tax_year_notes: "2025-26; FRCGW figures apply to contracts signed from 1 January 2025"
+last_updated: 2026-08-20
 review_status: pending_review
 category: international
 tier: 2
@@ -23,7 +24,7 @@ license: AGPL-3.0-or-later (code) / OpenAccountants Guide License v1.0 (content)
 | Applies to | Non-residents of Australia disposing of Australian assets |
 | CGT rate (non-resident) | **30% flat rate** on net gain (no 50% discount available) |
 | Key test | Taxable Australian Property (TAP) test |
-| Withholding | 12.5% of gross proceeds on TAP transactions > AUD $750,000 |
+| Withholding | 15% of the market value (usually sale price) on ALL Australian real property sales from 1 Jan 2025 — no minimum threshold |
 | Primary legislation | ITAA 1997 Div 855; TAA 1953 Sch 1 Subdiv 14-D |
 | Tax authority | ATO (ato.gov.au) |
 | Verified by | Pending — Australian CPA/CA sign-off required |
@@ -63,25 +64,29 @@ Non-residents are only subject to Australian CGT on **Taxable Australian Propert
 
 ## Section 5 — Foreign Resident Capital Gains Withholding (FRCGW)
 
-- **FRCGW obligation** — When a non-resident sells TAP with gross proceeds ≥ AUD $750,000, the buyer is required to withhold 12.5% of the gross proceeds and remit to the ATO.
+- **FRCGW obligation** — For contracts signed on or after 1 January 2025, the purchaser must withhold **15% of the market value (usually the sale price)** on **every** Australian real property sale — the previous AUD $750,000 de-minimis threshold was removed — unless the vendor produces an ATO clearance certificate (residents) or a variation notice (non-residents). _(TAA 1953 Sch 1 Subdiv 14-D, as amended by Treasury Laws Amendment (2024 Tax and Other Measures No. 1) Act 2024 (No. 135, 2024) Sch 1)_
+- **Prior regimes (for older contracts)** — Contracts signed 1 July 2017 – 31 December 2024: 12.5% where the property was valued at AUD $750,000 or more. Contracts signed 1 July 2016 – 30 June 2017: 10% at AUD $2,000,000 and above. The **contract date**, not settlement date, picks the regime.
 - **FRCGW nature** — This is a payment on account (not a final tax). Actual tax liability is computed in the non-resident's Australian tax return.
+- **Scope note** — FRCGW attaches to taxable Australian real property and indirect Australian real property (IARP) interests (and options/leases over them). Transactions on an approved stock exchange are excluded. Vendor declarations can apply for non-listed share/unit transactions.
 
-**FRCGW threshold table**
+**FRCGW rate table (contracts signed from 1 January 2025)**
 
-| FRCGW threshold | AUD $750,000 |
+| Item | Value |
 | --- | --- |
-| Withholding rate | 12.5% of gross proceeds |
+| Threshold | **None** — applies to all in-scope property regardless of value |
+| Withholding rate | **15%** of market value (usually the sale price) |
 | Who withholds | The buyer (purchaser) |
-| Remittance deadline | Day of settlement |
+| Remittance deadline | At or before settlement |
 
-**Example**: Non-resident sells shares (TAP) for AUD $10M. Buyer withholds AUD $1.25M (12.5%). Net gain is, say, AUD $8M. Australian tax at 30% = AUD $2.4M. The $1.25M already withheld is applied — balance payable AUD $1.15M via Australian tax return.
+**Example**: Non-resident signs a contract in March 2026 to sell shares that are an indirect Australian real property interest (TAP) for AUD $10M. Buyer withholds AUD $1.5M (15%). Net gain is, say, AUD $8M. Australian tax at 30% = AUD $2.4M. The $1.5M already withheld is applied — balance payable AUD $0.9M via Australian tax return.
 
 ## Section 6 — Clearance Certificate
 
-- **Clearance certificate for resident sellers** — If the seller is an Australian resident (not a foreign resident), the seller can apply for a clearance certificate from the ATO to confirm residency, relieving the buyer of the withholding obligation.
-- **Variation for non-resident sellers** — If the seller IS a non-resident but believes no tax is payable (e.g. asset is not TAP, or gain is nil due to losses), the seller can apply for a variation to reduce the withholding amount.
+- **Clearance certificate for resident sellers** — If the seller is an Australian resident (not a foreign resident), the seller must apply for a clearance certificate from the ATO to confirm residency, relieving the buyer of the withholding obligation. Because the $750,000 threshold was removed for contracts from 1 January 2025, **every Australian resident selling real property needs a clearance certificate** — including on the sale of a family home — or the buyer must withhold 15% at settlement and the seller waits for the next tax return to recover it.
+- **Timing** — Certificates are valid for 12 months, so vendors should apply early (before listing). Most issue quickly, but the ATO advises some can take up to 28 days.
+- **Variation for non-resident sellers** — If the seller IS a non-resident but believes 15% over-collects (e.g. the gain is small or nil, losses apply, or the asset is not TAP), the seller can apply for a variation notice specifying a reduced rate. The variation must be given to the purchaser before settlement.
 
-Applications: via ATO online portal (myGov / Tax Agent portal). Processing time: 14-28 days typically.
+Applications: via ATO online services (individuals) or the Tax/BAS Agent portal.
 
 ## Section 7 — Filing Obligations for Non-Residents
 
@@ -99,8 +104,9 @@ Always check the saving clause and specific treaty wording.
 
 - ITAA 1997 Division 855 (non-resident CGT)
 - Tax Administration Act 1953, Schedule 1, Subdivision 14-D (FRCGW)
-- ATO: ato.gov.au/individuals-and-families/investments-and-assets/capital-gains-tax/foreign-residents-and-capital-gains-tax
-- ATO: Foreign resident capital gains withholding (ato.gov.au/FRCGW)
+- Treasury Laws Amendment (2024 Tax and Other Measures No. 1) Act 2024 (No. 135, 2024), Schedule 1 — FRCGW rate to 15% and threshold removed for acquisitions from 1 January 2025
+- ATO: ato.gov.au/individuals-and-families/investments-and-assets/capital-gains-tax/foreign-residents-and-capital-gains-tax/foreign-resident-capital-gains-withholding/foreign-resident-capital-gains-withholding-overview (QC 48972, updated 22 June 2026)
+- ATO: Australian residents and clearance certificates (same section)
 
 > **Working paper only.** The TAP classification requires analysis of the company's asset composition by market value — not book value. Engage a qualified Australian tax adviser for transaction-specific advice.
 

--- a/skills/international/australia/au-payg-instalments.md
+++ b/skills/international/australia/au-payg-instalments.md
@@ -1,10 +1,10 @@
 ---
 name: au-payg-instalments
 description: Use this skill whenever asked about Australian PAYG Instalments for sole traders. Trigger on phrases like "PAYG instalments", "BAS T1 T2 T7 T9", "instalment rate", "instalment amount", "ATO instalment", "GDP uplift", "GIC", "variation of instalments", or any question about income tax prepayments through the Business Activity Statement. Covers entry/exit thresholds, instalment rate method (T1/T2), instalment amount method (T7), GDP uplift factor, voluntary variation, GIC exposure on under-estimation, and quarterly/annual election. ALWAYS read this skill before touching any PAYG instalment work for Australia.
-version: 2.0
+version: 2.1
 jurisdiction: AU
 tax_year: 2025
-last_updated: 2026-07-13
+last_updated: 2026-08-20
 review_status: pending_review
 depends_on: - income-tax-workflow-base
 category: international
@@ -187,6 +187,8 @@ No income calculation needed. ATO pre-fills the amount.
 ### 6.1 General Interest Charge (GIC)
 
 - **GIC rate** — base rate (90-day bank bill rate) + 7%  _(Updated quarterly. Applies from instalment due date if variation results in < 85% of correct amount.)_
+- **GIC not deductible from 1 July 2025** — GIC (and shortfall interest charge) incurred on or after 1 July 2025 is denied as an income tax deduction. GIC incurred up to 30 June 2025 remains deductible under the old law; if such deducted GIC is later remitted, the remitted amount is assessable. Post-1-July-2025 GIC that is remitted is not assessable.  _(Treasury Laws Amendment (Tax Incentives and Integrity) Act 2025 (No. 29, 2025) Sch 2; ATO QC 73746)_
+- **Quarterly GIC annual rates (recent)** — 2025-26: Jul–Sep 10.78%, Oct–Dec 10.61%, Jan–Mar 10.65%, Apr–Jun 10.96%. 2026-27: Jul–Sep 11.43%.  _(ATO GIC rates page, QC 16145)_
 
 ### 6.2 Late BAS lodgement penalty
 

--- a/skills/international/australia/au-payg-instalments.md
+++ b/skills/international/australia/au-payg-instalments.md
@@ -192,7 +192,7 @@ No income calculation needed. ATO pre-fills the amount.
 
 ### 6.2 Late BAS lodgement penalty
 
-- **Late BAS lodgement penalty** — $313 per 28-day period, up to 5 periods ($1,565 max for small entities)  _(Failure to lodge BAS)_
+- **Late BAS lodgement penalty** — 1 penalty unit per 28-day period, up to 5 periods, for small entities. Penalty unit: $364 from 1 Jul 2026; $330 for 7 Nov 2024 – 30 Jun 2026 (so max $1,820 / $1,650)  _(Failure to lodge BAS; ATO QC 71196)_
 
 ### 6.3 Safe harbour
 

--- a/skills/international/australia/au-rental-property.md
+++ b/skills/international/australia/au-rental-property.md
@@ -1,10 +1,10 @@
 ---
 name: au-rental-property
 description: Use this skill whenever asked about Australian rental property income and deductions. Trigger on phrases like "rental income Australia", "negative gearing", "rental deductions", "investment property tax", "Division 40", "Division 43", "capital works deduction", "depreciation schedule", "rental property CGT", "rental withholding", "body corporate fees", "strata levy deduction", "repairs vs improvements", "TR 97/23", or any question about completing the rental property schedule in an Australian individual tax return. This skill covers rental income reporting, deductible expenses, depreciation (Div 40 plant and Div 43 building), negative gearing, CGT on disposal, non-resident withholding, and common transaction classifications. ALWAYS read this skill before touching any Australian rental property work.
-version: "1.0"
+version: "1.1"
 jurisdiction: AU
 tax_year: 2025
-last_updated: 2026-07-13
+last_updated: 2026-08-20
 review_status: pending_review
 category: international
 tier: 2
@@ -13,7 +13,9 @@ license: AGPL-3.0-or-later (code) / OpenAccountants Guide License v1.0 (content)
 
 # AU Rental Property
 
-## Australia Rental Property -- Income & Deductions Skill v1.0
+> **Law-change alert — negative gearing (passed June 2026, applies from 1 July 2027).** The *Treasury Laws Amendment (Tax Reform No. 1) Act 2026* limits negative gearing of residential property to **new builds** from **1 July 2027**. Existing properties acquired on or before Budget night (**12 May 2026**) are fully grandfathered. Residential property acquired **after 12 May 2026** that is not a new dwelling can still be negatively geared up to 30 June 2027, but from 1 July 2027 its net rental losses are **quarantined** — usable only against future residential-property income, not salary or business income. The same Act replaces the 50% CGT discount with indexation + a 30% minimum rate for gains accruing from 1 July 2027 (see au-capital-gains). Acquisition date and new-build status are now mandatory intake facts for every rental client.
+
+## Australia Rental Property -- Income & Deductions Skill v1.1
 
 ## Section 1 -- Quick Reference
 
@@ -89,7 +91,7 @@ license: AGPL-3.0-or-later (code) / OpenAccountants Guide License v1.0 (content)
 
 ### 2.2 Negative Gearing
 
-- **Negative gearing** — Where total deductions exceed gross rental income, the net rental loss reduces other assessable income (salary, business income). There is no cap on negative gearing for existing or new properties (as of 2025 law).
+- **Negative gearing** — Where total deductions exceed gross rental income, the net rental loss reduces other assessable income (salary, business income). This remains the law for all properties through 30 June 2027, and permanently for grandfathered properties (acquired on or before 12 May 2026) and new builds. **From 1 July 2027**, losses on residential property acquired after 12 May 2026 that is not a new dwelling are quarantined to future residential-property income (Tax Reform No. 1 Act 2026 — see the alert at the top of this skill).
 
 ### 2.3 Deductible Expenses (Immediate)
 
@@ -200,7 +202,7 @@ Applies to the structural elements (building itself, fixed improvements).
 | --- | --- |
 | Applies to | Non-resident landlords receiving Australian rental income |
 | Rate | Payer (tenant/agent) must withhold amounts as directed by ATO |
-| FRCGW (foreign resident CGT withholding) | 12.5% of sale price if property value ≥ $750,000 (buyer withholds) |
+| FRCGW (foreign resident CGT withholding) | 15% of market value (usually sale price), no threshold, for contracts signed from 1 Jan 2025 (12.5% ≥ $750,000 for contracts signed 1 Jul 2017 – 31 Dec 2024); buyer withholds |
 | Clearance certificate | Resident vendor obtains to avoid FRCGW at settlement |
 
 ## Section 3 -- Transaction Pattern Library

--- a/skills/international/australia/australia-gst.md
+++ b/skills/international/australia/australia-gst.md
@@ -1,10 +1,10 @@
 ---
 name: australia-gst
 description: Use this skill whenever asked to prepare, review, or classify transactions for an Australian GST return (Business Activity Statement / BAS) for any client. Trigger on phrases like "prepare BAS", "do the GST", "fill in BAS", "create the return", "GST return", "Activity Statement", or any request involving Australian GST filing. Also trigger when classifying transactions for GST purposes from bank statements, invoices, or other source data. This skill covers Australia only and covers both Simpler BAS and full BAS reporting. GST groups, margin scheme, partial exemption complex, and going concern are all in the refusal catalogue. ALWAYS read this skill before touching any GST-related work.
-version: 2.0
+version: 2.1
 jurisdiction: AU
 tax_year: 2025
-last_updated: 2026-07-13
+last_updated: 2026-08-20
 review_status: pending_review
 tier: 2
 license: AGPL-3.0-or-later (code) / OpenAccountants Guide License v1.0 (content)
@@ -481,7 +481,7 @@ Each rule states the legal source and the BAS label mapping. Apply silently if t
 
 - **Entitlement conditions** — A registered entity is entitled to an input tax credit if ALL conditions are met (s 11-5): 1. Acquisition is for a creditable purpose (related to taxable or GST-free supplies); 2. Supply was a taxable supply (GST in the price); 3. Entity provides consideration; 4. Entity is registered for GST; AND 5. Entity holds a valid tax invoice (or can obtain one within 4 years).  _(s 11-5)_
 - **Blocked credits** — No credit for acquisitions relating to input taxed supplies (s 11-15), private/domestic use (s 11-15), entertainment where FBT exempt (s 69-5), non-deductible fines/penalties (s 69-5).  _(s 11-15, s 69-5)_
-- **Car limit** — Input tax credit for a car is capped at car limit / 11. For 2024-25: $69,674 / 11 = ~$6,334 maximum credit. No outright block on cars (unlike Malta).  _(s 69-10)_
+- **Car limit** — Input tax credit for a car is capped at car limit / 11. For 2026-27: $69,883 / 11 = $6,353 maximum credit (2025-26: $69,674 / 11 = ~$6,334). No outright block on cars (unlike Malta).  _(s 69-10; ATO car thresholds)_
 
 ### 5.7 Tax invoices (Division 29)
 
@@ -643,7 +643,7 @@ Infer the client profile from the data first. Only ask questions the data could 
 
 ### Penalties
 
-- **Failure to lodge (FTL)** — 1 penalty unit per 28-day period for small entities (turnover < $1M), up to 5 periods. Penalty unit: $330 (2024-25, indexed annually).
+- **Failure to lodge (FTL)** — 1 penalty unit per 28-day period for small entities (turnover < $1M), up to 5 periods. Penalty unit: $364 from 1 July 2026; $330 for infringements 7 Nov 2024 – 30 Jun 2026 (ATO QC 71196).
 - **General Interest Charge (GIC)** — 90-day Bank Accepted Bill rate + 7% per annum. Calculated daily, compounded. Tax deductible.
 - **Shortfall penalties** — Reasonable care not taken: 25%. Recklessness: 50%. Intentional disregard: 75%. Reduced 20% for voluntary disclosure before audit.
 
@@ -679,7 +679,7 @@ Infer the client profile from the data first. Only ask questions the data could 
 | GST registration | $75,000 | s 23-5 |
 | Simpler BAS eligibility | Turnover < $10M | TAA 1953 |
 | Cash basis eligibility | Turnover < $2M (or $10M SBE) | s 29-40 |
-| Car limit (2024-25) | $69,674 | s 69-10 |
+| Car limit (2026-27) | $69,883 (2025-26: $69,674) | s 69-10 |
 | LCT threshold (2025-26, general / other vehicles) | $80,567 | LCT Act / ATO car thresholds |
 | LCT threshold (2024-25, fuel-efficient) | $91,387 | LCT Act |
 | No ABN withholding exemption | Supplies < $75 excl GST | TAA Schedule 1 |

--- a/skills/international/australia/australia-gst.md
+++ b/skills/international/australia/australia-gst.md
@@ -733,7 +733,7 @@ This skill is v2.0, rewritten in April 2026 to align with the Malta v2.0 structu
 - **v2.0 (April 2026):** Full rewrite to align with Malta v2.0 structure. Ten sections: quick reference (1), inputs and refusals (2), supplier pattern library with 12 sub-tables (3), six worked examples from CBA NetBank format (4), Tier 1 rules compressed (5), Tier 2 catalogue with 7 items (6), Excel template (7), bank statement reading guide (8), onboarding fallback with inference rules (9), reference material (10). Five Australia-specific refusals (R-AU-1 through R-AU-5).
 - **v1.1 (April 2026):** Monolithic skill with classification rules, BAS labels, reverse charge, thresholds, edge cases, and test suite. Comprehensive but not aligned with v2.0 architecture.
 
-### Self-check (v2.0)
+### Self-check (v2.1)
 
 1. Quick reference at top with BAS label table and conservative defaults: yes (Section 1).
 2. Supplier library as literal lookup tables: yes (Section 3, 12 sub-tables).
@@ -751,7 +751,7 @@ This skill is v2.0, rewritten in April 2026 to align with the Malta v2.0 structu
 14. Payment processor fees as financial supply explicit: yes (Section 3.8 + Example 6).
 15. Supermarket split (GST-free food vs taxable items) explicit: yes (Section 3.6 + Example 3).
 
-## End of Australia GST Return Preparation Skill v2.0
+## End of Australia GST Return Preparation Skill v2.1
 
 ## Disclaimer
 

--- a/skills/international/australia/australia-payroll.md
+++ b/skills/international/australia/australia-payroll.md
@@ -11,10 +11,11 @@ description: >
   "activity statement", "annual leave", "long service leave",
   "minimum wage Australia", or any question about running payroll in Australia.
   ALWAYS read this skill before processing any Australian payroll work.
-version: 2.0
+version: 2.1
 jurisdiction: AU
-tax_year: 2025
-last_updated: 2026-08-02
+tax_year: 2026
+tax_year_notes: "2026-27 (payday super year); payroll tax and minimum wage tables current at Aug 2026"
+last_updated: 2026-08-20
 review_status: pending_review
 category: payroll
 tier: 2
@@ -49,7 +50,7 @@ PAYG withholding is calculated per pay period using ATO tax tables (Schedule 1 -
 
 ### Resident Individual Tax Rates (2026--27)
 
-**Resident Individual Tax Rates (2025--26)**
+**Resident Individual Tax Rates (2026--27)** — first bracket 15% from 1 July 2026 (was 16% in 2025-26; drops to 14% from 1 July 2027)
 
 | Taxable Income (AUD) | Rate | Tax on This Income |
 | --- | --- | --- |
@@ -127,30 +128,31 @@ The redesigned SGC **is tax-deductible** (GIC on late SGC and the late payment p
 
 ### Payroll Tax (State/Territory)
 
-**Payroll Tax (State/Territory)**
+**Payroll Tax (State/Territory) — 2026-27**
 
 | State/Territory | Threshold (Annual) | Rate |
 | --- | --- | --- |
-| NSW | $1,200,000 | 4.85% |
-| VIC | $900,000 | 4.85% |
-| QLD | $1,300,000 | 4.75% |
+| NSW | $1,200,000 | 5.45% |
+| VIC | $1,000,000 (from 1 Jul 2025; phase-out above; regional 1.2125%) | 4.85% |
+| QLD | $1,300,000 (deduction phases out to $10.4m) | 4.75% (≤$6.5m wages); 4.95% above |
 | WA | $1,000,000 | 5.50% |
-| SA | $1,500,000 | Varies (0%--4.95%) |
-| TAS | $1,250,000 | 4.00% |
+| SA | $1,500,000 | Variable 0%–4.95% |
+| TAS | $1,250,000 | 4.00% (to $2m); 6.10% above |
 | ACT | $2,000,000 | 6.85% |
-| NT | $1,500,000 | 5.50% |
+| NT | $1,500,000 (deduction phases out to $7.5m) | 5.50% |
 
-- **Payroll tax nature** — Payroll tax is a state/territory tax on total Australian wages above the threshold. Interstate employers must register in each jurisdiction where they have employees.
+- **Payroll tax nature** — Payroll tax is a state/territory tax on total Australian wages above the threshold. Interstate employers must register in each jurisdiction where they have employees; thresholds are apportioned by interstate wage share and change frequently — always confirm on the state revenue office site before advising.
+- **VIC surcharges** — Victorian employers with national payrolls above $10m also pay the mental health and wellbeing surcharge (0.5%, plus 0.5% above $100m) and the COVID-19 debt temporary payroll tax surcharge (0.5%, plus 0.5% above $100m; legislated to 30 June 2033).
 
 ## Section 5 -- Minimum Wage and Overtime
 
-### National Minimum Wage (from 1 July 2025)
+### National Minimum Wage (from 1 July 2026)
 
-**National Minimum Wage (from 1 July 2025)**
+**National Minimum Wage (from 1 July 2026)** — Annual Wage Review 2025-26 (3.5% increase). Prior year (from 1 July 2025): $24.95/hour, $948.10/week.
 
 | Category | Rate |
 | --- | --- |
-| Adult (full-time, 38 hrs/week) | $24.95/hour ($948.10/week) |
+| Adult (full-time, 38 hrs/week) | $26.44/hour ($1,004.90/week) |
 | Junior rates | Percentage of adult rate by age (under awards) |
 | Casual loading | 25% on top of base rate (in lieu of leave entitlements) |
 

--- a/skills/international/australia/australia-payroll.md
+++ b/skills/international/australia/australia-payroll.md
@@ -22,9 +22,9 @@ tier: 2
 license: AGPL-3.0-or-later (code) / OpenAccountants Guide License v1.0 (content)
 ---
 
-# Australia -- Payroll Skill v2.0
+# Australia -- Payroll Skill v2.1
 
-## Australia -- Payroll Skill v1.0
+## Australia -- Payroll Skill v2.1
 
 ## Section 1 -- Quick Reference
 
@@ -42,7 +42,7 @@ license: AGPL-3.0-or-later (code) / OpenAccountants Guide License v1.0 (content)
 | Pay frequency | Weekly, fortnightly, monthly (fortnightly most common) |
 | Employer registration | ABN + PAYG withholding registration via ATO |
 | Validated by | Pending -- requires sign-off by an Australian CPA, CA, or registered tax agent |
-| Skill version | 2.0 |
+| Skill version | 2.1 |
 
 ## Section 2 -- Income Tax Withholding (PAYG)
 

--- a/skills/international/australia/australia-tax-optimization.md
+++ b/skills/international/australia/australia-tax-optimization.md
@@ -1,10 +1,11 @@
 ---
 name: australia-tax-optimization
 description: Use this skill when advising on LEGAL tax minimization strategies for Australian taxpayers — individuals, sole traders, and small business owners. Trigger on phrases like "reduce my tax", "tax planning Australia", "salary vs dividends", "negative gearing", "instant asset write-off", "superannuation strategy", "CGT discount", "trust distribution", "income splitting", "GAAR", "Part IVA", or any question about structuring affairs to legally minimize Australian tax. Covers entity selection, deduction optimization, capital allowances, loss utilization, timing strategies, GST planning, superannuation, and red lines. ALWAYS read this skill before giving Australian tax optimization advice.
-version: 1.0
+version: 1.1
 jurisdiction: AU
 tax_year: 2025
-last_updated: 2026-07-13
+tax_year_notes: "2025-26; includes 1 July 2026/2027 reform alerts (Tax Reform No. 1 Act 2026)"
+last_updated: 2026-08-20
 review_status: pending_review
 depends_on: - bookkeeping-workflow-base
 category: tax-optimization
@@ -13,6 +14,8 @@ license: AGPL-3.0-or-later (code) / OpenAccountants Guide License v1.0 (content)
 ---
 
 # Australia Tax Optimization
+
+> **Law-change alert (Tax Reform No. 1 Act 2026 — passed June 2026, applies from 1 July 2027).** Three strategies in this skill change fundamentally from 1 July 2027: (1) the **50% CGT discount** for individuals/trusts/partnerships is replaced by cost-base indexation + a 30% minimum rate on gains accruing from 1 July 2027 (assets deemed re-acquired 1 July 2027; new residential dwellings keep the discount); (2) **negative gearing** on residential property is limited to new builds — properties acquired on or before Budget night 12 May 2026 are grandfathered, later non-new-build acquisitions have losses quarantined from 1 July 2027; (3) from 1 July 2026 a **$1,000 standard deduction** for work-related expenses applies to labour income (excluding PSI), and from 2027-28 a $250 **Working Australians Tax Offset**. Timing advice that straddles 30 June 2027 must model both regimes — escalate.
 
 ## Section 1 — Quick Reference
 
@@ -185,8 +188,8 @@ Discretionary (family) trusts allow income distribution to adult family members 
 
 | Strategy | Detail |
 | --- | --- |
-| CGT 50% discount | Individuals and trusts — hold assets >12 months for 50% discount on net capital gain |
-| Negative gearing | Investment property/share portfolio borrowing costs exceed income → net loss offsets other income. No cap in Australia |
+| CGT 50% discount | Individuals and trusts — hold assets >12 months for 50% discount on net capital gain. **Ends for gains accruing from 1 July 2027** (indexation + 30% minimum rate instead — see alert at top) |
+| Negative gearing | Investment property/share portfolio borrowing costs exceed income → net loss offsets other income. Uncapped through 30 June 2027; from 1 July 2027 residential-property losses are quarantined unless the property is a new build or was acquired on or before 12 May 2026 (see alert at top) |
 | Franking credits | Australian company dividends carry franking credits. Excess credits refundable for individuals and super funds |
 | Super in pension phase | Earnings on assets supporting income streams in pension phase are tax-free (up to transfer balance cap of $1.9m, indexed) |
 | Transition to retirement (TTR) | Access super as income stream from preservation age while still working. Earnings in TTR taxed at 15% (not tax-free) |

--- a/skills/international/australia/australia-tax-optimization.md
+++ b/skills/international/australia/australia-tax-optimization.md
@@ -84,7 +84,7 @@ Discretionary (family) trusts allow income distribution to adult family members 
 
 | Deduction | Legislation | Notes |
 | --- | --- | --- |
-| Home office running expenses | s 8-1 ITAA 1997 | Fixed rate 67c/hour (revised method from 1 July 2022) or actual cost. Must keep contemporaneous records (timesheets, diary) |
+| Home office running expenses | s 8-1 ITAA 1997 | Fixed rate 70c/hour (PCG 2023/1, from 1 July 2024; was 67c 2022-24) or actual cost. Must keep contemporaneous records (timesheets, diary) |
 | Self-education expenses | s 8-1 | Must have sufficient connection to current employment/business. First $250 non-deductible for employees (not self-employed) |
 | Phone and internet | s 8-1 | Apportion business use %. ATO accepts a representative 4-week diary |
 | Income protection insurance | s 8-1 | Premiums for policies replacing lost income are deductible |
@@ -100,7 +100,7 @@ Discretionary (family) trusts allow income distribution to adult family members 
 
 ### Instant Asset Write-Off (2025–26)
 
-- **Instant asset write-off eligibility** — Small businesses (aggregated turnover <$10m) can immediately deduct assets costing less than $20,000 (per asset) first used or installed ready for use by 30 June 2026.  _(Treasury Laws Amendment (Strengthening Financial Systems and Other Measures) Act 2025)_
+- **Instant asset write-off eligibility** — Small businesses (aggregated turnover <$10m) can immediately deduct assets costing less than $20,000 (per asset). The $20,000 limit is law for 2024-25 and 2025-26 (Treasury Laws Amendment (Strengthening Financial Systems and Other Measures) Act 2025) and the 2026-27 Budget announced it becomes permanent from 1 July 2026 — confirm enactment before relying on it for 2026-27.  _(ITAA 1997 Div 328; ATO QC 103578)_
 - **Simplified depreciation pool** — Assets ≥$20,000 enter the small business simplified depreciation pool: 15% first year, 30% declining balance thereafter. Pool balance <$20,000 at 30 June 2026 can be written off entirely.
 
 ### General Depreciation
@@ -116,8 +116,8 @@ Discretionary (family) trusts allow income distribution to adult family members 
 
 ### Motor Vehicles
 
-- **Car cost limit for depreciation (2025–26)** — $69,674 AUD (Only the business-use portion of this amount can be depreciated)
-- **Business-use substantiation** — Business-use percentage must be substantiated via logbook (minimum continuous 12-week period, valid for 5 years) or cents-per-km method (85c/km, max 5,000 business km = $4,250).
+- **Car cost limit for depreciation** — 2025–26: $69,674; 2026–27: $69,883 AUD (only the business-use portion of this amount can be depreciated)
+- **Business-use substantiation** — Business-use percentage must be substantiated via logbook (minimum continuous 12-week period, valid for 5 years) or cents-per-km method (88c/km in 2025-26; 91c/km in 2026-27; max 5,000 business km).
 
 ## Section 5 — Loss Utilization
 
@@ -130,9 +130,9 @@ Discretionary (family) trusts allow income distribution to adult family members 
 
 - **Continuity of ownership test (COT)** — Carry forward subject to continuity of ownership test (COT) — same persons must maintain >50% voting, dividend, and capital rights (s 165-12). If COT fails, the same business test (SBT) may save losses if the company carries on the same business (s 165-13). SBT was broadened in 2015 to a "similar business test."  _(s 165-12; s 165-13)_
 
-### Loss Carry-Back (Companies)
+### Loss Carry-Back (Companies) — ENDED
 
-- **Loss carry-back eligibility** — Companies with aggregated turnover <$5bn can carry back tax losses to offset tax paid in prior income years, generating a refundable tax offset. Capped by available franking account balance.
+- **Loss carry-back has ended** — The temporary loss carry-back (aggregated turnover <$5bn, refundable offset capped by the franking account) applied only to losses of the 2019-20 to 2022-23 income years, claimable in the 2020-21 to 2022-23 returns. It is NOT available for current-year losses; companies are back to carry-forward only (subject to COT/similar business test). Do not advise clients to expect a carry-back refund.  _(former Div 160 ITAA 1997)_
 
 ## Section 6 — Timing Strategies
 
@@ -191,7 +191,7 @@ Discretionary (family) trusts allow income distribution to adult family members 
 | CGT 50% discount | Individuals and trusts — hold assets >12 months for 50% discount on net capital gain. **Ends for gains accruing from 1 July 2027** (indexation + 30% minimum rate instead — see alert at top) |
 | Negative gearing | Investment property/share portfolio borrowing costs exceed income → net loss offsets other income. Uncapped through 30 June 2027; from 1 July 2027 residential-property losses are quarantined unless the property is a new build or was acquired on or before 12 May 2026 (see alert at top) |
 | Franking credits | Australian company dividends carry franking credits. Excess credits refundable for individuals and super funds |
-| Super in pension phase | Earnings on assets supporting income streams in pension phase are tax-free (up to transfer balance cap of $1.9m, indexed) |
+| Super in pension phase | Earnings on assets supporting income streams in pension phase are tax-free (up to the general transfer balance cap — $2.1m in 2026-27; $2.0m in 2025-26) |
 | Transition to retirement (TTR) | Access super as income stream from preservation age while still working. Earnings in TTR taxed at 15% (not tax-free) |
 
 ## Section 10 — Red Lines (GAAR & Scrutiny Triggers)

--- a/skills/orchestrator/au-return-assembly.md
+++ b/skills/orchestrator/au-return-assembly.md
@@ -12,7 +12,7 @@ license: AGPL-3.0-or-later (code) / OpenAccountants Guide License v1.0 (content)
 
 # AU Return Assembly
 
-## Australia Return Assembly Skill v0.1
+## Australia Return Assembly Skill v0.2
 
 ## CRITICAL EXECUTION DIRECTIVE -- READ FIRST
 

--- a/skills/orchestrator/au-return-assembly.md
+++ b/skills/orchestrator/au-return-assembly.md
@@ -1,10 +1,10 @@
 ---
 name: au-return-assembly
 description: Final orchestrator skill that assembles the complete Australian filing package for Australian-resident sole traders. Consumes outputs from all Australian content skills (australia-gst for BAS, au-individual-return for ITR, au-super-guarantee for voluntary contributions, au-medicare-levy for levy and surcharge, au-payg-instalments for instalment schedule) to produce a single unified reviewer package containing every worksheet, every form, every brief section, all cross-skill reconciliations, and the final action list with payment instructions, filing instructions, and next-year planning. This is the capstone skill that runs last and produces the final deliverable. MUST be loaded alongside all Australian content skills listed above. Australian full-year residents only. Sole traders only.
-version: 0.1
+version: 0.2
 jurisdiction: AU
 tax_year: 2025
-last_updated: 2026-07-13
+last_updated: 2026-08-20
 review_status: pending_review
 tier: 2
 license: AGPL-3.0-or-later (code) / OpenAccountants Guide License v1.0 (content)
@@ -87,8 +87,8 @@ This skill coordinates execution of the content skills, verifies cross-skill con
 | --- | --- | --- |
 | Income for MLS purposes | ITR taxable income + reportable fringe benefits + total net investment loss + reportable super | Combined figure |
 | PHI status | Insurer statement | If adequate hospital cover for full year, no MLS |
-| MLS thresholds (2024-25) | Single: $93,000; Family: $186,000 | Below threshold = no MLS regardless of PHI |
-| MLS rates | Tier 1: 1%; Tier 2: 1.25%; Tier 3: 1.5% | Applied to taxable income |
+| MLS thresholds | 2025-26: Single $101,000; Family $202,000. 2024-25: Single $97,000; Family $194,000 | Below threshold = no MLS regardless of PHI |
+| MLS rates | Tier 1: 1%; Tier 2: 1.25%; Tier 3: 1.5% | Applied to income for MLS purposes |
 
 ### Cross-check 4: PAYG instalments credit against final tax
 


### PR DESCRIPTION
## What

Rolls every indexed amount in the Australia pack forward to the current years (2025-26 lodgment season / 2026-27 current FY). Builds on #114 (branch includes that commit; only the second commit is new here — happy to rebase if #114 merges first).

Every figure verified against the ATO / state revenue office / FWC primary source on 2026-08-20:

### `au-medicare-levy`
- 2025-26 low-income thresholds: $28,011/$35,013 singles, $47,238 + $4,338/child family, SAPTO $44,268/$55,335 (ATO QC 27031)
- 2025-26 MLS tiers: $101,000/$202,000 base (ATO MLS thresholds page)
- PHI rebate percentages **by period**, including the 1 April 2026 adjustment-factor step-down (PHI Circular 12/26): 24.288% → 24.118% base etc.
- 2024-25 tables kept as prior-year reference
- All formulas, worked examples, self-checks and prohibitions recomputed — including cases whose **outcome flips** under the new thresholds (e.g. $28,000 income: shade-in under 2024-25, zero levy under 2025-26; family MLS self-check now lands under the threshold)

### `au-individual-return`
- Bracket table annotated: 2024-25 and 2025-26 identical; **15% first bracket from 1 July 2026, 14% from 1 July 2027** (More Cost of Living Relief Act 2025; ATO QC 73320 updated 13 Aug 2026)
- **LITO taper corrected** — the table had the taper starting at $45,000; it actually runs $700 to $37,500, then 5c/$1 to $45,000, then 1.5c/$1 to $66,667
- Cents-per-km 88c (2025-26) → **91c (2026-27)**; WFH fixed rate 70c/hr confirmed through 2026-27 (PCG 2023/1)
- Instant asset write-off: $20,000 for 2025-26 legislated; 2026-27 Budget announced permanence from 1 July 2026 (flagged as announce-vs-enacted)

### `australia-payroll`
- **NSW payroll tax corrected to 5.45%** — the table said 4.85%, which was the lapsed temporary COVID rate (Revenue NSW)
- VIC threshold $1,000,000 from 1 July 2025 + mental-health and COVID-debt surcharges noted (SRO Vic)
- QLD/TAS split rates and deduction phase-outs; caution that thresholds are apportioned interstate
- National minimum wage **$26.44/hr ($1,004.90/wk) from 1 July 2026** (FWC AWR 2025-26, 3.5%)
- Rates-table caption fixed (was labelled 2025-26 above 2026-27 figures)

### `australia-tax-optimization`
- Car cost limit $69,883 (2026-27); cents-per-km corrected (85c in the text was the 2023-24 rate); WFH 67c → 70c
- Transfer balance cap $2.1m (2026-27) replacing stale $1.9m
- **Loss carry-back marked ENDED** (2019-20 to 2022-23 claim years only) — the guide presented it as current law

### `au-return-assembly` (orchestrator)
- MLS thresholds corrected — $93,000/$186,000 were 2023-24 values presented as 2024-25

## Checks
- `python3 scripts/validate-guides.py --no-index-check` passes
- `skills/**` only; last_updated/version bumped monotonically