### PR TITLE
feat(au): add Division 296 to super guide; refresh crypto rates + CGT alert

### DIFF
--- a/skills/international/australia/au-crypto-tax.md
+++ b/skills/international/australia/au-crypto-tax.md
@@ -1,10 +1,10 @@
 ---
 name: au-crypto-tax
 description: Use this skill whenever asked about Australian cryptocurrency taxation. Trigger on phrases like "crypto tax Australia", "Bitcoin CGT", "ATO crypto", "crypto capital gains", "personal use asset crypto", "staking income", "airdrop tax", "DeFi tax Australia", "crypto cost base", "crypto trading tax", "Coinbase tax", "Swyftx tax", "CoinSpot tax", "NFT tax Australia", or any question about how cryptocurrency is taxed by the ATO. This skill covers CGT treatment of crypto assets, the personal use asset exemption, trading vs investing distinction, staking and airdrop income, DeFi events, record-keeping requirements, and exchange-specific transaction patterns. ALWAYS read this skill before touching any Australian crypto tax work.
-version: "1.0"
+version: "1.1"
 jurisdiction: AU
 tax_year: 2025
-last_updated: 2026-07-13
+last_updated: 2026-08-20
 review_status: pending_review
 category: international
 tier: 2
@@ -36,19 +36,21 @@ license: AGPL-3.0-or-later (code) / OpenAccountants Guide License v1.0 (content)
 
 ### Core Principle
 
+> **Law-change alert (applies from 1 July 2027).** Crypto assets are CGT assets, so the *Treasury Laws Amendment (Tax Reform No. 1) Act 2026* CGT reform applies to them: for gains accruing from 1 July 2027, the 50% discount for individuals and trusts is replaced by cost-base indexation + a 30% minimum rate, with a deemed re-acquisition of assets held at 30 June 2027. The 50%-discount statements below remain correct for gains accruing up to 30 June 2027 — see au-capital-gains for the full alert.
+
 The ATO treats cryptocurrency (including Bitcoin, Ethereum, stablecoins, NFTs, and DeFi tokens) as a **CGT asset**, not as foreign currency. Each disposal triggers a CGT event.
 
-### Individual Marginal Tax Rates (2024-25)
+### Individual Marginal Tax Rates
 
-**Individual Marginal Tax Rates (2024-25)**
+**Individual Marginal Tax Rates (2024-25 and 2025-26; second bracket 15% in 2026-27, 14% from 2027-28)**
 
-| Taxable Income (AUD) | Rate |
-| --- | --- |
-| 0 -- 18,200 | 0% |
-| 18,201 -- 45,000 | 16% |
-| 45,001 -- 135,000 | 30% |
-| 135,001 -- 190,000 | 37% |
-| 190,001+ | 45% |
+| Taxable Income (AUD) | Rate (2024-25 / 2025-26) | Rate (2026-27) |
+| --- | --- | --- |
+| 0 -- 18,200 | 0% | 0% |
+| 18,201 -- 45,000 | 16% | 15% |
+| 45,001 -- 135,000 | 30% | 30% |
+| 135,001 -- 190,000 | 37% | 37% |
+| 190,001+ | 45% | 45% |
 
 ### Key Thresholds
 

--- a/skills/international/australia/au-crypto-tax.md
+++ b/skills/international/australia/au-crypto-tax.md
@@ -13,7 +13,7 @@ license: AGPL-3.0-or-later (code) / OpenAccountants Guide License v1.0 (content)
 
 # AU Crypto Tax
 
-## Australia Crypto Tax -- CGT & Income Skill v1.0
+## Australia Crypto Tax -- CGT & Income Skill v1.1
 
 ## Section 1 -- Quick Reference
 
@@ -32,7 +32,7 @@ license: AGPL-3.0-or-later (code) / OpenAccountants Guide License v1.0 (content)
 | Tax authority | Australian Taxation Office (ATO) |
 | Filing portal | myTax / tax agent lodgement |
 | Filing deadline | 31 October (self-lodgement); agent-managed deadlines vary |
-| Skill version | 1.0 |
+| Skill version | 1.1 |
 
 ### Core Principle
 

--- a/skills/international/australia/au-super-guarantee.md
+++ b/skills/international/australia/au-super-guarantee.md
@@ -13,7 +13,7 @@ tier: 2
 license: AGPL-3.0-or-later (code) / OpenAccountants Guide License v1.0 (content)
 ---
 
-# Australia Superannuation Guarantee (SG) -- Sole Trader & Employer Skill v3.0
+# Australia Superannuation Guarantee (SG) -- Sole Trader & Employer Skill v3.1
 
 > **General reference only.** This skill is general tax/accounting reference material for AI-assisted workflows. It has not been reviewed for any specific person's facts, documents, elections, deadlines, residency, filing status, or local procedures. Do not rely on it to file, pay, amend, or take a tax position without review by a qualified professional in the relevant jurisdiction.
 

