### PR TITLE
feat(au): 2026-27 rates card + company/trust guided workflow

### DIFF
--- a/skills/international/australia/au-company-tax.md
+++ b/skills/international/australia/au-company-tax.md
@@ -373,7 +373,7 @@ If the client provides only financial statements and a trial balance:
 | Lodgment program | ato.gov.au Companies and super funds -- agent lodgment program (QC 34562, updated 1 July 2026); Income tax return -- companies (28 February self-preparer) |
 | PAYG instalments | ato.gov.au PAYG instalments (entry $2m/$500; monthly > $20m); GDP adjustment 5% for 2026-27 |
 | Amendment periods | ato.gov.au Request an amendment to a business or super tax return (SMB 4 years from 2024-25) |
-| GIC/SIC deduction denial | ato.gov.au -- deductions denied for GIC/SIC incurred from 1 July 2025 |
+| GIC/SIC deduction denial | Treasury Laws Amendment (Tax Incentives and Integrity) Act 2025 (No. 29, 2025) Sch 2; ato.gov.au QC 73746 -- GIC/SIC incurred from 1 July 2025 not deductible |
 
 ### Test suite
 

--- a/skills/international/australia/au-company-tax.md
+++ b/skills/international/australia/au-company-tax.md
@@ -1,0 +1,439 @@
+---
+name: au-company-tax
+description: >
+  Use this skill whenever asked about Australian company income tax for private small/medium
+  companies -- the 25% base rate entity rate versus the 30% standard rate, base rate entity
+  passive income (BREPI), aggregated turnover, franking dividends, maximum franking credits,
+  the franking account, benchmark franking percentage, franking deficit tax, carry-forward tax
+  losses (continuity of ownership or similar business test), company tax return due dates,
+  PAYG instalments, or bucket companies receiving trust distributions. Trigger on phrases like
+  "company tax rate", "base rate entity", "franking credits", "franking account", or "company
+  losses". ALWAYS read this skill before touching any company tax work.
+version: 1.0
+jurisdiction: AU
+tax_year: 2026
+tax_year_notes: "2026-27"
+last_updated: 2026-08-20
+review_status: pending_review
+category: international
+tier: 2
+license: AGPL-3.0-or-later (code) / OpenAccountants Guide License v1.0 (content)
+---
+
+# Australia Company Income Tax -- Private SME Company Skill v1.0
+
+> **General reference only.** This skill is general tax/accounting reference material for AI-assisted workflows. It has not been reviewed for any specific person's facts, documents, elections, deadlines, residency, filing status, or local procedures. Do not rely on it to file, pay, amend, or take a tax position without review by a qualified professional in the relevant jurisdiction.
+
+> **Law-change context.** (1) General interest charge (GIC) and shortfall interest charge (SIC) incurred on or after 1 July 2025 are NO LONGER deductible -- 2025-26 returns (this lodgment season) are the first affected; add back any GIC/SIC in the ledger. (2) The temporary loss carry-back offset is **ENDED** -- it was claimable only in the 2020-21 to 2022-23 returns for losses of 2019-20 to 2022-23; carry-forward is the only mechanism for current losses. (3) Small/medium business amendment periods extended from 2 to 4 years for assessments for 2024-25 and later income years.
+
+## Section 1 -- Quick reference
+
+**Read this whole section before computing or classifying anything.**
+
+| Field | Value |
+|---|---|
+| Country | Australia |
+| Primary Legislation | ITAA 1997; ITAA 1936; Income Tax Rates Act 1986 (rates: s 23(2); BRE: ss 23AA, 23AB) |
+| Tax Authority | Australian Taxation Office (ATO) |
+| Income Year | 2026-27 (1 July 2026 -- 30 June 2027); lodgment season for 2025-26 |
+| Base rate entity (BRE) rate | 25% (2021-22 onwards; 2025-26 and 2026-27 both 25%) |
+| Standard company rate | 30% (all companies that are not BREs) |
+| BRE test (BOTH limbs, current year) | Aggregated turnover < $50m AND base rate entity passive income (BREPI) <= 80% of assessable income |
+| Corporate tax rate for imputation purposes | Tested on the PRIOR year's turnover/BREPI/assessable income; new entities default to BRE (25%) |
+| Maximum franking credit | Distribution x (1 / gross-up rate); at 25%: distribution / 3; at 30%: distribution x 3/7 |
+| Franking period (private company) | The whole income year -- one benchmark franking percentage per year |
+| Franking deficit tax (FDT) | Deficit at year end -> franking account tax return + FDT by 31 July (30 June balancers) |
+| Distribution statement (private company) | Within 4 months of the end of the income year of the distribution |
+| Loss carry-forward | COT (s 165-12) or business continuity test (s 165-13: same business s 165-210; similar business s 165-211 for losses of years starting on/after 1 July 2015) |
+| Loss carry-back | **ENDED** -- last claim year 2022-23; do not claim |
+| Return due (2025-26, typical agent client) | 15 May 2027 lodge and pay (31 March 2027 if 2024-25 total income > $2m) |
+| Return due (self-preparer small company) | Generally 28 February 2027 lodge and pay (31 October 2026 if prior years outstanding) |
+| PAYG instalment GDP uplift | 5% for 2026-27 (4% for 2025-26) |
+| Amendment period (SMB, aggregated turnover < $50m) | 4 years for 2024-25 onwards (2 years for 2023-24 and earlier); others 4 years |
+| Contributor | Open Accountants |
+| Validated by | Pending |
+
+**Conservative defaults:**
+
+| Ambiguity | Default |
+|---|---|
+| BREPI composition unknown | Compute tax at BOTH 25% and 30%; flag -- never assume 25% |
+| Trust distribution received, trust workings not sighted | Assume 100% BREPI (30% rate candidate) until the trust's income is traced |
+| Prior-year figures unknown (imputation rate) | Do NOT issue distribution statements; establish the prior-year test first -- wrong-rate franking creates over/under-franking |
+| Aggregated turnover near $50m | Include connected entities and affiliates before concluding; flag grouping unresolved |
+| Franking account balance unknown | Rebuild from ATO ICA transactions + dividend history before franking anything |
+| Company in (or possibly in) a consolidated/MEC group | STOP -- R-AU-CT-1 |
+| Losses carried forward + ANY share movement | Assume COT broken until the share register is reviewed |
+| GIC/SIC expense in the ledger (post-1 July 2025) | Add back -- not deductible |
+| Debit shareholder/director loan balance | Route to au-div7a before the return is finalised |
+
+## Section 2 -- Refusal catalogue
+
+Compute nothing in these areas; document the trigger and escalate to a specialist reviewer.
+
+| Code | Trigger | Action |
+|---|---|---|
+| R-AU-CT-1 | Tax consolidation: forming/joining/leaving a group, ACA calculations, single-entity questions, MEC groups | Refuse; escalate. Membership changes also shift return due dates (28 February for exits) |
+| R-AU-CT-2 | Thin capitalisation / debt deduction creation rules (Div 820): foreign-controlled entity, overseas borrowings, debt deductions > $2m group-wide | Refuse; escalate |
+| R-AU-CT-3 | International dealings: transfer pricing, related-party cross-border transactions, CFCs, hybrid mismatches, DPT, Pillar Two, International Dealings Schedule | Refuse; escalate |
+| R-AU-CT-4 | R&D tax incentive: registration, eligible activities, offset rates, clawback, feedstock | Refuse; escalate to an R&D specialist -- registration deadlines (10 months after year end) are unforgiving |
+| R-AU-CT-5 | Loss integrity beyond plain COT arithmetic: Subdiv 165-CC unrealised losses, value shifting, s 165-15 injected-income schemes, SBT/similar-business judgement calls | Compute exposure only; escalate the judgement |
+| R-AU-CT-6 | Franking of deemed dividends, s 109RB requests, dividend access shares, franking credit trading / 45-day rule opinions | Refuse; escalate (Div 7A mechanics live in au-div7a) |
+
+## Section 3 -- GL sweep library
+
+Signs a company return needs attention. Sweep the trial balance before touching the return.
+
+| GL pattern | Likely issue | Action |
+|---|---|---|
+| Dividends paid / retained earnings fall with no franking working papers | Franking account never maintained | Rebuild register; check 4-month distribution statement deadline; benchmark rule |
+| Interest, rent or dividend income material relative to turnover | BREPI creeping toward 80% | Run the two-limb BRE test with actual numbers (Rule 1) |
+| Trust distribution receivable / income from a related trust | Rate risk: distribution may be 100% BREPI (Rule 2); UPE questions | Trace character in the TRUST's books; UPE/loan questions -> au-div7a |
+| Debit balance in shareholder/director loan account | Div 7A deemed dividend risk | STOP -- run au-div7a before lodgment day |
+| Income tax refund received during the year | Franking DEBIT posted; deficit risk | Recompute franking account; FDT screen (Rule 6) |
+| Carried-forward losses + movement in issued shares (ASIC forms, new share classes) | COT failure | Ownership analysis (Rule 7); escalate SBT judgement (R-AU-CT-5) |
+| "ATO interest", GIC, SIC expense accounts | Non-deductible from 1 July 2025 | Add back in the return; check ICA statements for accruals |
+| Fines, penalties, entertainment expense | Non-deductible add-backs | Adjust; entertainment also cross-checks to FBT (au-fbt) |
+| PAYG instalments in a clearing account not reconciled to the ICA | Instalments misposted as tax expense | Reconcile; instalments credit against assessed tax, they are not the expense |
+| Government grants / R&D offset receivable in P&L | R&D incentive in play | R-AU-CT-4 -- escalate |
+| Foreign exchange accounts, royalties paid offshore, overseas loans | International dealings | R-AU-CT-3 -- escalate; check IDS thresholds |
+| Legal/consulting fees around a share sale or restructure | Possible consolidation, rollovers, loss trigger events | R-AU-CT-1 / R-AU-CT-5 |
+
+---
+
+## Section 4 -- Worked examples
+
+### Example 1 -- The two-limb BRE test and the 25% rate
+
+Trading company, 2026-27: aggregated turnover $8.0m (no connected entities), assessable income $8.24m including $40,000 bank interest; taxable income $480,000.
+
+```
+Limb 1: $8.0m < $50m                          PASS
+Limb 2: BREPI = $40,000 / $8,240,000 = 0.5%   <= 80%  PASS
+Rate = 25%; tax = $480,000 x 25% = $120,000
+```
+
+Both limbs are tested on CURRENT-year figures; prior-year turnover is irrelevant to the tax rate (contrast the imputation rate, Example 4).
+
+### Example 2 -- Franking arithmetic at 25% and at 30%
+
+**(a) BRE for imputation purposes (25%).** Company pays a $75,000 fully franked dividend.
+
+```
+Gross-up rate = (100% - 25%) / 25% = 3.0
+Maximum franking credit = $75,000 x (1 / 3.0) = $25,000
+Resident shareholder (top marginal 47% incl Medicare):
+  Assessable = $75,000 + $25,000 gross-up = $100,000
+  Tax $47,000 - franking offset $25,000 = $22,000 net
+  Total tax on the $100,000 profit = $25,000 (company) + $22,000 = $47,000
+```
+
+**(b) Standard rate for imputation purposes (30%).** Company pays a $70,000 fully franked dividend.
+
+```
+Gross-up rate = (100% - 30%) / 30% = 2.3333
+Maximum franking credit = $70,000 x 3/7 = $30,000
+Shareholder: assessable $100,000; tax $47,000 - $30,000 = $17,000 net
+```
+
+Imputation washes company tax out at the shareholder's marginal rate either way -- but only if the franking account actually holds the credits being attached.
+
+### Example 3 -- Bucket company: trust distributions are usually passive income
+
+Bucket Co's only income in 2026-27 is a $200,000 distribution from a discretionary trust. The trust's net income comprised $140,000 net rental income, $42,000 franked dividends and $18,000 franking credits.
+
+Rent, dividends and franking credits are all BREPI in the trust's hands, and a trust distribution is BREPI **to the extent it is traceable (directly or indirectly) to BREPI of the trust** (ITRA s 23AB(1)(g); LCR 2019/5). Here 100% of Bucket Co's assessable income is BREPI -> limb 2 fails -> **30% rate**:
+
+```
+Tax = $200,000 x 30% = $60,000
+Less franking offset (credits flowing on the trust's franked dividends) = $18,000
+Net payable = $42,000; the $18,000 also CREDITS Bucket Co's franking account
+```
+
+**Contrast:** if the same $200,000 had been wholly referable to the trust's TRADING income, BREPI = 0% -> 25% rate -> tax $50,000. Character flows through chains of trusts level by level -- get the trust's workings, never assume. Passive-heavy bucket companies are 30% companies in most years. (UPE left unpaid? Div 7A/s 100A screens -> au-div7a.)
+
+### Example 4 -- The imputation-rate mismatch (franking at a different rate than you pay)
+
+Grower Pty Ltd's 2026-27 aggregated turnover is $30m with minimal BREPI -> taxed at **25%**. But its 2025-26 turnover was $55m. The imputation test uses the PRIOR year: turnover $55m >= $50m -> NOT a BRE for imputation -> franks 2026-27 distributions at **30%** (max credit = dividend x 3/7).
+
+Reverse case: Holdco is taxed at 30% in 2026-27 (100% BREPI bucket company) but last year's figures pass the BRE test -> it must frank at **25%** (max credit = dividend / 3). Tax paid at 30% enters the franking account, but each dollar of dividend can only carry out credits at the 25% rate -- credits strand in the account until a 30%-franking year. The rate you pay and the rate you frank at are set by different years' facts; establish both every year before any distribution statement is issued.
+
+### Example 5 -- Franking account, deficit, and the FDT offset haircut
+
+30 June 2027 franking account of a private company (franking period = full income year):
+
+```
+Opening surplus                                    $5,000 CR
+PAYG instalments paid during 2026-27              $20,000 CR
+Franked distribution paid ($75,000, 25% rate)     $25,000 DR
+Income tax refund received March 2027             $13,000 DR
+Closing balance                                    $13,000 DR (deficit)
+```
+
+FDT = $13,000, payable with a franking account tax return by **31 July 2027**. The FDT is creditable against future income tax, but the offset is REDUCED by 30% where the deficit exceeds 10% of the franking credits that AROSE during the year (here $20,000 of instalment credits -- the opening surplus is a balance, not a credit arising; $20,000 x 10% = $2,000; $13,000 > $2,000):
+
+```
+FDT offset available = $13,000 x 70% = $9,100 (the $3,900 haircut is permanent)
+```
+
+Exclusions (e.g. events outside the entity's control, Commissioner's discretion) exist -- escalate before conceding the haircut. Anti-deferral: a tax refund received within 3 months after year end is pushed back into the year for FDT purposes (return + payment due within 14 days of the refund).
+
+### Example 6 -- Carried-forward loss, ownership change, similar business test
+
+Retailer Pty Ltd carries forward a $300,000 tax loss from 2023-24. In February 2026 its founders sold 60% of the shares to an investor. For a 2026-27 recoupment the ownership test period runs from 1 July 2023 to 30 June 2027 -- continuity of more than 50% of voting power, dividend rights and capital rights fails at the February 2026 sale (s 165-12).
+
+Fallback (s 165-13): the business continuity test at the test time. The company still sells the same product lines but added an online channel -- a **similar business** analysis under s 165-211 is available because the loss arose in a year starting on/after 1 July 2015 (LCR 2019/1 factors: same assets, same activities generating income, identity of the business). If satisfied:
+
+```
+2026-27 taxable income before losses  $450,000
+Less prior-year loss                  $300,000
+Taxable income $150,000 x 25% = $37,500
+```
+
+The SBT conclusion is a judgement call -- document the four LCR 2019/1 factors and escalate (R-AU-CT-5). Losses are deducted in the order incurred, and a company may CHOOSE how much loss to deduct (s 36-17) -- e.g. leaving income taxable to absorb franking offsets rather than wasting them.
+
+---
+
+## Section 5 -- Tier 1 rules
+
+### Rule 1 -- The rate: two limbs, tested every year (ITRA ss 23AA-23AB)
+
+25% applies for an income year only if BOTH: (1) aggregated turnover for THAT year (company + connected entities + affiliates, worked out at year end) < $50m; and (2) BREPI <= 80% of the company's own assessable income. Otherwise 30%. BREPI (s 23AB): corporate distributions and their franking credits; royalties and rent; interest (limited exceptions); gains on qualifying securities; net capital gains; and trust/partnership amounts traceable to any of those. No Commissioner discretion exists. Limb 2 tests the company's OWN income only; limb 1 is the grouped test. Companies taxed at special rates (NFP shade-in, life insurance, PDFs) are outside this skill.
+
+### Rule 2 -- Trust and partnership distributions keep their character
+
+A distribution is BREPI to the extent traceable, directly or through a chain, to BREPI at the source level (LCR 2019/5): apply the test at each tier, apportion expenses reasonably, and treat streamed franked dividends as retaining dividend character. A dividend paid through a trust is never a "non-portfolio dividend" (the 10% voting exception cannot apply -- the dividend is not paid to a company). Practical effect: passive-investment bucket companies are almost always 30% companies (Example 3).
+
+### Rule 3 -- Corporate tax rate for imputation purposes (prior-year test)
+
+To set the franking rate for year Y, assume turnover, assessable income and BREPI equal year Y-1 actuals: if those pass the BRE test (against year Y's $50m threshold), frank at 25%; if not, 30%. An entity that did not exist in Y-1 franks at 25%. Maximum franking credit = distribution x (1 / applicable gross-up rate), gross-up rate = (100% - imputation rate) / imputation rate -> divide by 3 at 25%; multiply by 3/7 at 30%. Attaching more than the maximum: the account is debited only the maximum and the shareholder only gets the maximum. The tax rate and the imputation rate regularly diverge (Example 4) -- compute both, every year.
+
+### Rule 4 -- The franking account
+
+A rolling ledger, not a year-end invention. CREDITS: income tax and PAYG instalments paid (to the extent they relate to taxed profits), franking credits on distributions received (directly or through trusts/partnerships), FDT liability incurred. DEBITS: franking credits on distributions paid, income tax refunds received, over/under-franking adjustments, ceasing to be a franking entity. Only tax actually PAID supports credits -- accrued tax expense is irrelevant. Companies receiving franked dividends gross up and claim a NON-REFUNDABLE offset; excess franking offsets convert into a tax loss (s 36-55) rather than a refund.
+
+### Rule 5 -- Benchmark rule (private companies: one percentage per year)
+
+A private company's franking period is its whole income year. The franking percentage on the FIRST frankable distribution in the period sets the benchmark; every later frankable distribution in the period must be franked to the same percentage. Franking above benchmark = over-franking tax (equal to the excess credits, not creditable to anyone); below benchmark = under-franking debit (credits wasted -- debited as if fully franked at benchmark without reaching shareholders). Disclose to the ATO where the benchmark moves by more than 20 percentage points (x intervening periods) between successive franking periods with frankable distributions. Plan the year's dividends BEFORE the first statement is issued.
+
+### Rule 6 -- Franking deficit tax
+
+Deficit at year end (or on ceasing to be a franking entity) -> FDT equal to the deficit; lodge a franking account tax return and pay by the last day of the month after year end (31 July for 30 June balancers). FDT liability credits the account back to nil. FDT offsets future income tax, reduced 30% where the deficit exceeds 10% of the year's franking credits (exclusions and a discretion exist -- escalate). Refunds received within 3 months of year end count as pre-year-end for the deficit calculation (14-day lodge-and-pay window). Never frank against anticipated credits without modelling the year-end balance.
+
+### Rule 7 -- Loss carry-forward: COT then business continuity
+
+Tax losses carry forward indefinitely but are deductible only if the company satisfies the continuity of ownership test -- persons holding more than 50% of voting power, dividend rights AND capital rights at all times from the start of the loss year to the end of the claim year (s 165-12; trace through interposed entities; same-share rule s 165-165) -- or, failing COT, the business continuity test at s 165-13: same business (s 165-210) or, for losses of income years starting on/after 1 July 2015, similar business (s 165-211; LCR 2019/1). Net capital losses follow parallel rules (s 165-96). Deduct in order incurred; s 36-17 choice as to amount (Example 6). Anti-injection rules (s 165-15) and Subdiv 165-CC escalate (R-AU-CT-5).
+
+### Rule 8 -- Loss carry-back: ENDED
+
+The refundable loss carry-back offset applied to losses of 2019-20 to 2022-23, claimable ONLY in the 2020-21 to 2022-23 returns (against tax paid for 2018-19 onwards, capped at the franking account surplus). It has sunset. Any current-year claim is wrong; historical claims surface only via amendment questions -- escalate those (amendment periods have largely closed).
+
+### Rule 9 -- Lodgment and payment (2025-26 returns, 30 June balancers)
+
+Company income tax is full self-assessment: payment is due with lodgment per the program, not on a notice. Registered agent program: 31 October 2026 lodge / 1 December 2026 pay where prior-year returns were outstanding at 30 June 2026; 31 January 2027 lodge / 1 December 2026 pay for large-medium taxpayers taxable in 2024-25; 28 February 2027 for large-medium non-taxable and new registrant large-medium; 31 March 2027 where 2024-25 total income > $2m; **15 May 2027** for the rest; 5 June 2027 concession where both years are non-taxable/refund. Self-preparer small companies: generally 28 February 2027. Late lodgment risks FTL penalties and GIC -- and GIC from 1 July 2025 is non-deductible, so late payment now costs pre-tax dollars.
+
+### Rule 10 -- PAYG instalments interaction
+
+Companies enter automatically with instalment income >= $2m in the latest return, notional tax >= $500, or as head of a consolidated group. Default quarterly (typically 28 October / 28 February / 28 April / 28 July); instalment income > $20m -> monthly (21st of the following month); notional tax < $8,000 -> annual option (conditions apply). Amount method instalments are uplifted by the GDP factor: **5% for 2026-27** (4% for 2025-26). Variation is allowed but a variation below 85% of the actual liability attracts GIC on the shortfall. Instalments are credited against the assessed tax in the calculation statement -- reconcile the ICA before finalising; the 2026-27 instalments raised after the 2025-26 assessment are based on that return.
+
+### Rule 11 -- Return mechanics and add-backs
+
+Reconcile accounting profit to taxable income on the return: add back non-deductibles (GIC/SIC from 1 July 2025, fines and penalties, entertainment not subject to FBT, accounting depreciation) and adjust for tax timing (tax depreciation, prepayments, provisions -- deductible when incurred, not provided). Franked dividends received: gross up and offset (Rule 4). Distribution statements to shareholders within 4 months of year end (private companies). Amendment periods: SMB 4 years for 2024-25 onwards (2 years for 2023-24 and earlier); other taxpayers 4 years. Keep the losses schedule and flag it where losses > $100,000 are claimed or carried.
+
+### Rule 12 -- Div 7A boundary (cross-reference, do not duplicate)
+
+Any payment, loan, debt forgiveness or private asset use flowing from the company to shareholders/associates, any debit loan account, and any UPE question (including post-*Bendel* treatment) is **au-div7a** territory -- run that skill before this return is signed off. The only company-return touchpoints here: deemed dividends are generally unfrankable, Div 7A loan interest is assessable income, and the 2026-27 benchmark interest rate is 8.77%.
+
+---
+
+## Section 6 -- Tier 2 catalogue
+
+### T2-1 -- Turnover hovering at the $50m threshold
+
+**Trigger:** aggregated turnover $45m-$55m, or connected-entity/affiliate status unclear. **Issue:** grouping swings both the 25% rate and SMB concessions. **Action:** map the group per the s 328-125/328-130 tests; flag; do not conclude alone.
+
+### T2-2 -- BREPI classification edges
+
+**Trigger:** income that resists classification -- interest-like returns, mixed licence fees vs royalties, rent vs services (serviced offices, storage). **Issue:** LCR 2019/5 characterisation drives the rate near the 80% line. **Action:** compute the ratio both ways; escalate if the rate flips.
+
+### T2-3 -- Franking account rebuild
+
+**Trigger:** no franking register; dividends paid historically. **Issue:** deficits and benchmark breaches may already exist; distribution statements may never have been issued. **Action:** rebuild from ICA transactions and dividend documentation since the last verified balance; flag FDT/OFT exposure.
+
+### T2-4 -- Dual rate governance
+
+**Trigger:** rate for tax differs from rate for imputation (Example 4), or the company's BRE status flip-flops year to year. **Issue:** distribution statements issued at the wrong rate create over/under-franking and shareholder amendments. **Action:** minute both rates at year start; re-check before each dividend.
+
+### T2-5 -- Loss schedule with ownership noise
+
+**Trigger:** losses claimed plus any equity movement, share buy-back, new class of shares, or trustee shareholders. **Issue:** COT tracing through trusts is technical (family trust elections change the analysis). **Action:** build the ownership timeline; escalate FTE/SBT questions (R-AU-CT-5).
+
+### T2-6 -- Instalment variations in a falling year
+
+**Trigger:** client wants instalments varied down mid-year. **Issue:** variation below 85% of actual attracts GIC -- now non-deductible. **Action:** model the full-year estimate before varying; document the basis.
+
+---
+
+## Section 7 -- Excel working paper template
+
+```
+AUSTRALIA COMPANY TAX -- RETURN WORKING PAPER
+Company: [name]   Income year: [2025-26 / 2026-27]   Balancer: 30 June
+Prepared: [date]
+
+RATE TEST (CURRENT YEAR -- Rule 1)
+  Aggregated turnover (co + connected + affiliates): AUD [____]  < $50m? [Y/N]
+  Assessable income:               AUD [____]
+  BREPI (dividends+credits, rent, royalties, interest,
+         net capital gain, traceable trust/partnership amounts): AUD [____]
+  BREPI %:                         [____]%  <= 80%? [Y/N]
+  RATE: [25% / 30%]
+
+IMPUTATION RATE TEST (PRIOR YEAR -- Rule 3)
+  Prior-year turnover / BREPI % :  AUD [____] / [____]%
+  Imputation rate: [25% / 30%]   Max credit per $ of dividend: [1/3 | 3/7]
+
+TAXABLE INCOME RECONCILIATION
+  Accounting profit:               AUD [____]
+  + GIC/SIC (post-1 Jul 2025), fines, entertainment, accounting depn: AUD [____]
+  - Tax depreciation / other timing: AUD [____]
+  + Franking credit gross-up on dividends received: AUD [____]
+  - Prior-year losses applied (COT/BCT confirmed, order incurred): AUD [____]
+  Taxable income:                  AUD [____]
+  Tax @ [25/30]%:                  AUD [____]
+  - Franking offsets (non-refundable; excess -> loss s 36-55): AUD [____]
+  - PAYG instalments credited (per ICA): AUD [____]
+  Payable / (refundable):          AUD [____]
+
+FRANKING ACCOUNT
+  Opening balance:                 AUD [____]
+  + Tax/instalments paid; credits on dividends received: AUD [____]
+  - Credits on dividends paid; refunds received: AUD [____]
+  Closing balance:                 AUD [____]  Deficit? -> FDT by 31 July
+  Benchmark % this franking period: [____]%  All distributions at benchmark? [Y/N]
+  Distribution statements issued within 4 months? [Y/N]
+
+FLAGS
+  Div 7A candidates routed to au-div7a: [____]
+  Refusal triggers hit (R-AU-CT-1..6): [____]
+```
+
+---
+
+## Section 8 -- Reading guide
+
+1. Rate first, return second: run both limbs of the BRE test on real numbers before any tax computation -- and run the SEPARATE prior-year test before any dividend is franked.
+2. Trust distributions: character is set in the trust's books, not the company's. No trust workings = assume passive = 30% until proven otherwise.
+3. The franking account is continuous. Every instalment, refund and dividend moves it; the year-end balance decides FDT, not intentions.
+4. Losses: the share register is the evidence, not the client's memory. Any transfer, issue or redemption inside the ownership test period reopens the analysis.
+5. Payment dates are lodgment-linked for most SMEs (full self-assessment) -- lodging early does not delay payment beyond the program date, and lodging late compounds FTL penalties with non-deductible GIC.
+
+---
+
+## Section 9 -- Onboarding fallback
+
+If the client provides only financial statements and a trial balance:
+
+1. Run the Section 3 sweep; list rate-risk income lines and Div 7A candidates
+2. Compute the BRE test both years (rate + imputation rate) from the figures given
+3. Draft the taxable income reconciliation with add-backs visible
+4. Rebuild the franking account from the ICA and any dividend statements sighted
+5. **Flag:** "Computed from financial statements only. Aggregated turnover grouping, trust distribution character, share register continuity, franking history and instalment reconciliation not verified. Reviewer must confirm before lodgment or any distribution statement is issued."
+
+---
+
+## Section 10 -- Reference material
+
+### Key figures (2025-26 and 2026-27)
+
+| Item | 2025-26 | 2026-27 |
+|---|---|---|
+| BRE rate / standard rate | 25% / 30% | 25% / 30% |
+| Aggregated turnover threshold | $50m | $50m |
+| BREPI limb | <= 80% of assessable income | <= 80% |
+| Max franking credit (25% / 30% imputation rate) | dividend/3 or dividend x 3/7 | same |
+| FDT due (30 June balancer) | 31 July 2026 | 31 July 2027 |
+| PAYG GDP uplift | 4% | 5% |
+| Div 7A benchmark rate (see au-div7a) | 8.37% | 8.77% |
+| GIC/SIC deductibility | Not deductible (from 1 Jul 2025) | Not deductible |
+| Loss carry-back | ENDED | ENDED |
+
+### Primary sources (verified 20 August 2026)
+
+| Topic | Source |
+|---|---|
+| Rates and BRE definition | Income Tax Rates Act 1986 ss 23(2), 23AA, 23AB; ato.gov.au Changes to company tax rates (QC 54063, updated 27 May 2026) |
+| BREPI and trust tracing | LCR 2019/5 Base rate entities and base rate entity passive income; TR 2019/1 |
+| Imputation rate and max credit | ato.gov.au Allocating franking credits (QC 47305); ITAA 1997 Div 202, s 995-1 (corporate tax rate for imputation purposes) |
+| Franking account / FDT | ITAA 1997 Div 205; ato.gov.au Franking deficit tax (QC 47303); Franking account tax return and instructions 2026 |
+| Benchmark rule / franking periods | ITAA 1997 Div 203, s 204-75; ato.gov.au Benchmark rule and Franking period pages |
+| Distribution statements | ITAA 1997 Subdiv 202-E; ato.gov.au Issuing distribution statements (4-month private company rule) |
+| Losses | ITAA 1997 Div 36 (ss 36-17, 36-55), Div 165 (ss 165-12, 165-13, 165-96, 165-210, 165-211); LCR 2019/1 |
+| Loss carry-back (ENDED) | Former Div 160 ITAA 1997; ato.gov.au Loss carry back tax offset (2019-20 to 2022-23 only) |
+| Lodgment program | ato.gov.au Companies and super funds -- agent lodgment program (QC 34562, updated 1 July 2026); Income tax return -- companies (28 February self-preparer) |
+| PAYG instalments | ato.gov.au PAYG instalments (entry $2m/$500; monthly > $20m); GDP adjustment 5% for 2026-27 |
+| Amendment periods | ato.gov.au Request an amendment to a business or super tax return (SMB 4 years from 2024-25) |
+| GIC/SIC deduction denial | ato.gov.au -- deductions denied for GIC/SIC incurred from 1 July 2025 |
+
+### Test suite
+
+**Test 1:** Turnover $8m, BREPI 0.5%, taxable income $480,000. -> 25%; tax $120,000.
+
+**Test 2:** Turnover $30m, BREPI 100% (all trust-sourced rent/dividends). -> Limb 2 fails; 30%.
+
+**Test 3:** $75,000 dividend at 25% imputation rate. -> Max credit $25,000; shareholder grosses up to $100,000.
+
+**Test 4:** $70,000 dividend at 30% imputation rate. -> Max credit $30,000 ($70,000 x 3/7).
+
+**Test 5:** Taxed at 25% this year; prior-year turnover $55m. -> Franks at 30% regardless of current rate.
+
+**Test 6:** New company incorporated this year pays a maiden dividend. -> No prior year -> BRE for imputation -> franks at 25%.
+
+**Test 7:** Franking account deficit $13,000; credits arising in the year $20,000. -> FDT $13,000 by 31 July; deficit > 10% of credits -> offset reduced to $9,100.
+
+**Test 8:** First interim dividend franked 100%; final dividend proposed at 50%. -> Benchmark breach: under-franking debit on the final (credits wasted); same-year distributions must match the benchmark.
+
+**Test 9:** $300,000 loss from 2023-24; 60% share sale Feb 2026. -> COT fails; similar business test available (loss year starts post-1 July 2015); escalate the SBT judgement.
+
+**Test 10:** Client asks to carry back a 2026-27 loss against 2025-26 tax. -> Refuse: carry-back ENDED (last claim year 2022-23); carry forward instead.
+
+### Prohibitions
+
+- NEVER apply 25% without BOTH current-year limbs verified (turnover grouped; BREPI traced)
+- NEVER set the franking rate from current-year status -- the imputation rate uses PRIOR-year figures
+- NEVER frank above the maximum credit or away from the period's benchmark percentage
+- NEVER treat a trust distribution as active income without the trust's workings
+- NEVER claim loss carry-back -- the measure has ENDED
+- NEVER deduct GIC or SIC incurred on or after 1 July 2025
+- NEVER deduct carried-forward losses across an ownership change without COT/BCT analysis on the share register
+- NEVER issue distribution statements while the franking account balance is unverified
+- NEVER compute consolidation, thin cap, transfer pricing or R&D claims -- escalate (Section 2)
+- NEVER present figures as definitive
+
+---
+
+## Disclaimer
+
+This skill and its outputs are provided for informational and computational purposes only and do not constitute tax, legal, or financial advice. Open Accountants and its contributors accept no liability for any errors, omissions, or outcomes arising from the use of this skill. All outputs must be reviewed and signed off by a qualified professional (such as a CPA, CA, tax agent, or equivalent licensed practitioner in your jurisdiction) before filing or acting upon.
+
+The most up-to-date, verified version of this skill is maintained at [openaccountants.com](https://www.openaccountants.com). Log in to access the latest version, request a professional review from a licensed accountant, and track updates as tax law changes.
+
+> Contributed by Ryan Duguid.
+
+<!-- openaccountants-cta-block -->
+
+---
+
+## Talk to a verified accountant
+
+This guide is maintained by the OpenAccountants network — accountants who put
+their name behind the tax answers AI gives people. The live, always-current
+version (and the professional behind it) is at
+[openaccountants.com](https://www.openaccountants.com).
+
+- Use it in your AI: https://www.openaccountants.com/connect
+- Meet the accountants: https://www.openaccountants.com/network
+
+> **General reference only.** This document does not constitute tax, legal, or
+> financial advice. Verify figures against the cited primary sources or with a
+> licensed professional before relying on them.

--- a/skills/international/australia/au-psi.md
+++ b/skills/international/australia/au-psi.md
@@ -133,7 +133,7 @@ EngCo Pty Ltd (a base rate entity) derives $300,000 from the engineering service
   Immediate saving/deferral                  = $35,050
 ```
 
-PCG 2025/5 higher-risk indicators present: salary not commensurate with the value of Priya's services; retention of net PSI in a lower-taxed entity without a commercial purpose; splitting to a non-working associate (Guideline Examples 10-17). Franking on eventual distribution reduces but does not erase the benefit (deferral + choice of recipient). This file computes exposure only -- restructuring advice escalates (R-AU-PSI-6). A genuine move to a low-risk arrangement (full net PSI to Priya, taxed at her marginal rate) by 30 June 2027 is inside the ATO's stated transitional compliance approach (PCG 2025/5 para 11).
+PCG 2025/5 higher-risk indicators present: salary not commensurate with the value of Priya's services; retention of net PSI in a lower-taxed entity without a commercial purpose; splitting to a non-working associate (Guideline Examples 10-17). The 25% rate assumes EngCo is a base rate entity in the year -- service fees are trading income, not base rate entity passive income, so a pure-services company under the $50m turnover limb ordinarily qualifies; if retained profits later generate passive income above 80% of assessable income, the rate flips to 30% (see au-company-tax). Franking on eventual distribution reduces but does not erase the benefit (deferral + choice of recipient). This file computes exposure only -- restructuring advice escalates (R-AU-PSI-6). A genuine move to a low-risk arrangement (full net PSI to Priya, taxed at her marginal rate) by 30 June 2027 is inside the ATO's stated transitional compliance approach (PCG 2025/5 para 11).
 
 ---
 

--- a/skills/international/australia/au-psi.md
+++ b/skills/international/australia/au-psi.md
@@ -1,0 +1,392 @@
+---
+name: au-psi
+description: >
+  Use this skill whenever asked about Australian personal services income -- PSI, the PSI rules,
+  Divisions 84 to 87 ITAA 1997, personal services entities, personal services business tests, the
+  results test, the 80% rule, unrelated clients, employment or business premises tests, PSB
+  determinations, attribution of PSI, PSI deduction limits, contractors invoicing through companies
+  or trusts, income splitting or profit retention by consultants, PCG 2025/5, or Part IVA exposure
+  for PSBs. Trigger on phrases like "PSI", "personal services", "PSB", "results test", "80% rule",
+  "attribution", or a GL showing an entity invoicing one individual's skills. ALWAYS read this
+  skill before any PSI work.
+version: 1.0
+jurisdiction: AU
+tax_year: 2026
+tax_year_notes: "2026-27"
+last_updated: 2026-08-20
+review_status: pending_review
+category: international
+tier: 2
+license: AGPL-3.0-or-later (code) / OpenAccountants Guide License v1.0 (content)
+---
+
+# Australia Personal Services Income (PSI) -- Divisions 84-87 Skill v1.0
+
+> **General reference only.** This skill is general tax/accounting reference material for AI-assisted workflows. It has not been reviewed for any specific person's facts, documents, elections, deadlines, residency, filing status, or local procedures. Do not rely on it to file, pay, amend, or take a tax position without review by a qualified professional in the relevant jurisdiction.
+
+> **Law-change context.** Two 2025-26 developments reshape PSI work. (1) The ATO finalised draft PCG 2024/D2 as **PCG 2025/5** (issued 28 November 2025): qualifying as a personal services business does NOT immunise income splitting or profit retention from Part IVA -- Rule 11 carries the low-risk / higher-risk framework, including the ATO's statement that it will not pursue Part IVA compliance where a taxpayer makes a genuine attempt to move to a low-risk arrangement by 30 June 2027. (2) The $1,000 standard deduction for work-related expenses (Treasury Laws Amendment (Tax Reform No. 1) Act 2026, from 1 July 2026) does NOT extend to PSI earners -- Rule 12.
+
+## Section 1 -- Quick reference
+
+**Read this whole section before classifying any income or computing anything.**
+
+| Field | Value |
+|---|---|
+| Country | Australia |
+| Primary Legislation | ITAA 1997 Part 2-42: Div 84 (definition), Div 85 (individuals' deduction limits), Div 86 (attribution + entity deduction limits), Div 87 (PSB tests) |
+| Tax Authority | Australian Taxation Office (ATO) |
+| Income Year | 2026-27 (1 July 2026 -- 30 June 2027); lodgment season under way for 2025-26 |
+| PSI definition | Income mainly (**more than 50%**) a reward for an individual's personal efforts or skills (s 84-5) |
+| Results test | All 3 conditions met for **at least 75%** of the individual's PSI (s 87-18) |
+| 80% rule | **80% or more** of PSI from one client + its associates blocks self-assessment on the other three tests (s 87-15(3)) -- results test or PSBD only |
+| Other PSB tests | Unrelated clients (s 87-20), employment (s 87-25), business premises (s 87-30) -- each needs the 80% rule met |
+| PSB determination | ss 87-60 (individuals) / 87-65 (entities); unusual-circumstances gateway |
+| Attribution | Net PSI included in the individual's assessable income (s 86-15); NANE to the entity (s 86-30) |
+| PAYG on attributed PSI | TAA 1953 Sch 1 Div 13 (attributed amounts) and Div 12 (salary actually paid) |
+| Core ATO ruling | TR 2022/3 (replaced TR 2001/7 and TR 2001/8) |
+| Part IVA guideline | PCG 2025/5 (issued 28 Nov 2025; applies before and after issue) |
+| Contributor | Open Accountants |
+| Validated by | Pending |
+
+**Conservative defaults:**
+
+| Ambiguity | Default |
+|---|---|
+| Entity's fee income traced to one individual's work | Treat as PSI of that individual until the >50% "mainly" analysis says otherwise |
+| Hourly or daily-rate contract | Assume the results test FAILS (not paid for a result) until the contract shows otherwise |
+| Client concentration unknown | Assume the 80% rule FAILS; only the results test or a PSBD can then save PSB status |
+| "We advertise" claimed for unrelated clients test | Assume NOT satisfied until offers/invitations to the public are evidenced (website, tenders, ads -- not a labour-hire panel) |
+| Home office claimed as business premises | Assume the business premises test FAILS (not physically separate, rarely exclusive) |
+| PSB status asserted, low salary + retained profits visible | Treat as PCG 2025/5 HIGHER RISK; run the Rule 11 screen and escalate |
+| Employee-like engagement (one payer, their tools, their control) | Flag employee/contractor characterisation and sham-contracting risk before any PSI analysis (Rule 12, R-AU-PSI-5) |
+
+## Section 2 -- The five-step decision flow
+
+Work every engagement, per individual, per income year, in this order. Never skip a step.
+
+1. **Is any income PSI?** More than 50% of the reward under each contract/invoice for an individual's personal efforts or skills -> PSI (Rule 1). Test each contract separately.
+2. **Is the individual/entity a PSB under the results test?** (Rule 4). If yes for >= 75% of PSI -> PSI rules do not apply (go to step 5 anyway).
+3. **Is less than 80% of the PSI from one client and its associates?** If no -> PSI rules apply unless a PSBD is obtained (Rule 8). If yes -> test unrelated clients, employment, business premises (Rules 5-7).
+4. **No test met, no PSBD?** PSI rules apply: deduction limits (Rule 10), attribution (Rule 9), PAYG (Rule 9).
+5. **PSB after all?** The income keeps its PSI character; ordinary rules plus Part IVA apply -- run the PCG 2025/5 risk screen (Rule 11).
+
+## Section 3 -- GL sweep library
+
+PSI work starts with the ledger and the debtor list, not the client's self-assessment.
+
+| GL pattern | Likely issue | Action |
+|---|---|---|
+| Company/trust service fees generated by ONE individual's skills | PSE candidate | Run the Section 2 flow per individual; check invoices for goods/asset components |
+| One debtor >= 80% of fee income | 80% rule fails | Results test or PSBD are the only PSB routes; else attribution |
+| Low director salary + material retained profits | PCG 2025/5 higher-risk retention | Verify PSB status first, then Rule 11 screen; escalate structuring (R-AU-PSI-6) |
+| Dividends/distributions to non-working spouse or family members | Higher-risk income splitting | Rule 11; document services actually provided; escalate (R-AU-PSI-6) |
+| Rent, mortgage interest, rates paid to the individual/associate for their residence | Denied: s 85-15 / s 86-60 | Add back in the attribution computation |
+| Salary or "admin fee" to an associate | Deductible only for principal work (s 85-20); admin support denied | Add back non-principal amounts; test reasonableness |
+| Two or more cars with private use by the individual | One-car limit (s 85-25 / s 86-70) | Add back the excess |
+| Nil PAYG remitted but attribution applies | TAA Sch 1 Div 13 breach | Quantify; flag urgently |
+| Contract income billed hourly with timesheets | Results test likely failing | Evidence check before any PSB claim |
+
+---
+
+## Section 4 -- Worked examples
+
+### Example 1 -- IT contractor, 90% one client, attribution arithmetic
+
+BitWorks Pty Ltd derives $220,000 (GST-exclusive) in 2026-27 from the programming services of Dev, its sole director. Contracts are hourly-rate, the client supplies the dev environment, and BitWorks bears no rectification liability: **results test fails** (0% of PSI meets the s 87-18 conditions -- needs >= 75%). One bank supplies 90% of the income: **80% rule fails**, so the unrelated clients / employment / business premises tests cannot be self-assessed and no PSBD is held. The PSI rules apply.
+
+BitWorks paid Dev $100,000 salary (Div 12 PAYG withheld) and incurred: laptop and software $4,000; professional indemnity insurance $1,500; bookkeeping and ASIC fees $800 (entity maintenance); rent to Dev's spouse for the home office $12,000 (**denied** s 86-60/s 85-15); spouse "admin salary" $20,000 for non-principal work (**denied** s 86-60/s 85-20).
+
+```
+Attributed PSI (s 86-15, reduced per s 86-20)
+  PSI received                          $220,000
+  less salary promptly paid to Dev      (100,000)
+  less deductible outgoings:
+    equipment                             (4,000)
+    professional indemnity                (1,500)
+    entity maintenance (s 86-65)            (800)
+  Denied amounts NOT subtracted: rent to associate $12,000,
+    associate non-principal salary $20,000
+  = Net PSI attributed to Dev           $113,700
+Dev's assessable income = $100,000 salary + $113,700 attribution = $213,700
+```
+
+The attributed $113,700 is neither assessable nor exempt income of BitWorks (s 86-30). BitWorks must have remitted PAYG on the attributed income quarterly under TAA 1953 Sch 1 Div 13 and reports the attributed amount to Dev. The spouse's $20,000 stays assessable to the spouse even though the company's deduction is denied -- flag the double-tax sting for the reviewer.
+
+### Example 2 -- Consultant passing the unrelated clients test
+
+Mia, a sole-trader marketing consultant, earns $180,000 of PSI in 2026-27 from five unrelated clients won through her website and competitive tenders: A $81,000 (45%), B $45,000 (25%), C $27,000 (15%), D $18,000 (10%), E $9,000 (5%).
+
+No client (with associates) reaches 80% -> the 80% rule is met. Services were provided to 2+ non-associated entities as a direct result of offers to the public (website, tenders) -> **unrelated clients test met (s 87-20)**; Mia self-assesses as a PSB. Consequences: no deduction limits, no attribution (she is the individual anyway). The income **retains its PSI character** -- she declares it at the PSI labels of her return, and the $1,000 standard deduction is unavailable against it (Rule 12). Had Mia sourced the same five clients solely through a labour-hire firm's panel, s 87-20(2) would deny the "offers to the public" limb -- see R-AU-PSI-2.
+
+### Example 3 -- Company retains PSB profits: Part IVA risk zones
+
+EngCo Pty Ltd (a base rate entity) derives $300,000 from the engineering services of Priya, who genuinely passes the results test -- EngCo is a PSB, so no attribution. EngCo pays Priya a $90,000 salary, retains the balance, and pays franked dividends to Priya's non-working spouse, a 50% shareholder.
+
+```
+2026-27 comparison (resident rates, 15% first bracket from 1 Jul 2026)
+  Tax if Priya earned $300,000 directly:
+    $100,870 + Medicare $6,000              = $106,870
+  Arrangement as structured:
+    Priya on $90,000: $17,520 + $1,800      = $19,320
+    EngCo on $210,000 profit at 25%         = $52,500
+    Combined                                 = $71,820
+  Immediate saving/deferral                  = $35,050
+```
+
+PCG 2025/5 higher-risk indicators present: salary not commensurate with the value of Priya's services; retention of net PSI in a lower-taxed entity without a commercial purpose; splitting to a non-working associate (Guideline Examples 10-17). Franking on eventual distribution reduces but does not erase the benefit (deferral + choice of recipient). This file computes exposure only -- restructuring advice escalates (R-AU-PSI-6). A genuine move to a low-risk arrangement (full net PSI to Priya, taxed at her marginal rate) by 30 June 2027 is inside the ATO's stated transitional compliance approach (PCG 2025/5 para 11).
+
+---
+
+## Section 5 -- Tier 1 rules
+
+### Rule 1 -- What PSI is (s 84-5)
+
+Ordinary or statutory income that is **mainly** -- more than 50% -- a reward for an individual's personal efforts or skills. Assess contract by contract on the substance of what the payment rewards, not the invoice label. Only individuals have PSI, but a company, partnership or trust (a **personal services entity**, PSE) can receive it; the rules then operate per test individual. Almost any profession can earn PSI: IT contractors, engineers, medical practitioners, consultants, construction professionals.
+
+### Rule 2 -- What PSI is not
+
+Income mainly from: **supplying or selling goods**; **granting the use of income-producing assets** (e.g. plant hire, a truck where the payment mainly rewards the vehicle); or a **business structure** (substantial employees/practice assets generating the income rather than one person's exertion). A structure is not "business structure income" merely because a company exists, carries on a business, or qualifies as a PSB (PCG 2025/5 paras 18-20). Salary of a genuine employee is outside the PSI regime entirely (s 84-10 works the other way too -- see Rule 12). Professional firms with genuine structure income are PCG 2021/4 territory, not this file.
+
+### Rule 3 -- The gateway and the 80% rule (s 87-15)
+
+A PSE/individual conducts a PSB in an income year only if: the **results test** is met; or **less than 80%** of the individual's PSI comes from one client and its associates AND at least one of the other three tests is met; or a **PSB determination** is in force. At 80%-or-more concentration the unrelated clients, employment and business premises tests are unavailable to self-assessment no matter how clearly they would be satisfied -- only the results test or a PSBD helps. Apply the 80% rule per individual, aggregating each client with its associates.
+
+### Rule 4 -- Results test (s 87-18)
+
+Met if **at least 75% of the individual's PSI** for the year satisfies ALL three conditions, judged against custom or practice for independent contractors (s 87-18(4)):
+
+1. the income is for producing a **result** (payment contingent on outcome -- hourly/daily rates generally fail);
+2. the individual/entity is required to **supply the plant, equipment or tools of trade** needed to do the work (where the work genuinely needs none, the condition can still be satisfied -- TR 2022/3); and
+3. the individual/entity **is or would be liable for the cost of rectifying defective work** (a real exposure to rectify at own cost, not a right of the client to terminate).
+
+The results test is the only test available regardless of client concentration. Mixed contract books are common: measure the percentage of PSI dollars meeting all three limbs, not the number of contracts.
+
+### Rule 5 -- Unrelated clients test (s 87-20)
+
+Both limbs, in the income year: (a) PSI from **2 or more clients** who are not associates of each other or of the individual/PSE; and (b) the services are provided **as a direct result of making offers or invitations to the public or a section of the public** -- advertising, a public website, competitive tenders; word-of-mouth referrals can qualify in narrow, specialised markets (TR 2022/3). **Statutory carve-out:** merely being available through an entity whose business is arranging for persons to provide services to its clients (labour-hire firms, some agencies/platforms) is NOT making offers to the public (s 87-20(2)). Failing limb (b) with otherwise-plentiful clients is the most common practitioner error.
+
+### Rule 6 -- Employment test (s 87-25)
+
+Met if the entity/individual engages one or more others who perform **at least 20% (by market value) of the principal work** for the year, or has **one or more apprentices for at least half the year**. The test individual never counts toward it; for individuals, non-individual associates count only where the work is performed by others. "Principal work" is the work generating the PSI, not administration or bookkeeping.
+
+### Rule 7 -- Business premises test (s 87-30)
+
+**At all times** during the income year, the individual/PSE maintains AND uses business premises: (a) at which the PSI-producing activities are mainly conducted; (b) of which they have **exclusive use**; (c) **physically separate from private premises** of the individual/associates; and (d) **physically separate from the premises of the client** (and client's associates). The premises need not be the same all year, but there must be qualifying premises for every day. Home offices fail (c); a rented room without exclusive use fails (b); shared reception areas do not count.
+
+### Rule 8 -- PSB determinations (ss 87-60, 87-65)
+
+When self-assessment is unavailable -- typically 80%+ concentration, or a test narrowly missed -- the PSE/individual can apply for a **PSBD**. The Commissioner may make one where satisfied a test was met or **could reasonably be expected to be met but for unusual circumstances** (e.g. starting out while genuinely advertising to the public with a reasonable expectation of unrelated clients; temporary loss of a client; natural disasters interrupting premises -- TR 2022/3 example of flood-delayed premises). For the results/unrelated-clients routes at 80%+ concentration the ATO also looks to whether the income could have come from unrelated clients. Determinations operate for specified years and can be revoked on changed facts. **Preparing or lodging an actual PSBD application escalates -- R-AU-PSI-4.** This file only identifies candidacy.
+
+### Rule 9 -- Consequences: attribution and PAYG (Div 86; TAA 1953 Sch 1 Divs 12-13)
+
+Where the PSI rules apply to PSI received by a PSE:
+
+- **Attribution (s 86-15):** the individual's assessable income includes the entity's income that is that individual's PSI, EXCEPT amounts promptly paid to the individual as salary (within 14 days after the end of the relevant PAYG payment period) -- those are salary in the ordinary way.
+- **Net amount (s 86-20):** the attributed amount is reduced by the entity's deductions relating to that PSI (after the Rule 10 limits). If deductions exceed the PSI, the excess flows to the individual (s 86-27).
+- **No double tax (s 86-30):** attributed income is neither assessable nor exempt income of the entity.
+- **PAYG:** the entity withholds under Div 12 on salary actually paid AND must pay amounts to the Commissioner under **Div 13** in respect of attributed (alienated) PSI quarterly, reporting the attributed income to the individual annually. Missed Div 13 obligations are a standing audit flag.
+- Sole traders whose PSI is caught face the Rule 10 deduction limits directly (no attribution needed) and report at the PSI labels.
+
+### Rule 10 -- Consequences: deduction limits (Div 85; Subdiv 86-B)
+
+The organising principle: **no better than an employee**. Against PSI, the individual (s 85-10) -- and derivatively the PSE (s 86-60) -- can deduct only what an employee earning that income could deduct, plus a short statutory list. Specifically DENIED:
+
+- **rent, mortgage interest, rates, land tax** for the residence of the individual or an associate used for PSI work (s 85-15) -- the classic home-office occupancy claim;
+- **payments to associates** (salary, super) for **non-principal work** -- admin, bookkeeping, secretarial support (s 85-20); payments to associates for principal work remain deductible;
+- **car expenses beyond one car** used partly privately at a time (s 85-25; s 86-70);
+- general entity running costs beyond **entity maintenance deductions** -- the allowed list is narrow: financial-institution account fees, s 25-5 tax-related expenses, Corporations Act document/lodgment costs, statutory fees (s 86-65, applied first against the entity's other income).
+
+Still DEDUCTIBLE (s 85-10(2) and TR 2022/3): costs of gaining work (advertising, tendering, quoting), insuring against income loss, public liability and professional indemnity premiums, GST-related amounts, engaging others (non-associates, or associates for principal work), super for those workers, and the employee-style claims themselves (running expenses for a home work area, tools, self-education with nexus). s 85-30 switches Div 85 off where the individual is conducting a PSB; s 85-35 keeps employees and office-holders out of Div 85 entirely.
+
+### Rule 11 -- PSB does not mean safe: Part IVA and PCG 2025/5
+
+Passing a PSB test switches off Divs 85-86 only. The note to s 86-10, TR 2022/3 (para 161's income-splitting considerations) and **PCG 2025/5** (issued 28 November 2025, finalising PCG 2024/D2; applies before and after issue) all confirm **Part IVA of the ITAA 1936** can still cancel the tax benefit from alienation arrangements -- income splitting or retention of profits -- where the dominant purpose is a tax benefit (s 177D eight-factor test; *Tupicoff*, *Gulland*, *Mochkin*, *Hart*).
+
+| PCG 2025/5 zone | Markers | ATO posture |
+|---|---|---|
+| **Low risk** (Examples 1-9) | Entire net PSI assessed to the doing individual in the year earned, at marginal rates; remuneration commensurate with services; associate wages reasonable for bona fide work; superannuation for the individual; temporary retention with a genuine commercial purpose carried out; deferrals explained by events outside control (illness) | Compliance resources will not be applied |
+| **Higher risk** (Examples 10-17) | Net PSI diverted so it is taxed at an overall lower rate; individual's remuneration below the value of their services; nil distribution to the doer; splitting to lower-taxed associates; associate pay not commensurate with their actual services; retention beyond commercial needs -- retention of PSI is of itself a higher-risk indicator, including where retained funds return via complying Div 7A loans | Increased likelihood of review and Part IVA consideration; materiality of the diverted amount drives prioritisation |
+
+There is **no safe percentage of diversion** (para 41). Record-keeping expectations are extensive (contracts, timesheets, minutes, resolutions, contemporaneous purpose notes -- paras 43-47). Transitional: no Part IVA compliance pursuit for genuine moves to low-risk arrangements by **30 June 2027** (para 11). Spousal partnerships sit outside the Guideline's focus but artificial no-contribution partnerships still raise Part IVA (paras 16-17). Screening against the table is in scope; **any Part IVA position or restructure design escalates (R-AU-PSI-6)**.
+
+### Rule 12 -- Boundaries: employees, sham contracting, and the $1,000 standard deduction
+
+- **PSI rules do not make anyone an employee** (s 84-10): super guarantee, payroll tax, workers comp and Fair Work status are decided under their own laws.
+- **Employee in substance?** If the "contractor" is actually an employee (contract-rights analysis per *Personnel Contracting* [2022] HCA 1; TR 2023/4), the payer has PAYG/SG obligations and the PSI analysis is moot. Representing an employment relationship as independent contracting risks **sham contracting** penalties (Fair Work Act ss 357-359). Reclassification questions escalate (R-AU-PSI-5).
+- **Standard deduction excluded:** the up-to-**$1,000 standard deduction** for work-related expenses (Treasury Laws Amendment (Tax Reform No. 1) Act 2026 Sch 4; from 1 July 2026, first applying to 2026-27 returns) is for employment-style work income and does **not** apply to taxpayers whose relevant income is PSI or business income -- substantiated actual claims continue for them. Never net it against PSI or attributed amounts.
+
+---
+
+## Section 6 -- Tier 2 catalogue and refusal codes
+
+### T2-1 / R-AU-PSI-1 -- Agents regime (s 87-40)
+
+**Trigger:** commission agents (financial services, insurance, real estate) representing a principal but bearing entrepreneurial risk. **Issue:** s 87-40 modifies the 80% rule and unrelated clients test so the principal's customers count as the agent's clients -- but only where the agent is not an employee, receives at least **75% of the income as commission/results-based payments** (retainers count against the 75%), actively seeks customers, and does not work from the principal's premises except at arm's length. **Action:** identify the pattern, cite the conditions, REFUSE the detailed analysis and escalate.
+
+### T2-2 / R-AU-PSI-2 -- Labour-hire and platform engagements
+
+**Trigger:** income sourced through labour-hire firms, recruitment agencies or intermediary platforms. **Issue:** s 87-20(2) blocks the offers-to-the-public limb; separate labour-hire PAYG rules (TAA Sch 1) may apply to the payer; the worker may be an employee of the labour-hire firm. **Action:** flag that the unrelated clients test is generally unavailable; refuse characterisation of the tripartite arrangement; escalate.
+
+### T2-3 / R-AU-PSI-3 -- Foreign PSI and non-residents
+
+**Trigger:** PSI earned overseas, foreign residents earning Australian PSI, or attribution across borders. **Issue:** residency, source, DTA article interactions (income from employment vs independent personal services vs business profits) sit on top of Divs 84-87. **Action:** REFUSE; collect the contract, residency and location facts; escalate to a cross-border specialist.
+
+### T2-4 / R-AU-PSI-4 -- PSBD applications
+
+**Trigger:** client asks to apply for a PSB determination, or self-assessment is unavailable and a PSBD looks arguable. **Issue:** applications turn on evidence of unusual circumstances and forward expectations; a wrong application invites review of prior years. **Action:** identify candidacy and assemble the fact pattern only; REFUSE to prepare or lodge; escalate to the reviewer/tax agent.
+
+### T2-5 / R-AU-PSI-5 -- Employee reclassification / sham contracting
+
+**Trigger:** single payer, payer's tools and premises, payer control, no delegation right, or the payer asks how to "make them a contractor". **Action:** REFUSE structuring; flag PAYG, SG, payroll tax and Fair Work exposure; escalate.
+
+### T2-6 / R-AU-PSI-6 -- Part IVA positions and alienation restructures
+
+**Trigger:** designing salary levels, dividend/distribution flows or retention policies for a PSB; responding to an ATO Part IVA review; reliance on low-risk status for a marginal arrangement. **Action:** compute exposure and map the arrangement against the Rule 11 tables ONLY; REFUSE dominant-purpose opinions and restructure design; escalate. Check Div 7A whenever retained profits fund loans to the individual (see au-div7a).
+
+---
+
+## Section 7 -- Excel working paper template
+
+```
+AUSTRALIA PSI -- DECISION AND ATTRIBUTION REGISTER
+Entity/individual: [name]   Test individual(s): [names]   Income year: 2026-27
+Prepared: [date]
+
+STEP 1 -- PSI IDENTIFICATION (per contract)
+  Contract / client:                [____]
+  Amount:                           AUD [____]
+  Mainly (>50%) reward for personal efforts/skills? [Y/N -- basis]
+  Goods / asset-use / business-structure component: AUD [____]
+
+STEP 2 -- PSB TESTS (per test individual)
+  Results test: % of PSI meeting result + tools + defect liability: [__%]  (need >= 75%)
+  Client concentration: largest client + associates share: [__%]  (>= 80% blocks other tests)
+  Unrelated clients: 2+ non-associated clients? [Y/N]  Offers to public evidenced? [Y/N]
+  Employment: others perform >= 20% of principal work by market value? [Y/N]
+  Business premises: mainly-PSI / exclusive / separate from home / separate from client,
+    at ALL times? [Y/N x 4]
+  PSBD in force? [Y/N -- years covered]
+  CONCLUSION: PSB? [Y/N -- which test]
+
+STEP 3 -- IF PSI RULES APPLY
+  PSI received by entity:            AUD [____]
+  less salary promptly paid (14-day rule): AUD [____]
+  less deductible outgoings (employee-style + s 86-65 list): AUD [____]
+  add back DENIED items:
+    rent/mortgage/rates to associate residence: AUD [____]
+    associate non-principal work payments:      AUD [____]
+    second-car expenses:                        AUD [____]
+  = NET PSI ATTRIBUTED (s 86-15/86-20): AUD [____]
+  Div 13 PAYG remitted on attributed amounts? [Y/N -- amounts]
+
+STEP 4 -- IF PSB: PCG 2025/5 SCREEN
+  Net PSI assessed to the doing individual this year? [Y/N]
+  Remuneration commensurate with services? [Y/N]
+  Retention -- amount, stated commercial purpose, carried out? [____]
+  Distributions to associates -- recipient, services provided, amount: [____]
+  Zone assessment: [LOW / HIGHER -- indicators]
+
+REVIEWER FLAGS
+  [R-AU-PSI codes triggered; unresolved facts]
+```
+
+---
+
+## Section 8 -- Reading guide
+
+1. Identify PSI contract-by-contract before any test: the >50% "mainly" question comes first, and goods/asset components can split a single invoice.
+2. The 80% rule is a gate on self-assessment, not a definition of PSI -- clients conflate them constantly.
+3. Hourly rates are the tell: they usually sink the results test's first limb regardless of how skilled the work is.
+4. For the unrelated clients test, count only clients won by offers to the public -- the labour-hire carve-out (s 87-20(2)) is the most-missed subsection in the Division.
+5. PSB status ends the Div 85/86 analysis and starts the Part IVA one. Never write "PSI rules don't apply" without the PCG 2025/5 screen attached.
+
+---
+
+## Section 9 -- Reference material
+
+### Key figures
+
+| Item | Value |
+|---|---|
+| "Mainly" threshold (PSI definition) | More than 50% of the reward (s 84-5) |
+| Results test coverage | >= 75% of the individual's PSI, all 3 conditions (s 87-18) |
+| 80% rule | < 80% from one client + associates to self-assess the other tests (s 87-15(3)) |
+| Employment test | >= 20% of principal work by market value, or apprentice(s) >= half the year (s 87-25) |
+| Business premises test | All 4 conditions at all times in the year (s 87-30) |
+| Salary carve-out from attribution | Paid as salary within 14 days after the PAYG payment period (s 86-15(4)) |
+| Agents regime commission floor | >= 75% commission/results-based (s 87-40) |
+| Standard deduction (2026-27) | Up to $1,000; work expenses; EXCLUDES PSI/business-only earners |
+| PCG 2025/5 transition | Genuine move to low-risk arrangement by 30 June 2027 |
+
+### Primary sources (verified 20 August 2026)
+
+| Topic | Source |
+|---|---|
+| Statute | ITAA 1997 Part 2-42: Divs 84, 85, 86, 87 (ss 84-5, 85-10 to 85-35, 86-15, 86-20, 86-30, 86-60 to 86-70, 87-15, 87-18, 87-20, 87-25, 87-30, 87-40, 87-60, 87-65); ITAA 1936 Part IVA |
+| Core ruling | TR 2022/3 Income tax: personal services income and personal services businesses |
+| Part IVA guideline | PCG 2025/5 Personal services businesses and Part IVA (issued 28 Nov 2025; finalised PCG 2024/D2); PS LA 2005/24; IT 2121, IT 2330, IT 2503, IT 2639; TR 2003/6 |
+| PAYG on attributed PSI | TAA 1953 Sch 1 Divs 12 and 13 |
+| ATO guidance pages | PSI hub QC 16906; results test QC 46006; self-assessing/80% rule QC 46014; PSI-rules flow QC 70976; PSI decision tool QC 47696 |
+| Standard deduction | Treasury Laws Amendment (Tax Reform No. 1) Act 2026 (Sch 4); ATO new-legislation page QC 107405 (updated 26 June 2026) |
+| Employee/contractor | *CFMMEU v Personnel Contracting* [2022] HCA 1; *ZG Operations v Jamsek* [2022] HCA 2; TR 2023/4; Fair Work Act 2009 ss 357-359 |
+
+### Test suite
+
+**Test 1:** Company invoices $150,000 for its director's consulting, hourly rate, client's tools, no defect liability. -> PSI; results test fails; check 80% rule next.
+
+**Test 2:** 75% of PSI dollars meet all three s 87-18 limbs, one client pays 95% of income. -> Results test met at exactly 75%; PSB despite concentration.
+
+**Test 3:** Four unrelated clients (largest 40%) all sourced from a recruiter's panel. -> 80% rule met but s 87-20(2) defeats the offers-to-public limb; unrelated clients test fails.
+
+**Test 4:** Contractor's spouse does 25% (market value) of the principal design work as an employee. -> Employment test met; PSB if <80% concentration.
+
+**Test 5:** "Business premises" is a dedicated home-office wing. -> Fails s 87-30(c) physical separation; test not met.
+
+**Test 6:** PSE with $200,000 PSI, $120,000 prompt salary, $10,000 deductible costs, $15,000 rent paid to the individual for his house. -> Attribution = 200,000 - 120,000 - 10,000 = $70,000; the $15,000 is denied and ignored.
+
+**Test 7:** Deductions relating to PSI exceed the PSI by $5,000. -> Excess flows to the individual (s 86-27).
+
+**Test 8:** PSB company pays the doer 100% of net PSI as salary + super at the cap. -> PCG 2025/5 low risk (superannuation for the individual is a low-risk indicator).
+
+**Test 9:** PSB trust distributes 60% of net PSI to a non-working beneficiary. -> Higher risk (splitting, remuneration not commensurate); escalate R-AU-PSI-6.
+
+**Test 10:** Employee asks to claim the $1,000 standard deduction; sole trader with only PSI asks the same. -> Employee yes (2026-27 onward); PSI earner no.
+
+### Prohibitions
+
+- NEVER treat an ABN, company or trust as taking income outside PSI -- structure is irrelevant to the s 84-5 definition
+- NEVER use the 80% rule as the PSI definition -- "mainly" (>50%) defines PSI; 80% only gates self-assessment
+- NEVER self-assess the unrelated clients, employment or business premises tests at >= 80% single-client concentration
+- NEVER pass the results test on an hourly-rate contract without documented result-basis, tools and defect liability
+- NEVER count labour-hire or agency panel availability as offers to the public
+- NEVER deduct rent/mortgage interest to the individual or an associate, associate non-principal wages, or a second private-use car against PSI
+- NEVER claim the $1,000 standard deduction against PSI
+- NEVER treat PSB status as Part IVA protection -- run the PCG 2025/5 screen every time
+- NEVER design salary/distribution/retention levels, prepare PSBD applications, or opine on dominant purpose -- compute, flag, escalate
+- NEVER present figures as definitive
+
+---
+
+## Disclaimer
+
+This skill and its outputs are provided for informational and computational purposes only and do not constitute tax, legal, or financial advice. Open Accountants and its contributors accept no liability for any errors, omissions, or outcomes arising from the use of this skill. All outputs must be reviewed and signed off by a qualified professional (such as a CPA, CA, tax agent, or equivalent licensed practitioner in your jurisdiction) before filing or acting upon.
+
+The most up-to-date, verified version of this skill is maintained at [openaccountants.com](https://www.openaccountants.com). Log in to access the latest version, request a professional review from a licensed accountant, and track updates as tax law changes.
+
+<!-- openaccountants-cta-block -->
+
+---
+
+## Talk to a verified accountant
+
+This guide is maintained by the OpenAccountants network — accountants who put
+their name behind the tax answers AI gives people. The live, always-current
+version (and the professional behind it) is at
+[openaccountants.com](https://www.openaccountants.com).
+
+- Use it in your AI: https://www.openaccountants.com/connect
+- Meet the accountants: https://www.openaccountants.com/network
+
+> **General reference only.** This document does not constitute tax, legal, or
+> financial advice. Verify figures against the cited primary sources or with a
+> licensed professional before relying on them.

--- a/skills/international/australia/au-rates-2026-27.md
+++ b/skills/international/australia/au-rates-2026-27.md
@@ -1,0 +1,160 @@
+---
+name: au-rates-2026-27
+description: Use this skill whenever you need a current Australian tax rate, threshold, cap or due date for the 2026-27 or 2025-26 income year -- individual brackets, HELP repayment, Medicare levy and surcharge, super guarantee and contribution caps, Division 296, company rates, Div 7A benchmark, FBT, CGT caps and concessions, GST, PAYG instalment uplift, cents-per-km, car limits, penalty units, payroll tax, minimum wage or ASIC fees. Single-page rates card; every figure carries its source. Trigger on "what is the current rate", "2026-27 threshold", "how much is the cap", or any AU figure lookup. Load alongside the topic guide.
+version: "1.0"
+jurisdiction: AU
+tax_year: 2026
+tax_year_notes: "2026-27 primary; 2025-26 retained for lodgment-season work"
+last_updated: 2026-08-20
+review_status: pending_review
+category: international
+tier: 2
+license: AGPL-3.0-or-later (code) / OpenAccountants Guide License v1.0 (content)
+---
+
+# Australia Rates Card 2026-27 (with 2025-26) v1.0
+
+> **General reference only.** This skill is general tax/accounting reference material for AI-assisted workflows. It has not been reviewed for any specific person's facts, documents, elections, deadlines, residency, filing status, or local procedures. Do not rely on it to file, pay, amend, or take a tax position without review by a qualified professional in the relevant jurisdiction.
+
+Single-page lookup for the figures every other Australian guide relies on. Each row names its primary source. Verified against those sources on 20 August 2026. Deeper rules live in the topic guides named in each section; this card never overrides them.
+
+## Individual income tax
+
+**Resident brackets**
+
+| Taxable income | 2025-26 rate | 2026-27 rate |
+| --- | --- | --- |
+| $0 -- $18,200 | 0% | 0% |
+| $18,201 -- $45,000 | 16% | **15%** |
+| $45,001 -- $135,000 | 30% | 30% |
+| $135,001 -- $190,000 | 37% | 37% |
+| $190,001+ | 45% | 45% |
+
+Tax on full bands: 2025-26 -- $4,288 at $45,000, $31,288 at $135,000, $51,638 at $190,000. 2026-27 -- $4,020 / $31,020 / $51,370. The 15% rate falls to **14% from 1 July 2027**. _(ATO QC 73320; Treasury Laws Amendment (More Cost of Living Relief) Act 2025)_
+
+**Non-residents:** no tax-free threshold; 30% from $0 to $135,000 (2026-27), then resident bands. No Medicare levy.
+
+**Offsets and deductions**
+
+| Item | Value | Source |
+| --- | --- | --- |
+| LITO | $700 to $37,500; taper 5c/$1 to $45,000; then 1.5c/$1 to nil at $66,667 | ATO Low income tax offset |
+| SBITO | 16% of tax on net small business income, cap $1,000, turnover < $5m | ITAA 1997 Subdiv 328-F |
+| $1,000 standard WRE deduction | From 1 July 2026 (2026-27 returns). Excludes PSI and business-only earners | Tax Reform No. 1 Act 2026 Sch 4; QC 107405 |
+| WFH fixed rate | 70c/hour (2024-25 through 2026-27) | PCG 2023/1 |
+| Cents per km | 88c (2025-26); **91c (2026-27)**, cap 5,000 business km | ATO cents-per-km rates |
+| Car limit (depreciation) | $69,674 (2025-26); **$69,883 (2026-27)** | ATO car thresholds |
+
+## HELP/study loans (2025-26 onwards: marginal system)
+
+Repayment income = taxable income + reportable fringe benefits + reportable super + exempt foreign income + net investment losses.
+
+| Repayment income (2025-26) | Marginal repayment rate |
+| --- | --- |
+| Below $67,000 | Nil |
+| $67,001 -- $125,000 | 15% of excess over $67,000 |
+| $125,001 -- $179,285 | $8,700 + 17% of excess over $125,000 |
+| $179,286+ | 10% of repayment income (cap rule) |
+
+One-off 20% debt reduction applied before 1 June 2026 indexation; thresholds index for 2026-27 (confirm current-year bands at ATO study loan repayment thresholds before computing). _(Education and Other Legislation Amendment (VET Fee Protection and Other Measures) Act 2025; ATO QC 103927)_
+
+## Medicare
+
+| Item | 2025-26 | Source |
+| --- | --- | --- |
+| Levy | 2% of taxable income | MLA 1986 |
+| Low-income threshold (single) | $28,011 / shade-in to $35,013 | ATO QC 27031 |
+| Low-income threshold (family) | $47,238 + $4,338 per child | ATO QC 27031 |
+| SAPTO single | $44,268 / $55,335 | ATO QC 27031 |
+| MLS base tier | Single $101,000 / family $202,000 (then 1% / 1.25% / 1.5%) | ATO MLS thresholds |
+| PHI rebate (base, under 65) | 24.288% to 31 Mar 2026; 24.118% from 1 Apr 2026 | PHI Circular 12/26 |
+
+2026-27 Medicare low-income thresholds index with CPI; confirm at ATO QC 27031 when lodging 2026-27.
+
+## Superannuation
+
+| Item | 2025-26 | 2026-27 | Source |
+| --- | --- | --- | --- |
+| SG rate | 12% | 12% (terminal) | ATO SG rates |
+| Payment deadline | Quarterly (28th) | **Payday super: fund receipt within 7 business days of each payday from 1 Jul 2026** | payday super law; au-super-guarantee |
+| Concessional cap | $30,000 | **$32,500** | ATO contributions caps |
+| Non-concessional cap | $120,000 | **$130,000** | ATO contributions caps |
+| NCC bring-forward (TSB at prior 30 June) | <$1.76m: $360k/3yr | <$1.84m: $390k/3yr; $1.84--<$1.97m: $260k/2yr; $1.97--<$2.1m: $130k; >=$2.1m: nil | ATO contributions caps |
+| General transfer balance cap | $2.0m | **$2.1m** | ATO TBC |
+| CGT cap amount | $1,865,000 | **$1,935,000** | ATO key super rates |
+| Div 293 threshold | $250,000 (frozen) | $250,000 | ATO Div 293 |
+| Div 296 | -- | **First year: extra 15% on earnings share of TSB $3m--$10m; extra 25% above $10m; indexed; realised-earnings basis** | Building a Stronger and Fairer Super System Act 2026 |
+| Downsizer | $300,000 from age 55 | $300,000 | ATO downsizer |
+| SG maximum contribution base | $62,500/quarter | **$270,830/year (annual basis under payday super)** | ATO Super guarantee page |
+
+## Companies
+
+| Item | Value | Source |
+| --- | --- | --- |
+| BRE rate | 25% (turnover < $50m AND <= 80% BREPI) | ITRA 1986 ss 23AA-23AB |
+| Standard rate | 30% | ITRA 1986 |
+| Franking | At 25%: credit = distribution / 3. At 30%: x 3/7 | au-company-tax |
+| Loss carry-back | ENDED (2019-20 to 2022-23 claim years only) | former Div 160 |
+| Div 7A benchmark | 8.37% (2025-26); **8.77% (2026-27)** | ATO Div 7A rates |
+| PAYG GDP uplift | 4% (2025-26); **5% (2026-27)** | ATO GDP adjustment |
+| Amendment period (SMB) | 4 years for 2024-25+ assessments | ATO amendment periods |
+
+## FBT (year ending 31 March 2027)
+
+| Item | Value | Source |
+| --- | --- | --- |
+| Rate | 47% | FBTAA 1986 |
+| Type 1 / Type 2 gross-up | 2.0802 / 1.8868 | ATO FBT rates |
+| RFBA trigger | > $2,000 taxable value; report x 1.8868 | ATO RFBA |
+| EV exemption | Battery/hydrogen cars only; PHEVs out from 1 Apr 2025 (grandfathering); wind-back announced from 1 Apr 2027, not law | au-fbt Rule 5 |
+| EV home-charging shortcut | 5.47c/km (FBT year from 1 Apr 2026) | PCG 2024/2 |
+| Record-keeping exemption base | $10,962 (FBT 2026-27) | au-fbt Rule 12 |
+
+## CGT
+
+| Item | Value | Source |
+| --- | --- | --- |
+| Discount | 50% individuals/trusts (assets 12+ months); one-third super funds; nil companies | ITAA 1997 Div 115 |
+| **Reform from 1 Jul 2027** | Gains accruing from 1 Jul 2027: indexation + 30% minimum rate replaces the 50% discount (individuals/trusts/partnerships); deemed re-acquisition 30 Jun 2027 | Tax Reform No. 1 Act 2026; au-capital-gains |
+| FRCGW | 15%, no threshold, contracts from 1 Jan 2025; clearance certificate mandatory for resident vendors | TLA (2024 Tax and Other Measures No. 1) Act 2024; QC 26663 |
+| Div 152 gateways | $2m CGT SBE turnover / $6m MNAV | au-small-business-cgt |
+| Retirement exemption | $500,000 lifetime | Subdiv 152-D |
+
+## GST and indirect
+
+| Item | Value | Source |
+| --- | --- | --- |
+| Rate / registration | 10% / $75,000 ($150,000 NFP; $1 taxi-rideshare) | GST Act |
+| Instant asset write-off | $20,000 per asset (turnover < $10m) legislated to 30 Jun 2026; permanence from 1 Jul 2026 announced, confirm enactment | ATO QC 103578 |
+| Penalty unit | $330 (7 Nov 2024 -- 30 Jun 2026); **$364 from 1 Jul 2026** | ATO QC 71196 |
+| GIC | **Not deductible from 1 Jul 2025** (SIC likewise) | Tax Incentives and Integrity Act 2025; QC 73746 |
+
+## Employers
+
+| Item | Value | Source |
+| --- | --- | --- |
+| National minimum wage | **$26.44/hr, $1,004.90/wk from 1 Jul 2026** ($24.95 / $948.10 prior) | FWC AWR 2025-26 |
+| Payroll tax NSW | 5.45%, $1.2m threshold | Revenue NSW |
+| Payroll tax VIC | 4.85% (regional 1.2125%), $1.0m; surcharges >$10m | SRO Vic |
+| Payroll tax QLD | 4.75% <=$6.5m / 4.95% above; $1.3m deduction phasing to $10.4m | QRO |
+| Other states | WA 5.5%/$1m; SA 0-4.95%/$1.5m; TAS 4%+6.1%/$1.25m; ACT 6.85%/$2m; NT 5.5%/$1.5m | state revenue offices |
+| ASIC annual review (Pty Ltd) | **$342 from 1 Jul 2026** ($329 prior); registration $636; SMSF special purpose $70 | ASIC fee indexation |
+
+## Maintenance rule
+
+This card is the single place indexed figures live outside their topic guides. When any figure above changes: update the topic guide first, then this card in the same PR, and advance both `last_updated` fields. Rows sourced to a topic guide (au-fbt, au-company-tax) must never disagree with that guide; where they do, the topic guide wins and this card is the bug.
+
+## Provenance
+
+All figures verified 20 August 2026 directly against: ato.gov.au rate pages (QC 73320, 27031, 71196, 73746, 103578, 103927, contributions caps, key super rates, car thresholds, Div 7A rates, GDP adjustment), Department of Health PHI Circular 12/26, Revenue NSW / SRO Vic / QRO current-rates pages, FWC Annual Wage Review 2025-26 decision, ASIC fee indexation page (1 July 2026), and the amending Acts named inline.
+
+<!-- openaccountants-cta-block -->
+
+## Talk to a verified accountant
+
+This guide covers the mechanical rules. For anything touching judgement -- residency, structuring, disputes, amounts that matter -- speak to a verified accountant on Open Accountants.
+
+- Browse verified professionals: https://www.openaccountants.com
+- Meet the accountants: https://www.openaccountants.com/network
+
+> **General reference only.** This document does not constitute tax, legal, or accounting advice. Verify current rates and rules against primary sources before acting. Figures and thresholds change; the tax year stated in the front matter governs.

--- a/skills/international/australia/au-small-business-cgt.md
+++ b/skills/international/australia/au-small-business-cgt.md
@@ -1,0 +1,423 @@
+---
+name: au-small-business-cgt
+description: >
+  Use this skill whenever an Australian small business owner, company, trust or partnership asks about the Division 152 small business CGT concessions -- selling a business, premises, goodwill, or shares/units in a trading entity; the $2m turnover or $6m maximum net asset value gateways; the active asset test; the 15-year exemption; the 50% active asset reduction; the retirement exemption; the small business rollover; significant individual or CGT concession stakeholder tests; or contributing sale proceeds to super under the CGT cap. Trigger on "small business CGT", "SBCGT", "Div 152", "active asset", "retirement exemption", "CGT cap election". ALWAYS read this skill before touching any Div 152 work.
+version: 1.0
+jurisdiction: AU
+tax_year: 2026
+tax_year_notes: "2026-27"
+last_updated: 2026-08-20
+review_status: pending_review
+category: international
+tier: 2
+license: AGPL-3.0-or-later (code) / OpenAccountants Guide License v1.0 (content)
+---
+
+# Australia Small Business CGT Concessions -- Division 152 Skill v1.0
+
+> **General reference only.** This skill is general tax/accounting reference material for AI-assisted workflows. It has not been reviewed for any specific person's facts, documents, elections, deadlines, residency, filing status, or local procedures. Do not rely on it to file, pay, amend, or take a tax position without review by a qualified professional in the relevant jurisdiction.
+
+> **Law-change context (Tax Reform No. 1 Act 2026, Royal Assent 26 June 2026).** From **1 July 2027** the *Treasury Laws Amendment (Tax Reform No. 1) Act 2026* replaces the general 50% CGT discount for individuals and trusts (including gains flowing through partnerships) with **cost-base indexation plus a 30% minimum tax rate** on gains accruing from that date, deems assets held on 30 June 2027 (including pre-CGT assets) re-acquired on 1 July 2027, and -- **enacted in the Act via amendments made during passage** -- lifts the aggregated turnover gateway for the **small business 50% active asset reduction only** from **$2 million to $10 million** from 1 July 2027. The other three Div 152 concessions keep the $2m/$6m gateways. Everything below states the law for CGT events happening **up to 30 June 2027**; Rule 15 maps the transition. Straddle and timing questions escalate (R-AU-SBC-5).
+
+## Section 1 -- Quick reference
+
+**Read this whole section before computing or classifying anything.**
+
+| Field | Value |
+|---|---|
+| Country | Australia |
+| Primary legislation | ITAA 1997 Division 152 (Subdivs 152-A to 152-E); s 292-100 (CGT cap contributions) |
+| Tax authority | Australian Taxation Office (ATO) |
+| Income year | 2026-27 (1 July 2026 -- 30 June 2027); lodgment season for 2025-26 |
+| Gateway tests (either) | CGT small business entity: aggregated turnover < $2m -- OR -- maximum net asset value (MNAV) <= $6m just before the CGT event |
+| Active asset test | Active for at least half the ownership period, or 7.5 years if owned > 15 years |
+| Significant individual | Small business participation percentage (SBPP) >= 20% (direct + indirect) |
+| CGT concession stakeholder | Significant individual, or their spouse with SBPP > 0% |
+| 15-year exemption | 15 years' continuous ownership + (55+ and in connection with retirement, or permanent incapacity) -- gain fully disregarded |
+| Retirement exemption | $500,000 lifetime limit per individual; under 55 must pay the amount into complying super/RSA |
+| Rollover replacement period | 1 year before to 2 years after the CGT event (extendable); exit via CGT events J2/J5/J6 |
+| CGT cap amount | **2026-27: $1,935,000; 2025-26: $1,865,000** (excluded from the NCC cap with a valid election) |
+| From 1 July 2027 | 50% reduction gateway becomes $10m aggregated turnover (law); general discount replaced by indexation + 30% minimum |
+| Contributor | Open Accountants |
+| Validated by | Pending |
+
+**Conservative defaults:**
+
+| Ambiguity | Default |
+|---|---|
+| Turnover unknown or near $2m | Do not assume the SBE gateway; compute MNAV; if both unproven, flag eligibility as unestablished |
+| Related entities not mapped | Assume connected/affiliated until control percentages (40%+) and "acts in concert" facts are verified |
+| Asset partly rented out | Assume main use is deriving rent (NOT active) until the affiliate/connected-entity carve-out or temporary-use facts are evidenced |
+| Discretionary trust, no distribution in event year | Assume no significant individual until prior-year distribution minutes are sighted (s 152-70 alternative rule) |
+| Prior retirement-exemption use unknown | Treat the remaining lifetime limit as unverified; require written records of every prior CGT exempt amount |
+| Taxpayer's age near 55 | Assume under 55 -- super payment required -- until DOB confirmed against the date the choice is made |
+| "In connection with retirement" unclear | Flag: requires at least a significant reduction in working hours/involvement, not necessarily permanent exit |
+| CGT event date near 30 June 2027 | Assume the post-reform regime may apply; escalate before any computation is relied on |
+| Contract vs settlement dates differ | CGT event A1 happens at CONTRACT date; test everything at that date |
+
+## Section 2 -- Eligibility decision tree
+
+| Step | Question | Yes | No |
+|---|---|---|---|
+| 1 | Pre-CGT asset (acquired before 20 Sep 1985)? | Escalate (R-AU-SBC-4) -- and note reform removes pre-CGT status from 1 July 2027 | Continue |
+| 2 | Gain from CGT event J5/J6 (failed earlier rollover)? | Skip to retirement exemption only (Rule 12) -- no discount, no AAR, no 15-year | Continue |
+| 3 | Gateway: CGT SBE (< $2m aggregated turnover), MNAV <= $6m, passively-held-asset rules, or partner rules satisfied? | Continue | STOP -- no Div 152; general discount only |
+| 4 | Active asset test met (Rule 5)? | Continue | STOP -- no Div 152 |
+| 5 | Asset is a share or trust interest? | Extra conditions (Rules 7-8): stakeholder/90% test + object entity test + modified active asset test. Fail any -> STOP | Continue |
+| 6 | 15-year exemption conditions met (Rule 9)? | Gain FULLY disregarded -- losses preserved, lifetime limits untouched; consider CGT cap contribution | Continue |
+| 7 | Waterfall | Capital losses -> general 50% discount (if eligible) -> 50% active asset reduction (automatic unless choose out) -> retirement exemption and/or rollover, in either order, to reduce the remainder (to nil if limits allow) | -- |
+
+## Section 3 -- Basic conditions (Subdiv 152-A)
+
+### Rule 1 -- The gateway: s 152-10
+
+A capital gain (except from CGT events D1, H2, J5, J6 for gateway purposes -- J5/J6 have their own path) may be reduced or disregarded if: (a) a CGT event happens to your asset; (b) the event would otherwise produce a gain; (c) you satisfy ONE of: CGT small business entity (< $2m aggregated turnover), the $6m MNAV test, the passively-held asset rules (s 152-10(1A)/(1B)), or the partner rules; and (d) the asset passes the active asset test. Shares/units carry extra conditions (Rules 7-8). Test everything at the time of the CGT event -- for a sale contract, the CONTRACT date.
+
+### Rule 2 -- CGT small business entity: aggregated turnover < $2 million
+
+"CGT small business entity" (s 152-10(1AA)) = would be a small business entity under s 328-110 if the $10m there read $2m. You must carry on a business in the event year and pass any one of: prior-year aggregated turnover < $2m; a reasonable current-year estimate < $2m (unavailable if actual turnover was $2m+ in BOTH of the two prior years); or actual current-year turnover < $2m. **Aggregated turnover** = your annual turnover + annual turnovers of entities **connected with you** (control >= 40%: shareholdings carrying >= 40% of voting/dividend/capital rights; for a discretionary trust, trustee acts on your directions or you received >= 40% of distributions in any of the 4 prior years) + turnovers of your **affiliates** (an individual or company that acts, or could reasonably be expected to act, on your directions or in concert with you -- spouses and children are NOT automatic affiliates), excluding inter-group dealings.
+
+### Rule 3 -- Maximum net asset value test: $6 million (s 152-20)
+
+Just before the CGT event, the sum of the **net values** (market value minus attached liabilities minus provisions for annual leave, long service leave, unearned income and tax) of the CGT assets of you, entities connected with you, and your affiliates (and entities connected with your affiliates) must not exceed **$6,000,000**. It is a cliff, not a phase-out, and it is NOT indexed. Count affiliate-side assets only if used (or held ready for use) in a business carried on by you or an entity connected with you.
+
+**Excluded assets** (individuals): your own **main residence** to the extent of private use -- if part is used to produce assessable income with deductible interest, include only that percentage of the dwelling's net value; **superannuation** and approved-deposit-fund rights; life insurance policies; assets used solely for personal use and enjoyment by you or your affiliate (boats, holiday homes never rented). Also disregard shares/interests in your own connected entities to avoid double counting (their underlying assets already count).
+
+### Rule 4 -- Passively-held assets and partners
+
+You can access Div 152 without carrying on a business where your asset is used in the business of your **affiliate or an entity connected with you**, and that business entity is the CGT small business entity (s 152-10(1A)/(1B)) -- the classic case: individual owns the premises, their trading company runs the business. A spouse or child under 18 is deemed an affiliate where their entity uses your asset (s 152-47). Partners: an interest in a partnership asset, or a partner's own asset used in the partnership business, qualifies where the partnership is the CGT SBE.
+
+## Section 4 -- Active asset test (s 152-35, s 152-40)
+
+### Rule 5 -- The period test
+
+The asset must be active for at least **half of the ownership period** (acquisition to CGT event, or to business cessation if the event happens within 12 months after cessation), or for at least **7.5 years** if owned for more than 15 years. The active periods do NOT need to be continuous. An asset is active if you, your affiliate, or an entity connected with you uses it (or holds it ready for use) in carrying on a business -- or, for intangibles (goodwill, licences), it is inherently connected with the business. Look at the asset as a whole, not just the portion used.
+
+### Rule 6 -- Excluded assets and the rent nuance
+
+**Never active:** assets whose main use is to derive rent, interest, an annuity, royalties or foreign exchange gains; financial instruments (loans, debentures, futures); shares and trust interests (unless the 80% test below is met); subdivided vacant land held passively.
+
+**The rent carve-out that saves most premises:** in working out "main use", **disregard rent derived from your affiliate or a connected entity that uses the asset in its business** (s 152-40(4A)) -- premises leased to your own trading company or trust ARE active. Rent from unrelated tenants counts against you: a building mainly let to third parties fails even if the business occupies part. Temporary rental use is also disregarded. Short-stay accommodation with substantial services and no exclusive possession (motel-style) may not be "rent" at all -- degree-of-control analysis (TD 2006/78); flag, don't assume.
+
+**The 80% test for shares/units as active assets:** a share in an Australian-resident company (or interest in a resident trust) is active where active assets plus inherently-connected cash and financial instruments are >= 80% of the market value of all its assets. Momentary or temporary dips below 80% are ignored.
+
+## Section 5 -- Shares and trust interests: extra conditions (s 152-10(2))
+
+### Rule 7 -- Significant individual, stakeholder, 90% test
+
+- **Small business participation percentage (SBPP)** = direct + indirect. Direct, for a company: the **smallest** of the percentages of voting power, dividend entitlement, and capital entitlement (all share classes except redeemable; discretionary dividend rights can drive it to 0%). For a trust where entitlements are not fixed: the smaller of the income and capital distribution percentages actually made **during the event year**; if the trustee distributed nothing and the trust had no net income or a tax loss that year, use the most recent prior distribution year (s 152-70). Indirect = your direct percentage in the interposed entity x its total percentage in the target.
+- **Significant individual**: SBPP >= 20% in the company or trust.
+- **CGT concession stakeholder**: a significant individual, or the spouse of one with SBPP > 0%.
+- **The 90% test**: where the entity CLAIMING the concession is itself a company or trust, CGT concession stakeholders in the object company/trust must together hold an SBPP of at least **90% in the claimant entity**.
+
+### Rule 8 -- The four extra conditions (gains from 8 February 2018)
+
+For a gain on shares or trust interests, ALL of:
+
+1. You either carried on a business just before the CGT event or you satisfy the MNAV test yourself;
+2. Just before the event, you are a CGT concession stakeholder in the object company/trust, OR the 90% test is met for the claimant entity;
+3. The object company/trust would itself be a CGT small business entity or satisfy the MNAV test, applying a **modified connected-entity rule** (deemed control at 20%+ when tracing what the object entity controls) so groups cannot be fragmented;
+4. The shares/units pass the **modified active asset test**: look through to the underlying assets; active assets + inherently-connected cash and financial instruments must be >= 80% of total market value, disregarding cash/instruments injected to pass the test, and ignoring temporary breaches.
+
+Gains made before 8 February 2018 faced fewer conditions -- historical only. These integrity rules kill many HoldCo sales: run them BEFORE the waterfall.
+
+## Section 6 -- The four concessions
+
+### Rule 9 -- 15-year exemption (Subdiv 152-B) -- always first
+
+The ENTIRE gain is disregarded (no cap) if: basic conditions are met; you **continuously owned the asset for the 15 years** ending just before the CGT event; and you are **55 or older** at the event and it happens **in connection with your retirement** (a significant reduction in hours/involvement suffices; permanent exit not required), or you are **permanently incapacitated** (no age requirement). Company/trust claimants must additionally have had a significant individual for periods totalling at least 15 years of ownership (not necessarily the same person or continuous), and the individual who is a significant individual just before the event must satisfy the 55+/retirement or incapacity limb. Payments of the exempt amount by a company/trust to its CGT concession stakeholders **within 2 years** of the event (capped by each stakeholder's participation percentage) are not assessable and not dividends (s 152-125). If the 15-year exemption applies, capital losses are NOT consumed and the other concessions are irrelevant. Death: the LPR/beneficiary can claim within 2 years of death to the extent the deceased could have (55+ just before death; no retirement connection needed).
+
+### Rule 10 -- 50% active asset reduction (Subdiv 152-C)
+
+Basic conditions only -- no extra tests. The remaining gain (after losses and the general discount) is reduced by 50%. It applies **automatically unless you choose for it not to apply**. Why skip it: a company or trust that skips the AAR can shelter a LARGER amount with the retirement exemption and pay it out tax-free to stakeholders -- the AAR-sheltered half otherwise sits in the company as untaxed profit that is an **unfranked dividend** (or CGT event G1/E4 issue) when extracted later. Companies never get the general discount; the AAR is their only 50%.
+
+### Rule 11 -- Retirement exemption (Subdiv 152-D)
+
+Disregard a chosen "CGT exempt amount" up to a **$500,000 lifetime limit per individual** (per CGT concession stakeholder for company/trust claimants -- also $500,000 each, reduced by earlier use). No requirement to actually retire or stop working. Keep a written record of every amount chosen. **Individuals under 55 just before making the choice** (the choice is generally made when the return is lodged -- turning 55 before then removes the requirement) must contribute the exempt amount to a complying super fund or RSA by the later of making the choice and receiving the proceeds. **Company/trust claimants** must PAY the exempt amount to at least one CGT concession stakeholder (capped by participation percentage) by 7 days after the later of making the choice and receiving capital proceeds; if the stakeholder is under 55 just before the payment, the entity must pay it into super on their behalf. The payment is NANE income of the stakeholder, not a dividend. Gains from CGT events J5/J6 can use this exemption without re-meeting the basic conditions.
+
+### Rule 12 -- Replacement asset rollover (Subdiv 152-E; CGT events J2/J5/J6)
+
+Defer all or part of the remaining gain by acquiring a **replacement active asset or making a 4th-element capital improvement** to an existing asset within the **replacement asset period: 1 year before to 2 years after** the CGT event (extendable by the Commissioner; extended automatically for look-through earnout rights). The same entity must choose and acquire. Replacement shares/units must pass the 80% test with a stakeholder connection maintained. Exit events:
+
+- **J5** -- no qualifying replacement (or it isn't active) at the end of the period: the whole rolled-over gain crystallises at that time.
+- **J6** -- replacement acquired but its cost (1st + 2nd element + improvement spend) is less than the rolled-over amount: the shortfall crystallises at the end of the period.
+- **J2** -- after the period, the replacement asset later changes status (sold, stops being active, becomes trading stock): the deferred gain revives then; a further rollover or the retirement exemption can be chosen.
+
+J5/J6 gains get NO general discount, NO 50% AAR and NO 15-year exemption -- only the retirement exemption (basic conditions not re-tested). Rolling over into nothing is therefore only a 2-year deferral, commonly used by 53-54 year-olds to reach 55 before a retirement-exemption choice (planning -- escalate, don't advise).
+
+## Section 7 -- Ordering and stacking
+
+### Rule 13 -- The waterfall and the arithmetic
+
+For each gain, in order: **(0)** 15-year exemption -- if it applies, stop, the gain never enters the net-capital-gain calculation; **(1)** capital losses (current then carried forward; taxpayer chooses allocation for pre-1 July 2027 events); **(2)** general 50% discount (individuals/trusts, asset held > 12 months; NEVER companies; not J2/J5/J6 gains); **(3)** small business 50% active asset reduction (automatic unless choose out); **(4)** retirement exemption and/or rollover on the remainder, in either order, until nil.
+
+```
+Individual, active asset held > 12 months, no losses, gain G:
+  after discount              G x 50%        = 0.50G
+  after 50% AAR               0.50G x 50%    = 0.25G   (25% inclusion)
+  tax at 47% top marginal     0.25G x 47%    = 11.75% effective
+  retirement exemption/rollover on 0.25G     -> 0% if within limits
+Trust beneficiary gross-up: x2 if one halving applied, x4 if both.
+Company: no discount -- AAR alone leaves 0.50G; 25% rate -> 12.5% effective,
+  and the sheltered half is untaxed profit with an extraction cost later.
+```
+
+The concessions apply per-asset, per-gain: with several gains you may stack every concession you qualify for on each until each is nil.
+
+## Section 8 -- CGT cap super contributions (s 292-100; QC 18123)
+
+### Rule 14 -- Getting sale proceeds into super outside the NCC cap
+
+Amounts sheltered by the **15-year exemption** (up to the whole **capital proceeds**, even though the gain was disregarded) and the **retirement exemption** (the CGT exempt amount, max $500,000) can be contributed to super and **excluded from the non-concessional contributions cap**, up to the lifetime **CGT cap amount**: **$1,935,000 for 2026-27** ($1,865,000 for 2025-26; indexed to AWOTE in $5,000 increments). Mechanics -- all three must hold, or the contribution counts as an ordinary NCC (2026-27 NCC cap: $130,000):
+
+1. **Form**: give the fund a **CGT cap election (NAT 71161) at or before the time the contribution is made** -- late is fatal;
+2. **Timing (individual)**: contribute by the later of the day the return for the event year is due to be lodged and 30 days after receiving the proceeds. The compulsory under-55 retirement-exemption payment automatically counts against the CGT cap;
+3. **Timing (via company/trust)**: the stakeholder contributes within 30 days after receiving the s 152-125 / s 152-325 payment.
+
+The CGT cap is a lifetime running total across both concessions. Contributions still count toward total super balance and transfer balance cap planning -- flag, don't advise.
+
+## Section 9 -- Interaction with the 1 July 2027 CGT reform
+
+### Rule 15 -- What is law and what is only announced (as at 20 August 2026)
+
+| Item | Status |
+|---|---|
+| *Treasury Laws Amendment (Tax Reform No. 1) Act 2026* | **Law** -- Royal Assent 26 June 2026 |
+| General 50% discount replaced by cost-base indexation + 30% minimum tax rate on gains accruing from 1 July 2027 (individuals and trusts, incl. gains through partnerships); discount retained for new residential dwellings and affordable housing | **Law** -- applies from 1 July 2027 |
+| Deemed disposal/re-acquisition of assets held 30 June 2027; later disposals split into pre/post components across four asset categories | **Law** -- from 1 July 2027 |
+| Pre-CGT (pre-20 Sep 1985) status removed after 30 June 2027 | **Law** |
+| Capital losses must be applied against discounted gains first | **Law** -- from 1 July 2027 (removes taxpayer choice) |
+| **Small business 50% active asset reduction gateway: aggregated turnover $2m -> $10m** | **Law** -- enacted in the Act (added by government amendments during passage), commencing **1 July 2027**, and applying **ONLY to the 50% reduction**. The 15-year exemption, retirement exemption and rollover keep the $2m turnover / $6m MNAV gateways |
+| 50% discount for early-stage investors/founders (start-up carve-out) | **Announced only** -- Treasury consultation; not law |
+| 30% minimum tax on discretionary trusts from 1 July 2028 | **Announced only** -- consultation closed 31 July 2026; not law |
+
+Practical consequences: CGT events **up to 30 June 2027** use everything in this skill unchanged. From 1 July 2027, Div 152 itself survives -- the AAR still halves the gain -- but the base it halves is an indexed gain, the 30% minimum rate applies underneath, and a $2m-$10m turnover business gains AAR access (but still needs the $6m MNAV or another gateway for the other three concessions). How the minimum rate, indexation, deemed re-acquisition and the Div 152 waterfall interleave in detail awaits ATO guidance -- **any disposal, rollover tail (J2/J5/J6) or contribution-timing question straddling 1 July 2027 escalates (R-AU-SBC-5)**. Never advise accelerating or deferring a sale around the date.
+
+## Section 10 -- Worked examples
+
+All examples assume CGT events in 2026-27 (before 1 July 2027), Australian residents, and no capital losses unless stated.
+
+### Example 1 -- Gateways: turnover fails, MNAV passes (and a fail variant)
+
+Nadia (58) contracts on 30 November 2026 to sell her sole-trader business premises, owned 8 years and used in her business throughout. Aggregated turnover (including her 100%-owned company) was $3.4m in 2025-26 and is estimated at $3.1m for 2026-27 -- **CGT SBE gateway fails**. MNAV just before the event:
+
+```
+Business premises ($2,600,000 MV - $700,000 mortgage)        $1,900,000
+Trading company (connected, 100%): net CGT assets            $1,750,000
+Share portfolio                                                $600,000
+Main residence: 10% deductible-interest office use
+  10% x ($2,400,000 - $900,000)                                $150,000
+Super balance $1,900,000                                       excluded
+Boat (solely personal use)                                     excluded
+Total net asset value                                        $4,400,000  <= $6,000,000  PASS
+```
+
+Basic conditions met via MNAV. **Variant:** if the portfolio were $2,500,000, the total is $6,300,000 -- MNAV fails by $300,000, both gateways fail, and only the general 50% discount applies. There is no shading: $6,000,001 is out.
+
+### Example 2 -- Stacking to zero
+
+Continuing Example 1: gain $900,000; premises active 8 of 8 years (>= half) -- active asset test passed. Not owned 15 years, so no 15-year exemption.
+
+```
+Capital gain                                    $900,000
+less general 50% discount (held > 12 months)   -$450,000  -> $450,000
+less 50% active asset reduction                -$225,000  -> $225,000
+less retirement exemption (elects $225,000)    -$225,000  -> NET GAIN NIL
+```
+
+Nadia is 58 -- 55+ just before making the choice, so NO super payment is required. Lifetime retirement-exemption tally: $225,000 used, $275,000 remains. She may still voluntarily contribute the $225,000 to super under the CGT cap (Rule 14). Without the retirement exemption her tax would have been $225,000 x 47% = **$105,750** (11.75% effective on the gross gain); with it, **nil**.
+
+### Example 3 -- Retirement exemption under 55: super is compulsory
+
+Marco (48) sells an active asset in March 2027: gain $600,000, held 4 years, basic conditions met.
+
+```
+Gain $600,000 -> discount -> $300,000 -> 50% AAR -> $150,000
+Retirement exemption elected: $150,000 -> net gain NIL
+```
+
+Because Marco is **under 55 just before making the choice**, he MUST pay $150,000 into a complying super fund/RSA by the later of making the choice and receiving the proceeds -- with a **CGT cap election (NAT 71161) given to the fund at or before the contribution**. The $150,000 is excluded from his $130,000 (2026-27) NCC cap and uses $150,000 of his $1,935,000 lifetime CGT cap. Lifetime retirement limit remaining: $350,000. (A 53-54 year-old wanting the cash instead could roll over for up to 2 years and choose the retirement exemption after turning 55 -- planning; escalate.)
+
+### Example 4 -- Share sale with the stakeholder tests
+
+Priya has owned 40% of OpCo Pty Ltd (one ordinary class, equal rights) for 9 years; unrelated Kai owns 60%. She sells her parcel in October 2026 for a $700,000 gain. Extra conditions (Rule 8):
+
+1. Priya carries on no business -- she must pass MNAV herself. Her 40% >= 40% makes her **connected** with OpCo, so OpCo's net assets count: total $4.2m <= $6m. PASS.
+2. Direct SBPP = smallest of voting/dividend/capital = 40% >= 20% -- **significant individual**, hence CGT concession stakeholder. PASS (90% test not needed for an individual claimant who is a stakeholder).
+3. OpCo is a CGT SBE (aggregated turnover $1.6m), applying the modified connected-entity rule. PASS.
+4. Modified active asset test: OpCo assets at market value $2.0m; active assets $1,550,000 + inherently-connected cash and receivables $250,000 = $1,800,000; $1,800,000 / $2,000,000 = **90% >= 80%**. PASS.
+
+Waterfall: $700,000 -> discount -> $350,000 -> AAR -> $175,000 -> retirement exemption/rollover available. **Fail variants:** if Priya held non-voting shares with discretionary dividends, her smallest percentage could be 0% -- not a significant individual, concessions denied. If a HoldCo she owns 100% held the 40% instead and sold, Priya's indirect SBPP in OpCo = 100% x 40% = 40% (stakeholder), and stakeholders of OpCo hold 100% >= 90% of HoldCo -- the **90% test** rescues the HoldCo sale.
+
+### Example 5 -- 15-year exemption plus CGT cap contribution
+
+Colin (62) contracts in September 2026 to sell farmland owned 22 years, used in his primary production business for 16 of those years (>= 7.5-year test), turnover $850,000, retiring to part-time consulting (significant reduction -- "in connection with retirement"). Gain $1,100,000; proceeds $2,100,000.
+
+The gain is **fully disregarded** under the 15-year exemption -- no discount, no losses consumed, retirement lifetime limit untouched. Colin may contribute up to the **capital proceeds** to super under the CGT cap: maximum exclusion **$1,935,000** (2026-27 cap; the remaining $165,000 of proceeds would be an ordinary NCC against his $130,000 cap -- flag bring-forward analysis). Deadline: later of his 2026-27 lodgment due date and 30 days after receiving proceeds; NAT 71161 at or before each contribution.
+
+### Example 6 -- Rollover with no replacement: CGT event J5
+
+A trading trust rolls over a $180,000 remainder (after discount and AAR) from a March 2027 disposal. Replacement asset period: March 2026 to March 2029. By March 2029 it has acquired nothing. **CGT event J5** happens at the end of the period: a $180,000 capital gain arises in 2028-29 -- no discount, no AAR, no 15-year exemption. The trust may choose the **retirement exemption** without re-meeting the basic conditions, but must have a CGT concession stakeholder to pay (Rule 11). NOTE: this J5 gain arises AFTER 1 July 2027 -- how the reform's indexation/minimum-rate rules treat J-event gains from pre-reform rollovers is not yet settled in ATO guidance. Escalate (R-AU-SBC-5).
+
+## Section 11 -- Refusal catalogue
+
+### R-AU-SBC-1 -- Look-through earnout rights
+
+**Trigger:** sale consideration includes contingent financial benefits over up to 5 years (Subdiv 118-I). **Issue:** MNAV valuation choices for the right, prior-year amendments as benefits arrive, retirement-exemption payment and CGT cap timing recalibrated to each benefit, extended replacement periods. **Action:** refuse computation; document the earnout terms; escalate.
+
+### R-AU-SBC-2 -- Marriage/relationship breakdown rollovers combined with Div 152
+
+**Trigger:** asset previously transferred under a Subdiv 126-A breakdown rollover now claimed under Div 152. **Issue:** the transferee inherits acquisition history for some purposes but active-asset and 15-year continuity questions (and s 152-45 modifications) are fact-heavy and unforgiving. **Action:** map the transfer chain; escalate.
+
+### R-AU-SBC-3 -- Non-resident or temporary-resident stakeholders
+
+**Trigger:** any significant individual, spouse stakeholder, or claimant who is (or becomes) a foreign or temporary resident; non-resident object entities; assets that are not taxable Australian property. **Issue:** residency interacts with the discount denial, the 80% test's residency limb, and payment mechanics. **Action:** refuse analysis; escalate.
+
+### R-AU-SBC-4 -- Pre-CGT assets
+
+**Trigger:** asset acquired before 20 September 1985. **Issue:** gains generally disregarded without Div 152 -- but the Tax Reform No. 1 Act 2026 removes pre-CGT status after 30 June 2027 (deemed re-acquisition), making the exemption's endgame a valuation and timing problem. **Action:** never assume continued exemption; escalate.
+
+### R-AU-SBC-5 -- Transactions straddling 1 July 2027
+
+**Trigger:** contracts, settlements, rollover tails (J2/J5/J6), retirement-exemption payments or CGT cap contributions falling on either side of 1 July 2027, or requests to time a sale around it. **Action:** compute the pre-reform position only, labelled as such; refuse timing recommendations; escalate.
+
+### R-AU-SBC-6 -- Death, incapacity evidence, and extensions of time
+
+**Trigger:** deceased-estate claims outside the 2-year window, permanent-incapacity determinations, or any Commissioner discretion (replacement-period or 2-year extensions). **Action:** state the standard rule; refuse to assume a discretion will be exercised; escalate.
+
+## Section 12 -- Excel working paper template
+
+```
+AUSTRALIA DIV 152 -- SBCGT ELIGIBILITY AND WATERFALL
+Taxpayer: [name/entity]   CGT event + date (CONTRACT date): [____]
+Income year: 2026-27      Prepared: [date]
+
+GATEWAY
+  Aggregated turnover (self + connected + affiliates): AUD [____]  < $2m? [Y/N]
+  Connected entities (>= 40% control) mapped:          [list]
+  Affiliates (acts in concert) mapped:                 [list]
+  MNAV just before event (per schedule):               AUD [____]  <= $6m? [Y/N]
+    - main residence % included / super excluded / personal-use excluded? [Y/N]
+  Passively-held asset rules relied on?                [Y/N -- business entity: ____]
+
+ACTIVE ASSET TEST
+  Ownership period: [____] yrs   Active periods: [____] yrs
+  Test: >= half, or >= 7.5 yrs if owned > 15 yrs:      [PASS/FAIL]
+  Rent component? Carve-out (affiliate/connected user) evidenced? [____]
+
+SHARES/UNITS ONLY (s 152-10(2))
+  Claimant carried on business OR own MNAV pass:       [____]
+  Stakeholder status / 90% test (SBPP workings):       [____]
+  Object entity CGT SBE or MNAV (modified rule):       [____]
+  Modified active asset test: [active+cash] / [total] = [____]% >= 80%? [Y/N]
+
+WATERFALL (per gain)
+  Gross gain:                       AUD [____]
+  15-year exemption? (15 yrs + 55+/retirement or incapacity) [Y/N -> if Y, STOP]
+  less capital losses:              AUD [____]
+  less general 50% discount:        AUD [____]   (individual/trust only; > 12 mths)
+  less 50% AAR (unless choose-out): AUD [____]   (choose-out reason: ____)
+  less retirement exemption:        AUD [____]   (lifetime register below)
+  less rollover:                    AUD [____]   (replacement period ends: ____)
+  NET CAPITAL GAIN:                 AUD [____]
+
+REGISTERS
+  Retirement exemption lifetime ($500,000): prior use AUD [____] + this AUD [____]
+  Under 55 at choice? Super payment made + date:        [____]
+  CGT cap (2026-27 $1,935,000): prior use AUD [____] + this AUD [____]
+  NAT 71161 given at/before contribution?               [Y/N + date]
+  Company/trust: stakeholder payment within 7 days (152-D) / 2 yrs (152-B)? [____]
+
+REVIEWER FLAGS
+  [R-AU-SBC items triggered; post-1 July 2027 exposure]
+```
+
+## Section 13 -- Reference material
+
+### Key figures
+
+| Item | Value |
+|---|---|
+| Gateways | < $2m aggregated turnover (CGT SBE) OR <= $6m MNAV (not indexed) |
+| Active asset period | >= half of ownership, or >= 7.5 years if owned > 15 years |
+| Significant individual / stakeholder | SBPP >= 20% / significant individual or spouse with > 0% |
+| 90% test / modified active asset test | 90% SBPP in claimant entity / 80% underlying-asset threshold |
+| Retirement exemption | $500,000 lifetime per individual; under-55 super payment compulsory |
+| Rollover window | 1 year before to 2 years after event; J5/J6 at period end; J2 later |
+| CGT cap | 2026-27: $1,935,000; 2025-26: $1,865,000 (NCC caps: $130,000 / $120,000) |
+| Company/trust payment windows | Retirement: 7 days after later of choice/proceeds; 15-year: 2 years |
+| From 1 July 2027 | AAR turnover gateway $10m (law); indexation + 30% minimum replaces discount |
+
+### Primary sources (verified 20 August 2026)
+
+| Topic | Source |
+|---|---|
+| Statute | ITAA 1997 Div 152: Subdiv 152-A (basic conditions, ss 152-10 to 152-49), 152-B (15-year), 152-C (50% AAR), 152-D (retirement), 152-E (rollover); ss 104-185/190/197-198 (J2/J5/J6); s 292-100 (CGT cap) |
+| ATO hub | Small business CGT concessions (QC 72742); eligibility conditions (QC 72743) |
+| Gateways | Maximum net asset value test (QC 52270); CGT small business entity eligibility pages under QC 72743 |
+| Active asset test | QC 52271 (updated 2 February 2026) -- rent carve-out, 80% test |
+| Shares/trust interests | Additional conditions (QC 52283) -- stakeholder, SBPP, 90% test, modified tests |
+| The four concessions | 15-year exemption (QC 52288); 50% active asset reduction (QC 52289); retirement exemption (QC 52290); roll-over (QC 52291) |
+| CGT cap amount | ATO key super rates and thresholds -- contributions caps, Table 6 (QC 18123); CGT cap election form NAT 71161 |
+| Reform | Treasury Laws Amendment (Tax Reform No. 1) Act 2026 (Royal Assent 26 June 2026); 2026-27 Budget (12 May 2026); Treasury consultations on start-up carve-out and trust minimum tax (not law) |
+
+### Test suite
+
+**Test 1:** Turnover $3.4m, MNAV $4.4m. -> Gateway passes via MNAV; turnover irrelevant.
+
+**Test 2:** MNAV $6,000,001. -> Fails; no Div 152; general discount only.
+
+**Test 3:** Premises leased 100% to the owner's own trading company for 10 of 10 years. -> Rent disregarded (s 152-40(4A)); active asset.
+
+**Test 4:** Same premises leased to unrelated tenants for 6 of 10 years, own business 4. -> Main use deriving rent for the majority; fails unless facts change the main-use conclusion; flag.
+
+**Test 5:** Individual gain $900,000, discount + AAR + retirement $225,000. -> Net gain nil; lifetime tally $225,000; 58yo -> no super payment.
+
+**Test 6:** Same but company. -> No discount: $900,000 -> AAR $450,000 -> retirement exemption capped at $500,000 per stakeholder; consider choosing OUT of AAR so two 50% stakeholders can extract $450,000 each ($900,000 total) tax-free within their lifetime limits.
+
+**Test 7:** 30% shareholding, one equal-rights class. -> SBPP 30%; significant individual; stakeholder.
+
+**Test 8:** Discretionary trust, no distribution and tax loss in event year; last distribution year gave A 21%. -> A is a significant individual via the prior-year rule.
+
+**Test 9:** Rolled over $200,000; replacement cost only $150,000 at period end. -> J6 gain $50,000; retirement exemption only.
+
+**Test 10:** Retirement exemption $150,000, taxpayer 48. -> Compulsory super payment $150,000; NAT 71161 at/before contribution; excluded from NCC cap; CGT cap reduced to $1,785,000.
+
+**Test 11:** 2027-28 disposal, turnover $7m, net assets $8m. -> Post-reform: 50% AAR available ($10m gateway, law from 1 July 2027); 15-year/retirement/rollover NOT available (fails $2m and $6m); escalate for indexation/minimum-rate mechanics.
+
+### Prohibitions
+
+- NEVER apply any concession before the gateway AND active asset test are evidenced at the CGT event (contract) date
+- NEVER treat a rent-deriving asset as active without checking the affiliate/connected-entity carve-out -- and never the reverse
+- NEVER apply the general 50% discount to a company, or any discount/AAR/15-year to a J5/J6 gain
+- NEVER exceed the $500,000 lifetime retirement limit or skip the under-55 compulsory super payment
+- NEVER treat a CGT cap contribution as excluded without a NAT 71161 given at or before the contribution
+- NEVER use the $10m turnover gateway before 1 July 2027, or for any concession other than the 50% active asset reduction
+- NEVER advise timing a disposal around 1 July 2027 -- compute the pre-reform position, label it, escalate
+- NEVER present figures as definitive
+
+---
+
+## Disclaimer
+
+This skill and its outputs are provided for informational and computational purposes only and do not constitute tax, legal, or financial advice. Open Accountants and its contributors accept no liability for any errors, omissions, or outcomes arising from the use of this skill. All outputs must be reviewed and signed off by a qualified professional (such as a CPA, CA, tax agent, or equivalent licensed practitioner in your jurisdiction) before filing or acting upon.
+
+The most up-to-date, verified version of this skill is maintained at [openaccountants.com](https://www.openaccountants.com). Log in to access the latest version, request a professional review from a licensed accountant, and track updates as tax law changes.
+
+<!-- openaccountants-cta-block -->
+
+---
+
+## Talk to a verified accountant
+
+This guide is maintained by the OpenAccountants network — accountants who put
+their name behind the tax answers AI gives people. The live, always-current
+version (and the professional behind it) is at
+[openaccountants.com](https://www.openaccountants.com).
+
+- Use it in your AI: https://www.openaccountants.com/connect
+- Meet the accountants: https://www.openaccountants.com/network
+
+> **General reference only.** This document does not constitute tax, legal, or
+> financial advice. Verify figures against the cited primary sources or with a
+> licensed professional before relying on them.

--- a/skills/international/australia/au-trust-distributions.md
+++ b/skills/international/australia/au-trust-distributions.md
@@ -177,7 +177,7 @@ Income to which no beneficiary is presently entitled (and no valid streaming app
 
 ### Rule 5 -- Division 6AA minors' rates
 
-Applies to "eligible taxable income" (unearned income, including discretionary trust distributions) of resident minors who are not excepted persons: $0-$416 nil; $417-$1,307 taxed at 66% of the excess over $416; over $1,307 the ENTIRE amount at 45% (cliff, not marginal). Non-resident minors: 32.5%/66%/45% analogues with no tax-free band. The trustee pays under s 98(1) while the minor is under a legal disability; the minor also returns the share with a credit for the trustee's tax if they must lodge. LITO cannot offset Div 6AA tax. Excepted income (employment, testamentary trusts, compensation, inheritances) is taxed at adult rates -- verify character before assuming.
+Applies to "eligible taxable income" (unearned income, including discretionary trust distributions) of resident minors who are not excepted persons: $0-$416 nil; $417-$1,307 taxed at 66% of the excess over $416; over $1,307 the ENTIRE amount at 45% (cliff, not marginal). Non-resident minors get no tax-free band: $0-$416 at 30% of the entire amount (the non-resident first rate from 2024-25), then 66% of the excess, then 45% of the whole amount (ATO "Tax rates if you're under 18 years old"). The trustee pays under s 98(1) while the minor is under a legal disability; the minor also returns the share with a credit for the trustee's tax if they must lodge. LITO cannot offset Div 6AA tax. Excepted income (employment, testamentary trusts, compensation, inheritances) is taxed at adult rates -- verify character before assuming.
 
 ### Rule 6 -- Streaming capital gains (Subdiv 115-C)
 

--- a/skills/international/australia/au-trust-distributions.md
+++ b/skills/international/australia/au-trust-distributions.md
@@ -1,0 +1,430 @@
+---
+name: au-trust-distributions
+description: >
+  Use this skill whenever asked about Australian discretionary or family trust distributions -- trustee resolutions, present entitlement, section 95 net income versus trust income, streaming capital gains or franked distributions, minors' penalty rates under Division 6AA, section 99A trustee assessments, family trust elections, interposed entity elections, family trust distribution tax, section 100A reimbursement agreements, unpaid present entitlements after Bendel, TFN withholding for closely held trusts, or trust losses. Trigger on phrases like "trust distribution", "trustee resolution", "distribution minute", "streaming", "FTE", "FTDT", "s 100A", "bucket company", "UPE", or "30 June deadline". ALWAYS read this skill before touching any trust distribution work.
+version: 1.0
+jurisdiction: AU
+tax_year: 2026
+tax_year_notes: "2026-27"
+last_updated: 2026-08-20
+review_status: pending_review
+category: international
+tier: 2
+license: AGPL-3.0-or-later (code) / OpenAccountants Guide License v1.0 (content)
+---
+
+# Australia Trust Distributions -- Discretionary & Family Trusts Skill v1.0
+
+> **General reference only.** This skill is general tax/accounting reference material for AI-assisted workflows. It has not been reviewed for any specific person's facts, documents, elections, deadlines, residency, filing status, or local procedures. Do not rely on it to file, pay, amend, or take a tax position without review by a qualified professional in the relevant jurisdiction.
+
+> **Law-change context (three live fronts).** (1) *Commissioner of Taxation v Bendel* [2026] HCA 18 (10 June 2026): a UPE owed to a corporate beneficiary is not, of itself, a Div 7A loan; ATO decision impact statement 26 June 2026 accepts it -- see Rule 10 and the au-div7a skill. (2) Treasury Laws Amendment (Tax Reform No. 1) Act 2026 (Royal Assent 26 June 2026): from 1 July 2027 the 50% CGT discount for individuals, trusts and partnerships is replaced by cost base indexation plus a 30% minimum rate on capital gains, with new trustee capital-gain categorisation/statement obligations -- LAW, see Rule 14. (3) A 30% minimum tax on discretionary trust distributions from 1 July 2028 (testamentary trusts carved out) was ANNOUNCED in the 2026-27 Budget and is NOT in that Act -- consultation closed 31 July 2026, not yet law. Verify all three before relying.
+
+## Section 1 -- Quick reference
+
+**Read this whole section before computing or classifying anything.**
+
+| Field | Value |
+|---|---|
+| Country | Australia |
+| Primary Legislation | ITAA 1936 Part III Division 6 (ss 95-102), Div 6AA, Div 6D, Div 6E, s 100A; ITAA 1997 Subdivs 115-C, 207-B; Sch 2F ITAA 1936 (FTE/FTDT/trust losses) |
+| Tax Authority | Australian Taxation Office (ATO) |
+| Income Year | 2026-27 (1 July 2026 -- 30 June 2027); lodgment season for 2025-26 |
+| Present entitlement deadline | 30 June (11:59pm) -- or EARLIER if the deed requires |
+| Capital-gain specific entitlement recording | Within 2 months of year end (31 August) via appointment of trust capital |
+| Franked-distribution specific entitlement recording | By 30 June (in the trust's records, in its character) |
+| s 99A rate (no present entitlement) | 45% + 2% Medicare levy = 47% flat, no tax-free threshold |
+| Div 6AA minor's eligible income (resident) | $0-$416 nil; $417-$1,307 = 66% of excess over $416; over $1,307 = 45% of the WHOLE amount |
+| Family trust distribution tax (FTDT) | 47% of distributions outside the family group; due 21 days after the distribution; non-deductible |
+| TFN withholding (closely held trusts, no TFN quoted) | 47%; annual report 30 Sep; activity statement + payment 28 Oct; quarterly TFN report ABOLISHED from 1 July 2026 |
+| UPE to corporate beneficiary | NOT a Div 7A loan while passive (*Bendel* [2026] HCA 18); s 100A and Subdiv EA survive -- see au-div7a |
+| s 100A guidance | TR 2022/4 + PCG 2022/2 (white/green/red zones) -- in force, under post-Bendel review |
+| Contributor | Open Accountants |
+| Validated by | Pending |
+
+**Conservative defaults:**
+
+| Ambiguity | Default |
+|---|---|
+| Deed not sighted | Do NOT assume trust income = s 95 net income; obtain the deed (income clause, default beneficiaries, vesting date, deadline for resolutions) |
+| Resolution date unverified | Assume made AFTER 30 June; test the default-beneficiary clause, else s 99A at 47% |
+| Streaming records unsighted | Assume NO specific entitlement -- gains and franked amounts flow proportionately |
+| FTE status unknown | Check ATO records; assume no FTE for franking-credit flow-through; assume FTE EXISTS when scanning for FTDT exposure on unusual beneficiaries |
+| Beneficiary's family-group status unknown | Assume OUTSIDE the group -- FTDT exposure at 47% until mapped |
+| Minor beneficiary, income character unknown | Assume eligible (penalty rates), not excepted income |
+| Beneficiary TFN status unknown | Assume not quoted -- 47% withholding exposure |
+| UPE credit balance in the books | Passive UPE = no Div 7A loan (post-Bendel), but ALWAYS run the s 100A screen |
+| Trust has carried-forward losses | Schedule 2F tests unresolved -- escalate before offsetting |
+
+## Section 2 -- Required inputs and refusal catalogue
+
+### Required inputs
+
+**Minimum viable** -- trust deed (plus amendments), the signed distribution resolution/minute with its date, draft trust income and s 95 net income, beneficiary list with residency/age/TFN status, FTE/IEE status.
+
+**Recommended** -- prior-year statements of distribution, beneficiary loan/UPE ledgers, franking account of any corporate beneficiary, capital gains schedule with acquisition dates, evidence of payment of entitlements.
+
+**Ideal** -- family group map around the test individual, streaming clauses marked up in the deed, bank evidence of where entitlement cash actually went (s 100A), loss schedules with Sch 2F test evidence.
+
+### Refusal catalogue
+
+**R-AU-TR-1 -- Deceased estates and testamentary trusts.** *Trigger:* deceased estate in administration, testamentary trust, s 99 concessional-rate questions, excepted-income status of testamentary distributions to minors. *Message:* "Deceased estate and testamentary trust taxation (s 99 discretion, stages of administration, Div 6AA excepted income, and the announced minimum-tax carve-out) is out of scope. Escalate to a qualified practitioner."
+
+**R-AU-TR-2 -- Special disability trusts.** *Trigger:* special disability trust or vulnerable-beneficiary trust. *Message:* "Special disability trusts have their own concessional rules and social-security interactions. Out of scope. Escalate."
+
+**R-AU-TR-3 -- Non-resident beneficiaries or trustees.** *Trigger:* any non-resident beneficiary, foreign trust, or beneficiary who changed residency. *Message:* "Trustee assessment under s 98(2A)/(3)/(4), withholding, treaty issues and the *Greensill* line on capital gains are out of scope. Escalate before any resolution is signed."
+
+**R-AU-TR-4 -- Circular trust distributions / TBNT.** *Trigger:* trust-to-trust distributions that loop back (directly or indirectly), or trustee beneficiary statement failures. *Message:* "Circular distributions attract trustee beneficiary non-disclosure tax at 47% (s 102UM) -- family trusts included. Computation and remediation are out of scope. Escalate."
+
+**R-AU-TR-5 -- s 100A red-zone positions.** *Trigger:* facts matching any PCG 2022/2 red-zone scenario, or entitlement cash that went to someone other than the beneficiary. *Message:* "This has red-zone s 100A features. Document the flows; do not sign off or restructure. Escalate."
+
+**R-AU-TR-6 -- Trust loss recoupment.** *Trigger:* prior-year losses claimed as deductions in net income. *Message:* "Schedule 2F testing (50% stake, control, pattern of distributions, income injection) is out of scope beyond the overview in Rule 13. Escalate."
+
+**R-AU-TR-7 -- FTE revocation, variation or FTDT remediation.** *Trigger:* request to revoke/vary an FTE or IEE, or FTDT already triggered. *Message:* "Revocation and variation windows are narrow and FTDT is joint-and-several for directors. Escalate."
+
+## Section 3 -- Distribution-resolution timeline and GL sweep
+
+### 3.1 Compliance timeline (2025-26 year being lodged; same shape every year)
+
+| Deadline | Obligation |
+|---|---|
+| Before 30 June (check deed -- some require earlier, e.g. 28 June) | Trustee resolution conferring present entitlement to trust income; written record if deed requires (write it regardless) |
+| By 30 June | Franked-distribution streaming: specific entitlement recorded in trust records in its character (s 207-58) |
+| By 31 August | Capital-gain streaming via appointment of trust CAPITAL: specific entitlement recorded within 2 months of year end (s 115-228) -- cannot override amounts already dealt with by 30 June |
+| 21 days after distribution | FTDT payment where an FTE trust distributes outside the family group |
+| By 30 September | Annual TFN withholding report (only if amounts were withheld) |
+| By 14 October | Payment summaries to beneficiaries who had TFN amounts withheld |
+| By 28 October | Annual activity statement + payment of TFN amounts withheld |
+| Trust return lodgment | Statement of distribution (annual trustee payment report); beneficiary TFNs reported here from the 2027 return; TB statements where Div 6D applies |
+
+### 3.2 GL / document sweep
+
+| Pattern | Likely issue | Action |
+|---|---|---|
+| "Beneficiary loan" / "distribution payable" credit balances | UPEs | Age them; s 100A screen; post-Bendel no Div 7A while passive (au-div7a) |
+| UPE unpaid beyond ~2 years with funds retained | Falls outside parts of the PCG 2022/2 green zone | Document green-zone conditions or escalate (T2-5) |
+| Distributions exactly $416 to children | Div 6AA planning at the tax-free band | Confirm eligible vs excepted income; confirm actual payment/benefit |
+| Distribution to a loss entity | Red zone scenario 5 if outside family group | s 100A screen; Sch 2F escalation |
+| Franking credits claimed by beneficiary of non-fixed trust | Qualified-person rules | Confirm FTE in force (Rule 7) |
+| First-time or unusual beneficiary | Family-group breach | Map against test individual; FTDT at 47% (Rule 8) |
+| Trust lends cash to the person who funded a beneficiary's entitlement | Circular benefit | Red zone screen (R-AU-TR-5) |
+| Resolution undated / signed with return | Backdating risk; s 99A | Sight contemporaneous evidence (emails, file notes) |
+
+---
+
+## Section 4 -- Worked examples
+
+### Example 1 -- Proportionate approach (trust income vs s 95 net income)
+
+Deed defines income as ordinary income. Trust income $100,000; s 95 net income $120,000 (non-deductible amounts and timing differences). Resolution: A 60%, B 40% of trust income.
+
+Bamford proportionate approach: each beneficiary is assessed on their PERCENTAGE of net income, not the dollars they were promised. A: 60% x $120,000 = **$72,000**. B: 40% x $120,000 = **$48,000**. The $20,000 gap is taxed even though nobody can bank it -- flag to the client.
+
+### Example 2 -- Streaming a capital gain and a franked dividend
+
+2026-27 receipts: $80,000 gross capital gain (asset held > 12 months), $70,000 fully franked dividend (franking credit $70,000 x 30/70 = $30,000), $40,000 rent. Trustee validly streams: gain 100% to A (individual; capital appointment recorded 20 August 2027 -- inside 31 August), franked dividend 100% to C Pty Ltd (recorded by 30 June 2027), rent to B.
+
+- A (Subdiv 115-C): attributable gain $40,000 (post-discount share) grossed up x2 = $80,000 capital gain in A's own return; A applies A's own 50% discount (no losses) = **$40,000 assessable**. (From 1 July 2027 this discount mechanic changes -- Rule 14.)
+- C (Subdiv 207-B): includes $70,000 + $30,000 credit = $100,000; tax at 30% (bucket company is not a base rate entity on passive trust income) = $30,000 less $30,000 franking offset = **nil net**, franking account credited $30,000.
+- B (Div 6/6E): assessed on the $40,000 rent share.
+
+### Example 3 -- Minor beneficiaries (Division 6AA)
+
+Resolutions give grandchild G1 (age 9) $416 and grandchild G2 (age 12) $1,200, both eligible (unearned) income; trustee assessed under s 98(1) as they are under a legal disability.
+
+- G1: $416 sits in the $0-$416 band -> **tax nil** (assuming no other income).
+- G2: 66% x ($1,200 - $416) = 66% x $784 = **$517.44** -- a 43% average rate on a $1,200 entitlement.
+- Had G2 received $5,000: over $1,307, so 45% x THE WHOLE $5,000 = **$2,250** (plus Medicare levy where applicable; LITO cannot reduce tax on minors' unearned income).
+
+Distributing eligible income beyond $416 per minor is almost always pointless. Excepted persons (e.g. minors in full-time work, certain disabled minors) and excepted income (employment, testamentary trust income, compensation, deceased estate income) escape Div 6AA -- testamentary questions escalate (R-AU-TR-1).
+
+### Example 4 -- Family trust distribution tax
+
+FTE in force, test individual David. Trustee distributes $20,000 to David's cousin. Cousins are OUTSIDE the s 272-90 family group.
+
+FTDT = 47% x $20,000 = **$9,400**, payable by the trustee (directors of a corporate trustee jointly and severally liable), due 21 days after the distribution, non-deductible. The $20,000 is then excluded from the cousin's assessable income. There is no materiality threshold and no Commissioner discretion -- map the family group BEFORE every unusual distribution.
+
+### Example 5 -- No resolution, no default clause (s 99A)
+
+Deed requires a resolution by 30 June and names no default beneficiaries. The 2026-27 minute is signed 15 July 2027. Net income $150,000.
+
+No beneficiary was presently entitled at 30 June -> trustee assessed under s 99A: 47% x $150,000 = **$70,500** flat (no tax-free threshold). A default-beneficiary clause would have rescued present entitlement -- but check WHO defaults: minor default beneficiaries swap a 47% problem for a Div 6AA one. The s 99 concessional alternative is confined to deceased estates and other Commissioner-discretion cases -- escalate (R-AU-TR-1).
+
+### Example 6 -- s 100A red zone -> s 99A exposure
+
+Adult child at university (marginal rate ~nil) is made presently entitled to $100,000. Under a pre-existing family understanding the cash is paid to the parents' loan offset; the child never benefits. This is PCG 2022/2 red zone scenario 1 (entitlement gifted/lent to another party).
+
+If s 100A applies (TR 2022/4 elements: connection, benefit-to-another, tax-reduction purpose, not ordinary family/commercial dealing), the child's present entitlement is deemed never to have existed -> trustee assessed under s 99A: 47% x $100,000 = **$47,000**, and s 100A assessments are not sheltered by the standard amendment periods. Contrast the green zone: if the child had actually received and used the money, scenario 2 applies. *Guardian* confirms the agreement must exist at or before the entitlement is created; *BBlood* shows contrived dealings fail the ordinary-dealing exception. Escalate red-zone facts (R-AU-TR-5).
+
+---
+
+## Section 5 -- Tier 1 rules
+
+### Rule 1 -- Division 6 architecture
+
+s 95 "net income" = the trust's taxable income computed as if the trustee were a resident taxpayer. "Income of the trust estate" (distributable/trust income) is a TRUST-LAW amount fixed by the deed. Beneficiaries presently entitled and not under a legal disability are assessed under s 97 on their share of net income; trustees are assessed under s 98 for presently entitled beneficiaries under a legal disability (e.g. minors) and non-residents; s 99A (or rarely s 99) taxes the trustee on anything nobody is presently entitled to. Div 6E carves streamed capital gains and franked distributions out of the Div 6 math so Subdivs 115-C and 207-B can tax them instead (no double count).
+
+### Rule 2 -- Present entitlement by 30 June and trustee resolutions
+
+Present entitlement = a vested, indefeasible, immediately demandable interest in trust income, existing by 11:59pm 30 June. It is created by the deed (default clauses), by trustee resolution, or both. The ATO does not require writing unless the deed does -- but an unwritten resolution is unprovable, so ALWAYS have a signed, dated minute before 30 June (or the deed's earlier deadline). Entitlements must identify beneficiary and share (percentages beat dollar figures; include a balance clause). An invalid or late resolution hands the income to the default beneficiaries, or failing that to s 99A. Backdating is fraud -- never assist it.
+
+### Rule 3 -- Proportionate approach (Bamford)
+
+*FCT v Bamford* [2010] HCA 10: a beneficiary's assessable share = (beneficiary's share of TRUST income / total trust income) x s 95 NET income. Differences between the two amounts (depreciation clawbacks, non-deductibles, deed income clauses) change WHO pays tax, not how much income exists. Read the deed's income clause first: an "income equalisation" / s 95 clause aligns the amounts; a pure ordinary-income clause guarantees gaps in gain years.
+
+### Rule 4 -- s 99A trustee assessment
+
+Income to which no beneficiary is presently entitled (and no valid streaming applies) is assessed to the trustee at 45% + 2% Medicare levy = 47%, flat from the first dollar. s 99 (ordinary progressive rates) is available only where the Commissioner considers s 99A unreasonable -- in practice deceased estates and a few statutory trusts (escalate, R-AU-TR-1). Common causes: late/defective resolutions, distributing "income" the deed doesn't recognise, vesting-date breaches.
+
+### Rule 5 -- Division 6AA minors' rates
+
+Applies to "eligible taxable income" (unearned income, including discretionary trust distributions) of resident minors who are not excepted persons: $0-$416 nil; $417-$1,307 taxed at 66% of the excess over $416; over $1,307 the ENTIRE amount at 45% (cliff, not marginal). Non-resident minors: 32.5%/66%/45% analogues with no tax-free band. The trustee pays under s 98(1) while the minor is under a legal disability; the minor also returns the share with a credit for the trustee's tax if they must lodge. LITO cannot offset Div 6AA tax. Excepted income (employment, testamentary trusts, compensation, inheritances) is taxed at adult rates -- verify character before assuming.
+
+### Rule 6 -- Streaming capital gains (Subdiv 115-C)
+
+A beneficiary is "specifically entitled" to a capital gain to the extent they have received, or can reasonably expect to receive, the financial benefit referable to the gain AND that entitlement is recorded in its character in the trust's accounts/records by the deadline: 30 June where the gain forms part of trust income, or 31 August (2 months after year end) where the trustee appoints trust CAPITAL. The deed must permit streaming. The specifically entitled beneficiary grosses up their attributable gain and applies their own discount/losses; unstreamed gains flow proportionately, and gains nobody is presently or specifically entitled to are assessed to the trustee (s 115-222) at 47%. You cannot create a specific entitlement after 30 June over amounts a default beneficiary already became presently entitled to.
+
+### Rule 7 -- Streaming franked distributions (Subdiv 207-B)
+
+Franked distributions and their credits follow the beneficiary specifically entitled, recorded in the trust's records IN CHARACTER by 30 June -- no 31 August grace. Credits require the beneficiary/trustee to be a "qualified person" (45-day holding rule); for a discretionary (non-fixed) trust, beneficiaries generally CANNOT be qualified persons for credits > $5,000 unless a family trust election is in force. Small individual beneficiaries: the $5,000 franking-credit ceiling applies per taxpayer, not per trust.
+
+### Rule 8 -- FTE, IEE and family trust distribution tax
+
+An FTE (s 272-80 Sch 2F) makes the trust a "family trust" for: trust-loss testing (only the modified income injection test), franking-credit flow-through (Rule 7), company loss tracing, and trustee-beneficiary reporting exclusions. The election names a test individual; the family group (s 272-90) is roughly the test individual, spouse, lineal ancestors/descendants, siblings, nieces/nephews, their spouses, family companies/trusts/partnerships with IEEs, and certain charities. An IEE (s 272-85) brings an entity into the group. THE PRICE: any conferral/distribution of income or capital outside the group triggers FTDT at 47% (Div 271), payable by the trustee -- directors jointly and severally -- due 21 days after the distribution, non-deductible, with the amount excluded from the recipient's assessable income. Elections are effectively permanent: revocation/variation windows are narrow (escalate, R-AU-TR-7). Review the group EVERY year before signing resolutions.
+
+### Rule 9 -- s 100A reimbursement agreements
+
+**AUDIT FLASH POINT**
+
+s 100A strikes where a beneficiary's present entitlement arises from a "reimbursement agreement" -- someone other than the beneficiary gets the benefit, a purpose of the arrangement is that somebody pays less tax, and the dealing is not ordinary family or commercial dealing. Beneficiaries under a legal disability are outside it. Consequence: the entitlement is ignored and the trustee is assessed under s 99A at 47%, with no standard amendment-period shelter. Current framework:
+
+- **TR 2022/4** -- ATO's view of the elements (connection, benefit-to-another, purpose, ordinary-dealing exception).
+- **PCG 2022/2** risk zones: WHITE = arrangements in years ended before 1 July 2014 (no new compliance resources, limited exceptions); GREEN = documented low-risk scenarios (entitlement paid to and used by the beneficiary or their family; funds retained by the trustee on documented terms; TR 2022/4 ordinary-dealing examples) -- document how you qualify; RED = priority review/audit: entitlements gifted or lent back, income round-robined to the trust, unit-issue set-offs, share-of-net-income >> entitlement, loss beneficiaries outside the group, Taxpayer Alert arrangements (e.g. TA 2022/1 -- parents enjoying adult children's entitlements).
+- **Cases:** *Guardian AIT* ([2021] FCA 1619; [2023] FCAFC 3) -- no reimbursement agreement where none existed when the entitlement was created; Part IVA partially succeeded instead. *BBlood* ([2022] FCA 1112; upheld [2023] FCAFC 89; special leave refused 2024) -- s 100A applied to a contrived buy-back arrangement.
+- **Post-Bendel posture:** TR 2022/4 and PCG 2022/2 remain IN FORCE but under review; with the Div 7A route to UPEs closed, s 100A is the ATO's primary lever on trust entitlements that don't reach the named beneficiary. Expect s 100A questions wherever UPE balances age.
+
+### Rule 10 -- UPEs to corporate beneficiaries post-Bendel
+
+*Bendel* [2026] HCA 18: a UPE owed to a corporate beneficiary is not "financial accommodation" and so not a Div 7A loan while the company stays PASSIVE. ATO DIS 26 June 2026 accepts this. Still live: (1) s 100A on the arrangement creating the UPE; (2) Subdiv EA (trust pays/lends to the company's shareholders while the UPE is unpaid); (3) any ACTIVE step -- conversion to a loan, promissory note, call for payment -- can create a real s 109D loan from that point; (4) the announced UPE/Div 7A legislative response (2018-19 Budget measure, still unenacted) and the announced 30% minimum trustee tax (Rule 14). Full mechanics, guidance-status table and examples: **au-div7a skill, Rule 11** -- read it before touching any bucket-company structure.
+
+### Rule 11 -- TFN withholding (closely held trusts)
+
+Beneficiaries of closely held trusts (discretionary trusts and trusts with < 20 members holding >= 75%) must quote their TFN before being paid or made presently entitled; otherwise the trustee withholds at 47% from the payment/entitlement (to the extent of the share of net income), registers for PAYG withholding (closely held), lodges an Annual TFN withholding report by 30 September, gives payment summaries by 14 October, and pays via annual activity statement by 28 October. Exclusions: beneficiaries under a legal disability, non-residents, exempt entities, amounts subject to FTDT or a TB statement, s 98 liabilities, and entitlements under $120 for the year. From 1 July 2026 the quarterly TFN report is ABOLISHED (final report for April-June 2026 was due 31 July 2026); beneficiary TFNs are instead reported in the statement of distribution in the trust return (2027 return onward). Withholding obligations themselves are unchanged.
+
+### Rule 12 -- Trustee beneficiary statements and circular distributions (Div 6D)
+
+A closely held trust distributing a share of net income to a TRUSTEE beneficiary must make a TB statement in the return; failure = trustee beneficiary non-disclosure tax at 47% on the untaxed part. s 102UM imposes TBNT where a distribution ultimately circles back to the originating trust -- and since 1 July 2019 this catches FAMILY trusts too (an FTE does not immunise round-robins). Any loop pattern -> refuse and escalate (R-AU-TR-4).
+
+### Rule 13 -- Trust losses (Schedule 2F) -- overview only
+
+Carried-forward trust losses are deductible only if the trust passes the relevant tests: non-fixed trusts face the 50% stake test (where applicable), control test, pattern of distributions test, and income injection test; family trusts (FTE in force) face only a modified income injection test. This is the main practical reason FTEs exist. Do not compute recoupment from this skill -- escalate (R-AU-TR-6).
+
+### Rule 14 -- 2026 reform landscape: what IS law vs what is ANNOUNCED
+
+| Measure | Status (verified 20 August 2026) |
+|---|---|
+| Treasury Laws Amendment (Tax Reform No. 1) Act 2026 + Income Tax Rates Amendment (Tax Reform No. 1) Act 2026 | **LAW** -- Royal Assent 26 June 2026 |
+| 50% CGT discount for individuals, trusts, partnerships replaced by cost base indexation + 30% minimum rate on capital gains (direct or through trusts) | **LAW**, applies from 1 July 2027, and only to gains accruing after that date; discount retained for eligible new dwellings/affordable housing |
+| New trustee obligations to categorise capital gains and issue statements so beneficiaries can apply indexation and the 30% minimum rate | **LAW**, from 1 July 2027 -- detailed ATO forms/guidance still emerging; verify before building 2027-28 templates |
+| Pre-CGT (pre-20 Sep 1985) status ends after 30 June 2027; capital losses ordered against discounted gains first; SBE 50% reduction turnover threshold $2m -> $10m | **LAW** (same Act) |
+| 30% minimum tax on TRUSTEE distributions of discretionary trusts from 1 July 2028 (trustee-level tax on s 95(1) net income; non-refundable offset for individual beneficiaries; corporate beneficiaries DENIED the offset; franking credits proposed to stop flowing through; directors jointly/severally liable) | **ANNOUNCED, NOT LAW** -- 2026-27 Budget (12 May 2026); Treasury consultation paper 8 July 2026, consultation closed 31 July 2026; expected in a LATER bill |
+| Carve-outs from the announced minimum tax: testamentary trusts (pre-1 July 2028 trusts excluded if genuinely testamentary and assets from the estate or injected before 12 May 2026; later ones only if beneficiaries limited to individuals/tax-exempts), fixed trusts, widely held trusts, complying super funds, special disability trusts, deceased estates, charities, primary production income, Div 6AA vulnerable-minor categories | **ANNOUNCED, NOT LAW** -- design still in consultation |
+| Restructure rollover relief (Subdiv 328-G-style, from 1 July 2027, ~3 years) out of discretionary trusts | **ANNOUNCED, NOT LAW** |
+
+Never present an announced measure as enacted, and never advise restructures around it -- note it, quantify nothing, escalate planning (T2-6).
+
+---
+
+## Section 6 -- Tier 2 catalogue
+
+### T2-1 -- Deed income clause vs s 95
+
+**Trigger:** deed not sighted, or income clause silent on capital gains/franking gross-up. **Issue:** streaming power and Bamford percentages both hang off the deed. **Action:** obtain and quote the clause; if the deed lacks streaming powers, streaming fails regardless of records.
+
+### T2-2 -- Disclaimers, variations and late "fixes"
+
+**Trigger:** beneficiary wants to disclaim after year end, or trustee wants to "amend" a resolution. **Issue:** disclaimers can trigger s 99A and green-zone exclusions; amendments after 30 June cannot create present entitlement retrospectively. **Action:** escalate; document only.
+
+### T2-3 -- Bucket company with no cash movement
+
+**Trigger:** corporate beneficiary entitlements accrue year after year, never paid. **Issue:** passive UPEs are Div 7A-safe post-Bendel but are s 100A magnets and the company still returns the s 97 share -- tax without cash. **Action:** run the au-div7a UPE screen; confirm the company actually returned its shares of net income.
+
+### T2-4 -- Part IVA overlay
+
+**Trigger:** arrangement survives s 100A but exists mainly to route income at lower rates (cf. *Guardian* round two). **Issue:** general anti-avoidance is a live fallback for the ATO. **Action:** flag dominant-purpose facts; escalate.
+
+### T2-5 -- Aged UPEs and the green-zone clock
+
+**Trigger:** individual-beneficiary entitlements retained by the trustee beyond 2 years, or undocumented retention terms. **Issue:** parts of the PCG 2022/2 green zone expressly exclude prolonged retention; documentation is a green-zone entry condition. **Action:** document lending/retention terms or escalate.
+
+### T2-6 -- Announced 30% minimum trustee tax horizon
+
+**Trigger:** structuring, FTE, or bucket-company decisions with effect past 1 July 2028. **Issue:** announced-not-law measure would tax trustees at 30% with corporate beneficiaries denied the offset (effective rates to ~60-70% on corporate chains per Treasury's consultation design). **Action:** note on all forward-looking advice; escalate planning; never model it as enacted.
+
+### T2-7 -- Vesting date and appointor checks
+
+**Trigger:** old deed (pre-1990s), unclear appointor succession, or vesting date within 5 years. **Issue:** distributions after vesting are void; appointor gaps break resolutions. **Action:** flag for legal review.
+
+---
+
+## Section 7 -- Excel working paper template
+
+```
+AUSTRALIA TRUST DISTRIBUTIONS -- WORKING PAPER
+Trust: [name]   Income year: 2026-27   Deed sighted: [YES/NO + date]
+Prepared: [date]
+
+DEED CHECKS
+  Income clause type:            [ordinary income / s 95 equalisation / other]
+  Streaming powers:              [YES/NO -- clause ref]
+  Default beneficiaries:         [names / NONE]
+  Resolution deadline per deed:  [30 June / earlier: ____]
+  Vesting date:                  [____]
+  FTE / IEE status:              [FTE year + test individual / none]
+
+INCOME RECONCILIATION
+  Trust (distributable) income:  AUD [____]
+  s 95 net income:               AUD [____]
+  Difference explained:          [____]
+
+RESOLUTION REGISTER (per beneficiary)
+  Name / TFN quoted / residency / age:  [____]
+  Family-group member:           [YES/NO/UNKNOWN -> FTDT check]
+  Share of trust income:         [% and AUD]
+  Assessed share of net income (Bamford %):  AUD [____]
+  Streamed amounts (character):  [capital gain / franked + credits]
+  Recording deadline met:        [30 Jun franked / 31 Aug capital -- evidence]
+  Minor? Div 6AA band:           [nil / 66% band / 45%]
+  Entitlement PAID or UPE:       [paid date / UPE balance]
+  s 100A zone assessment:        [white/green/red + why]
+
+TRUSTEE-ASSESSED AMOUNTS
+  s 99A income (no entitlement): AUD [____] x 47% = AUD [____]
+  s 98 amounts (minors/non-residents -- escalate non-residents): AUD [____]
+
+WITHHOLDING / FTDT
+  TFN withholding 47%:           AUD [____]  (report 30 Sep; pay 28 Oct)
+  FTDT events:                   AUD [____] x 47% = AUD [____] (due 21 days)
+
+REVIEWER FLAGS
+  [Tier 2 flags, refusals triggered, reform-horizon notes]
+```
+
+---
+
+## Section 8 -- Reading guide
+
+1. Deed first, always: income clause, streaming powers, default beneficiaries, deadlines, vesting date. Every later step depends on it.
+2. Date-stamp the resolution before anything else -- a perfect resolution signed 1 July is a 47% problem.
+3. Reconcile trust income to s 95 net income before allocating; the Bamford percentage applies to net income.
+4. Sweep beneficiary loan/UPE accounts: aged UPEs are the s 100A and Bendel intersection.
+5. Map the family group annually where an FTE exists -- FTDT has no de minimis.
+6. Minors: check the character of what they receive before assuming penalty rates (or assuming they don't apply).
+7. Label every 2026 reform item as LAW (Tax Reform No. 1 Act, from 1 July 2027) or ANNOUNCED (30% trustee minimum tax, from 1 July 2028) -- never blur them.
+
+---
+
+## Section 9 -- Onboarding fallback
+
+If the client provides only financial statements and a trial balance:
+
+1. Pull trust income and any "distributions" from equity/liability movements; list beneficiary credit balances as UPE candidates
+2. Build the resolution register with resolution date UNKNOWN flagged; request the signed minutes and the deed
+3. Recompute Bamford shares from stated percentages against net income per the return workpapers
+4. Screen every UPE for s 100A zone features; screen every beneficiary against the (unconfirmed) family group
+5. **Flag:** "Prepared from financial statements only. Deed, signed resolutions, streaming records, TFN evidence and FTE status not sighted. Present entitlement at 30 June unverified -- s 99A exposure unquantified. Reviewer must confirm before lodgment."
+
+---
+
+## Section 10 -- Reference material
+
+### Key figures
+
+| Item | Value |
+|---|---|
+| s 99A / FTDT / TFN-withholding / TBNT rate | 47% (45% + 2% Medicare levy) |
+| Div 6AA minor bands (resident) | $416 nil / $417-$1,307 at 66% of excess over $416 / > $1,307 at 45% of whole |
+| Streaming recording deadlines | Franked: 30 June. Capital gains via capital appointment: 31 August |
+| FTDT due date | 21 days after distribution (or after election if later) |
+| TFN withholding calendar | Report 30 Sep; payment summaries 14 Oct; pay 28 Oct; quarterly TFN report abolished 1 July 2026 |
+| TFN withholding de minimis | $120 per beneficiary per year |
+| Franking-credit ceiling without FTE (non-fixed trust) | $5,000 per beneficiary |
+| CGT reform start (LAW) | 1 July 2027 (indexation + 30% minimum rate; trustee statements) |
+| Trustee minimum tax (ANNOUNCED, not law) | 30% from 1 July 2028; testamentary and other carve-outs under consultation |
+
+### Primary sources (verified 20 August 2026)
+
+| Topic | Source |
+|---|---|
+| Division 6, 6AA, 6D, 6E, s 99A, s 100A | ITAA 1936 (current compilation, legislation.gov.au); ITAA 1997 Subdivs 115-C, 207-B |
+| Minor rates | ato.gov.au -- Tax rates if you're under 18 years old; Income Tax Rates Act 1986 |
+| Trustee resolutions & streaming deadlines | ato.gov.au -- Trustee resolutions checklist (QC 25912); Becoming specifically entitled |
+| Proportionate approach | *FCT v Bamford* [2010] HCA 10 |
+| s 100A | TR 2022/4; PCG 2022/2 (8 Dec 2022); *Guardian* [2023] FCAFC 3; *BBlood* [2022] FCA 1112, [2023] FCAFC 89; TA 2022/1 |
+| Bendel / UPEs | [2026] HCA 18 (10 June 2026); ATO decision impact statement 26 June 2026; au-div7a skill Rule 11 |
+| FTE / FTDT | ato.gov.au -- Family trusts (FTDT 47%, due 21 days, joint & several directors); Sch 2F ITAA 1936 |
+| TFN withholding | ato.gov.au -- TFN withholding for closely held trusts: What trustees need to do (QC 23140, updated 16 July 2026); Changes to beneficiary TFN reporting (QC 107776, 14 July 2026) |
+| Circular distributions | s 102UM ITAA 1936; Treasury Laws Amendment (2019 Tax Integrity and Other Measures No. 1) Act 2019 |
+| 2026 reforms | Treasury Laws Amendment (Tax Reform No. 1) Act 2026 (Assent 26 June 2026); ATO -- Reforming negative gearing and CGT (QC 107304, updated 29 June 2026); 2026-27 Budget (12 May 2026); Treasury consultation paper 8 July 2026 |
+
+### Test suite
+
+**Test 1:** Trust income $100,000, net income $120,000, 50/50 resolution. -> Each beneficiary assessed on $60,000.
+
+**Test 2:** No resolution, no default clause, net income $80,000. -> s 99A: $37,600.
+
+**Test 3:** Resident minor's eligible trust income $416 -> nil. $1,200 -> $517.44. $10,000 -> $4,500 (whole amount at 45%), before Medicare levy.
+
+**Test 4:** Capital-gain streaming minute signed 15 September. -> Too late (31 August); gain flows proportionately or to the trustee at 47%.
+
+**Test 5:** Franked-distribution streaming recorded 15 July. -> Too late (30 June); credits follow the proportionate/adjusted Div 6E shares instead.
+
+**Test 6:** FTE trust distributes $50,000 to a beneficiary outside the family group. -> FTDT $23,500, due 21 days after the distribution; excluded from recipient's assessable income.
+
+**Test 7:** Beneficiary refuses to quote a TFN; entitlement $1,000. -> Withhold $470 at the time of entitlement; report by 30 Sep; pay by 28 Oct.
+
+**Test 8:** UPE to bucket company sits unpaid, company passive. -> No Div 7A loan (*Bendel*); run s 100A / Subdiv EA screens per au-div7a; corporate beneficiary still assessed on its s 97 share.
+
+**Test 9:** Trust A distributes to Trust B which distributes back to Trust A. -> s 102UM TBNT at 47% even with an FTE; refuse and escalate.
+
+**Test 10:** Client asks you to apply the 30% trustee minimum tax to 2026-27 distributions. -> Refuse: announced-not-law, proposed start 1 July 2028; the ENACTED changes start 1 July 2027 and concern CGT.
+
+### Prohibitions
+
+- NEVER backdate, or help reconstruct after 30 June, a trustee resolution
+- NEVER assume trust income equals s 95 net income without the deed
+- NEVER stream a capital gain recorded after 31 August or a franked distribution recorded after 30 June
+- NEVER apply adult rates to a minor's eligible trust income -- and never assume Div 6AA applies to excepted income
+- NEVER let an FTE trust distribute to an unmapped beneficiary without pricing FTDT at 47%
+- NEVER treat a passive UPE as a Div 7A loan post-Bendel -- and NEVER skip the s 100A / Subdiv EA screen
+- NEVER claim green-zone protection without documenting how the scenario conditions are met
+- NEVER present the announced 30% minimum trustee tax (or any consultation design detail) as law
+- NEVER compute trust loss recoupment, non-resident trustee assessments, or TBNT without escalating
+- NEVER present figures as definitive
+
+---
+
+## Disclaimer
+
+This skill and its outputs are provided for informational and computational purposes only and do not constitute tax, legal, or financial advice. Open Accountants and its contributors accept no liability for any errors, omissions, or outcomes arising from the use of this skill. All outputs must be reviewed and signed off by a qualified professional (such as a CPA, CA, tax agent, or equivalent licensed practitioner in your jurisdiction) before filing or acting upon.
+
+The most up-to-date, verified version of this skill is maintained at [openaccountants.com](https://www.openaccountants.com). Log in to access the latest version, request a professional review from a licensed accountant, and track updates as tax law changes.
+
+> Contributed by Ryan Duguid.
+
+<!-- openaccountants-cta-block -->
+
+---
+
+## Talk to a verified accountant
+
+This guide is maintained by the OpenAccountants network — accountants who put
+their name behind the tax answers AI gives people. The live, always-current
+version (and the professional behind it) is at
+[openaccountants.com](https://www.openaccountants.com).
+
+- Use it in your AI: https://www.openaccountants.com/connect
+- Meet the accountants: https://www.openaccountants.com/network
+
+> **General reference only.** This document does not constitute tax, legal, or
+> financial advice. Verify figures against the cited primary sources or with a
+> licensed professional before relying on them.

--- a/workflows/README.md
+++ b/workflows/README.md
@@ -13,6 +13,7 @@ When a user's situation matches a trigger, fetch the relevant jurisdiction bundl
 | Malta freelancer | [malta-freelancer.md](malta-freelancer.md) | Malta self-employed / part-time |
 | Portugal self-employed | [portugal-self-employed.md](portugal-self-employed.md) | Portugal NHR/IFICI / recibos verdes |
 | UK capital gains | [uk-capital-gains.md](uk-capital-gains.md) | UK shares, crypto, or property sale |
+| Australia company & trust | [australia-company-trust.md](australia-company-trust.md) | AU Pty Ltd, family trust, Div 7A, franking |
 
 ## How to use via MCP
 

--- a/workflows/australia-company-trust.md
+++ b/workflows/australia-company-trust.md
@@ -1,0 +1,69 @@
+# Australia Small Company & Trust Tax Workflow
+
+**MCP prompt name:** `australia-company-trust`
+**Bundle:** `GET https://www.openaccountants.com/api/bundle/AU`
+
+## Trigger phrases
+
+- "my company's tax return Australia"
+- "Pty Ltd tax"
+- "base rate entity"
+- "franking my dividend"
+- "family trust distribution"
+- "trustee resolution"
+- "bucket company"
+- "Div 7A loan"
+- "selling my business CGT concessions"
+- "PSI company"
+
+## What it produces
+
+- Company taxable-income reconciliation working paper (add-backs, timing differences)
+- BRE rate determination (25% vs 30%) with the two-limb test evidenced
+- Franking account rollforward and maximum-frankable-distribution check
+- Trust distribution package: s 95 net income, resolution checklist (30 June deadline), streaming schedule, s 100A risk-zone screen
+- Div 7A loan register: benchmark interest, minimum yearly repayments, deemed-dividend exposure
+- PSI screen for service entities (attribution risk and PCG 2025/5 zones)
+- Division 152 eligibility map when a business sale is in scope
+- Reviewer brief with escalation list
+
+## Skills to load
+
+From the AU bundle:
+- `au-rates-2026-27` — current-year figures used throughout
+- `au-company-tax` — BRE tests, franking, losses, lodgment program
+- `au-trust-distributions` — Div 6, resolutions, streaming, s 100A, FTE/FTDT
+- `au-div7a` — shareholder loans, UPEs post-Bendel, MYR arithmetic
+- `au-psi` — personal services income attribution and Part IVA zones
+- `au-small-business-cgt` — Div 152 concessions when a sale/restructure is live
+- `au-fbt` — employee benefits picked up in the company ledger
+- `australia-gst` — BAS reconciliation for the entity
+- `au-return-assembly` — final assembly and reviewer brief
+
+## 6-phase structure
+
+### Phase 1 — Entity intake
+Establish: entity type (company / discretionary trust / unit trust / company-as-trustee), income year, aggregated turnover (grouping connected entities and affiliates), shareholder/beneficiary map with associate relationships, prior-year returns, franking account balance brought forward, existing Div 7A loan agreements, FTE status. Upload-first: ASIC extract, prior return, trust deed, loan agreements, trial balance. A trust return without the deed and any FTE/IEE history is an automatic reviewer flag.
+
+### Phase 2 — Ledger sweep
+Run the GL sweep tables from `au-company-tax` (companies) or `au-trust-distributions` (trusts). Highest-risk patterns: debit loans to shareholders or beneficiaries (route to `au-div7a`), partner/director "salary" that is really a distribution, GIC/SIC in the interest expense account (not deductible from 1 July 2025), one individual generating the revenue of a service entity (route to `au-psi`), trust distribution journals without a matching signed resolution.
+
+### Phase 3 — Entity tax computation
+**Companies:** reconcile accounting profit to taxable income; determine BRE status on the two-limb test (watch bucket companies: trust distributions are usually base rate entity passive income); apply 25%/30%; compute franking for any distributions paid and check the account never goes into deficit at 30 June. **Trusts:** compute s 95 net income vs distributable income; confirm present entitlement by 30 June via signed resolutions; apply streaming where the deed permits; screen every arrangement against the PCG 2022/2 s 100A zones; s 99A exposure for any undistributed income.
+
+### Phase 4 — Cross-entity flows
+Trace every dollar crossing entity lines: dividends carry franking (gross-up and offset in the recipient), trust distributions carry character (BREPI in a bucket company), UPEs to corporate beneficiaries follow Bendel (not Div 7A loans while passive, but s 100A and Subdiv EA still bite), loans and payments to shareholders/associates go through the Div 7A register with complying-agreement deadlines diarised to lodgment day.
+
+### Phase 5 — Positions and elections
+Confirm before lodgment: loss utilisation (COT/similar business test evidence for companies; Schedule 2F escalation for trusts), FTE make/keep/revoke analysis where franking credits or losses flow through the trust, Div 152 concession stack if a CGT event occurred (gateways first, then concession order), instant asset write-off claims against the current threshold, PAYG instalment variation risk (GIC on shortfalls below 85%, and GIC is no longer deductible).
+
+### Phase 6 — Handoff
+Run `au-return-assembly` for the reviewer brief. The brief must list: BRE determination basis, franking account closing balance, resolution dates sighted, s 100A zone conclusions, Div 7A register with next MYR dates, and every escalation triggered from refusal catalogues. Recommend review by a registered tax agent or CA/CPA. Lodgment dates follow the agent program (`au-company-tax` Rule 9). Route to: https://www.openaccountants.com
+
+## Escalation boundaries
+
+This workflow stops and refers when it hits: consolidation/MEC groups, trust loss recoupment, Everett assignments, s 100A red-zone arrangements, restructures and rollovers, international dealings, R&D claims, or any dispute already on foot. The refusal catalogues in the loaded skills are binding.
+
+## Verifier
+
+Pending. Australian CPA/CA sign-off required; drafted from primary sources (ATO, legislation.gov.au) and awaiting Partner review.


### PR DESCRIPTION
## What

Two pieces of connective tissue for the AU pack. **Stacks on #118** (includes its commits; only the last commit is new). Happy to rebase once #118 merges.

### `au-rates-2026-27` — single-page rates card
Every AU guide repeats indexed figures, and each 1 July they all go stale at once. This card gives the pack one lookup surface for 2026-27 (with 2025-26 retained for this lodgment season):

- Individual brackets (incl. the 15% band and its 14% successor), LITO taper, $1,000 standard WRE deduction with PSI exclusion
- HELP marginal-system bands; Medicare levy/MLS/PHI rebate **by period** (1 Apr 2026 step-down)
- Super: CC $32,500 / NCC $130,000 + bring-forward TSB tiers / TBC $2.1m / CGT cap $1,935,000 / Div 293 / Div 296 / downsizer, and the **maximum contribution base's structural change to annual $270,830** under payday super
- Companies: BRE tests, franking fractions, Div 7A 8.77%, PAYG GDP uplift 5%, 4-year SME amendments
- FBT 2026-27 (gross-ups, EV/PHEV state, 5.47c/km charging shortcut, $10,962 record-keeping base)
- CGT: discount rules, the 1 Jul 2027 indexation+30% reform, FRCGW 15%, Div 152 gateways
- GST/IAWO/penalty units ($364)/GIC non-deductibility; NMW $26.44; payroll tax by state; ASIC fees

Every row names its primary source; all verified 2026-08-20. A **maintenance rule** section makes the card subordinate: topic guide updates first, card in the same PR, topic guide wins any disagreement.

### `workflows/australia-company-trust.md` — second AU guided workflow
The four #118 guides serve company/trust engagements; this gives them the same 6-phase workflow harness as the sole-trader flow in #115: entity intake → GL sweep → entity computation → **cross-entity flows** (franking, BREPI character in bucket companies, post-Bendel UPEs, Div 7A register) → positions/elections → reviewer handoff with binding escalation boundaries.

README row appended at the table's end so it merges cleanly with #115's insertion.

## Checks
- `python3 scripts/validate-guides.py --no-index-check` passes
- `skills/**` + `workflows/**` only
- Australian English throughout