--- a/skills/international/australia/au-super-guarantee.md
+++ b/skills/international/australia/au-super-guarantee.md
@@ -1,11 +1,12 @@
 ---
 name: au-super-guarantee
 description: >
-  Use this skill whenever asked about Australian Superannuation Guarantee (SG) obligations, payday super deadlines, voluntary super contributions, concessional and non-concessional caps, Division 293 tax, government co-contribution, spouse contribution tax offset, carry-forward rules, or any question about super for sole traders or employers. Trigger on phrases like "how much super do I pay", "SG rate", "super guarantee", "payday super", "7 business days super", "SG shortfall", "concessional cap", "Division 293", "salary sacrifice super", "personal super contribution deduction", "co-contribution", "BPAY super", "super clearing house", "super fund contribution", or any question about Australian superannuation. Also trigger when classifying bank statement transactions showing super fund payments, BPAY super debits, or clearing house payments. ALWAYS read this skill before touching any SG-related work.
-version: 3.0
+  Use this skill whenever asked about Australian Superannuation Guarantee (SG) obligations, payday super deadlines, voluntary super contributions, concessional and non-concessional caps, Division 293 tax, Division 296 large-balance tax, government co-contribution, spouse contribution tax offset, carry-forward rules, or any question about super for sole traders or employers. Trigger on phrases like "how much super do I pay", "SG rate", "super guarantee", "payday super", "7 business days super", "SG shortfall", "concessional cap", "Division 293", "Division 296", "$3 million super tax", "salary sacrifice super", "personal super contribution deduction", "co-contribution", "BPAY super", "super clearing house", "super fund contribution", or any question about Australian superannuation. Also trigger when classifying bank statement transactions showing super fund payments, BPAY super debits, or clearing house payments. ALWAYS read this skill before touching any SG-related work.
+version: 3.1
 jurisdiction: AU
-tax_year: 2024
-last_updated: 2026-08-02
+tax_year: 2026
+tax_year_notes: "2026-27 (payday super + Division 296 first year); quarterly-regime rules retained for pre-1-July-2026 paydays"
+last_updated: 2026-08-20
 review_status: pending_review
 category: international
 tier: 2
@@ -264,6 +265,13 @@ $130,000 (2026-27; 4 x concessional cap). Bring-forward tiers by TSB at 30 June 
 - **Division 293 formula** — Div 293 income = taxable income + concessional contributions If > $250,000: Div 293 tax = 15% x lesser of (concessional contributions, excess over $250,000)  _(Rule 9)_
 
 Threshold frozen at $250,000 (not indexed).
+
+### Rule 10A -- Division 296 (large balances, from 1 July 2026)
+
+- **What it is** — An additional individual tax on a proportion of superannuation earnings when total superannuation balance (TSB) exceeds the large-balance thresholds: **extra 15%** on the earnings proportion attributable to the TSB between **$3 million and $10 million** (headline 30% with fund tax), and **extra 25%** on the proportion above **$10 million** (headline 40%). Legislated by the Treasury Laws Amendment (Building a Stronger and Fairer Super System) Act 2026; **first affected year is 2026-27** (first measurement date 30 June 2027, transitional rules apply to the first year).
+- **Key design points (final law, not the 2023 proposal)** — (1) both thresholds are **indexed** (CPI, $150,000 / $500,000 increments); (2) earnings are based on **realised** earnings concepts rather than the originally proposed unrealised-gains formula; (3) the tax is levied on the individual (payable personally or released from super), not on the fund.
+- **Who to flag** — any client whose 30 June TSB approaches $3m: contribution strategy, asset location, and pension-phase decisions all interact with Div 296. **This skill does not compute Div 296** — escalate to a qualified adviser; computation depends on ATO-calculated earnings proportions from fund reporting.
+- **Do not confuse** Division 293 (contributions tax for incomes > $250,000, unchanged) with Division 296 (large-balance earnings tax from 1 July 2026).
 
 ### Rule 11 -- Redesigned SGC (QE days from 1 July 2026)
 

--- a/skills/international/australia/australia-bookkeeping.md
+++ b/skills/international/australia/australia-bookkeeping.md
@@ -146,7 +146,7 @@ Australian software (Xero, MYOB, QuickBooks) typically uses 3–4 digit codes. T
 | 6040 | Insurance — Business | Expense |
 | 6050 | Repairs and Maintenance | Expense |
 | 6100 | Wages and Salaries | Expense |
-| 6110 | Superannuation Guarantee (11.5% from Jul 2025) | Expense |
+| 6110 | Superannuation Guarantee (12% from Jul 2025) | Expense |
 | 6120 | Workers' Compensation Insurance | Expense |
 | 6130 | Payroll Tax (state-based) | Expense |
 | 6140 | Staff Training | Expense |
@@ -510,7 +510,7 @@ TOTAL EQUITY                                          xxx
 
 ### Superannuation Guarantee
 
-- Rate: 11.5% of ordinary time earnings (from 1 Jul 2025); rising to 12% from 1 Jul 2026
+- Rate: 12% of ordinary time earnings from 1 July 2025 (terminal SG rate; 2024-25 was 11.5%). From 1 July 2026, payday super: contributions must reach the fund within 7 business days of each payday — see au-super-guarantee
 - Due: 28 days after end of quarter
 - Nominal: 6110 (expense) / 2110 (payable)
 - SG Charge: if late, lose deduction and pay additional penalties

--- a/skills/international/australia/australia-financial-statements.md
+++ b/skills/international/australia/australia-financial-statements.md
@@ -1,10 +1,10 @@
 ---
 name: australia-financial-statements
 description: Use this skill when preparing, reviewing, or advising on annual financial statements for an Australian company. Trigger on phrases like "ASIC financial report", "AASB", "Australian Accounting Standards", "general purpose financial statements", "special purpose financial statements", "large proprietary company", "small proprietary company", "directors' report Australia", "audit Australia", "Form 388", "Corporations Act 2001 reporting", or any question about preparing and filing statutory accounts under the Corporations Act 2001. Covers AASB frameworks, size thresholds (large/small proprietary), required statements, formats, notes, lodgement deadlines, and audit requirements.
-version: 1.0
+version: 1.1
 jurisdiction: AU
 tax_year: 2025
-last_updated: 2026-07-13
+last_updated: 2026-08-20
 review_status: pending_review
 depends_on: - financial-statements-workflow-base
 category: financial-statements
@@ -237,7 +237,7 @@ Total equity
 | Documents lodged | Financial report + directors' report + auditor's report |
 | Fee | No filing fee for Form 388 |
 | Late lodgement | Civil penalty provisions; ASIC may impose administrative penalties |
-| Annual review fee | Separate from lodgement (AUD 310 for proprietary companies, 2024) |
+| Annual review fee | Separate from lodgement (AUD 342 for proprietary companies from 1 July 2026; 2025-26: AUD 329) |
 | Extension | Possible by application to ASIC under s.340 |
 
 ### Small proprietary companies — exceptions requiring lodgement

--- a/skills/international/australia/australia-financial-statements.md
+++ b/skills/international/australia/australia-financial-statements.md
@@ -14,7 +14,7 @@ license: AGPL-3.0-or-later (code) / OpenAccountants Guide License v1.0 (content)
 
 # Australia Financial Statements
 
-## Australia Financial Statements Skill v1.0
+## Australia Financial Statements Skill v1.1
 
 ## Section 1 -- Quick Reference
 

--- a/skills/international/australia/australia-formation.md
+++ b/skills/international/australia/australia-formation.md
@@ -1,10 +1,10 @@
 ---
 name: australia-formation
 description: Use this skill whenever asked about forming, incorporating, or registering a company in Australia. Trigger on phrases like "set up a company in Australia", "Pty Ltd", "ASIC registration", "Australian company formation", "register a business Australia", "ABN", "ACN", "proprietary limited", "sole trader Australia", "partnership Australia", or any question about starting a business entity in Australia. Covers entity types (Pty Ltd, Ltd, sole trader, partnership, trust), registration process, costs, post-formation compliance, and bank account opening. ALWAYS read this skill before advising on Australian company formation.
-version: 1.0
+version: 1.1
 jurisdiction: AU
 tax_year: 2025
-last_updated: 2026-07-13
+last_updated: 2026-08-20
 review_status: pending_review
 depends_on: - company-formation-workflow-base
 category: formation
@@ -43,7 +43,7 @@ license: AGPL-3.0-or-later (code) / OpenAccountants Guide License v1.0 (content)
 | Max. shareholders | 1 | N/A | 50 (non-employee) | Unlimited | N/A |
 | Tax treatment | Personal income tax | Partners taxed individually | Company tax rate | Company tax rate | Trust distributions taxed in beneficiaries' hands |
 | Admin burden | Very low | Low | Medium | High | Medium--High |
-| ASIC registration | No | No (ABN only) | Yes ($611) | Yes | Only if trustee is a company |
+| ASIC registration | No | No (ABN only) | Yes ($636) | Yes | Only if trustee is a company |
 | Audit required | No | No | Only if large proprietary | Yes | No (unless regulated) |
 
 **Recommended default:** Proprietary company limited by shares (Pty Ltd) for most commercial purposes.
@@ -64,7 +64,7 @@ license: AGPL-3.0-or-later (code) / OpenAccountants Guide License v1.0 (content)
 
 ### Step 4: Register via Business Registration Service (BRS)
 
-- **Register via BRS** — Go to register.business.gov.au; Can simultaneously apply for: company registration, ABN, TFN, GST, PAYG withholding; Fee: $611 (Pty Ltd, 2025--26 financial year); ASIC processes and issues ACN (Australian Company Number) typically within 1--3 days
+- **Register via BRS** — Go to register.business.gov.au; Can simultaneously apply for: company registration, ABN, TFN, GST, PAYG withholding; Fee: $636 (Pty Ltd, from 1 July 2026; 2025-26: $611); ASIC processes and issues ACN (Australian Company Number) typically within 1--3 days
 
 ### Step 5: Receive Certificate of Registration
 
@@ -99,13 +99,13 @@ license: AGPL-3.0-or-later (code) / OpenAccountants Guide License v1.0 (content)
 
 | Cost Component | Amount (AUD) | Notes |
 | --- | --- | --- |
-| ASIC company registration | $611 | One-time (Pty Ltd, 2025--26) |
+| ASIC company registration | $636 | One-time (Pty Ltd, from 1 Jul 2026; 2025-26: $611) |
 | Name reservation (optional) | $62 | Valid 2 months |
 | Business name registration (if different from company name) | $45/year or $104/3 years | Only if trading under a different name |
 | ABN registration | Free | Via ABR |
 | GST registration | Free | Via ATO |
-| ASIC annual review fee | $329/year | Pty Ltd (2025--26) |
-| **Total initial cost (government)** | **$611--$673** | Excluding professional fees |
+| ASIC annual review fee | $342/year | Pty Ltd (from 1 Jul 2026; 2025-26: $329) |
+| **Total initial cost (government)** | **$636--$698** | Excluding professional fees (from 1 Jul 2026) |
 | Legal / accountant setup fees | $500--$2,000 | Constitution, shareholder agreement, tax setup |
 | **Total with professional help** | **$1,100--$2,700** |  |
 
@@ -115,7 +115,7 @@ license: AGPL-3.0-or-later (code) / OpenAccountants Guide License v1.0 (content)
 
 | Item | Cost (AUD) |
 | --- | --- |
-| ASIC annual review fee | $329 |
+| ASIC annual review fee | $342 |
 | Accountant / tax agent fees | $1,500--$5,000/year |
 | Business name renewal (if applicable) | $45/year |
 | Registered office service (if using) | $200--$600/year |

--- a/skills/international/australia/australia-formation.md
+++ b/skills/international/australia/australia-formation.md
@@ -14,7 +14,7 @@ license: AGPL-3.0-or-later (code) / OpenAccountants Guide License v1.0 (content)
 
 # Australia Formation
 
-## Australia Company Formation Skill v1.0
+## Australia Company Formation Skill v1.1
 
 ## Section 1 -- Quick Reference
 
@@ -28,7 +28,7 @@ license: AGPL-3.0-or-later (code) / OpenAccountants Guide License v1.0 (content)
 | Key legislation | Corporations Act 2001 (Cth) |
 | Typical formation time | 1--3 business days (online via BRS) |
 | Corporate tax rate | 25% (base rate entities, turnover < $50M); 30% (all others) |
-| Skill version | 1.0 |
+| Skill version | 1.1 |
 
 ## Section 2 -- Entity Types Comparison
 


### PR DESCRIPTION
## What

### `au-super-guarantee` — Division 296 (new Rule 10A)
The pack's super guide had no mention of Division 296, which is **in effect now** (first affected year 2026-27, first measurement date 30 June 2027). Adds a flag-and-escalate rule covering the **enacted** design from the Treasury Laws Amendment (Building a Stronger and Fairer Super System) Act 2026:

- extra 15% on the earnings proportion attributable to TSB between $3m and $10m (headline 30%)
- extra 25% above $10m (headline 40%)
- both thresholds **CPI-indexed** ($150k/$500k increments), **realised-earnings** basis, levied on the individual — i.e. the final law, not the 2023 unrealised-gains proposal that circulated for years
- explicit Div 293 vs Div 296 disambiguation (very common confusion)
- computation deliberately out of scope → escalate (depends on ATO-calculated earnings proportions)

Frontmatter: version 3.0 → 3.1, tax_year 2024 → 2026 with tax_year_notes, Division 296 trigger phrases added to the description.

### `au-crypto-tax`
- Marginal-rates table extended: 2024-25/2025-26 identical; 15% second bracket 2026-27
- CGT-reform alert added (crypto is a CGT asset → the 1 July 2027 indexation + 30% minimum regime applies; deemed re-acquisition 30 June 2027), cross-referencing au-capital-gains

## Checks
- `python3 scripts/validate-guides.py --no-index-check` passes
- `skills/**` only; versions/last_updated bumped monotonically
- Sources: aph.gov.au Bills Digest 48 (2025-26); ATO/industry commentary confirming commencement 1 July 2026