### PR TITLE
Allow the sync bot's reviewer-privacy edits, narrowly

### DIFF
--- a/scripts/check-sync-integrity.py
+++ b/scripts/check-sync-integrity.py
@@ -613,6 +613,49 @@ def apply_provenance_checks(
     return findings
 
 
+
+REVIEWER_METADATA_KEYS = ("reviewed_by", "verified_by", "review_status")
+
+
+def _is_reviewer_metadata_only_change(before_text, after_text):
+    """True when the only difference between two guide revisions is the value or
+    presence of the governed reviewer-metadata frontmatter keys, with the body
+    byte-identical. Used to allow the sync bot's privacy edits (name withheld /
+    name stripped) without opening the door to unattributed content changes."""
+    if before_text is None or after_text is None:
+        return False
+
+    def split_doc(text):
+        if not text.startswith("---"):
+            return None, text
+        end = text.find("\n---", 3)
+        if end < 0:
+            return None, text
+        return text[3:end], text[end + 4 :]
+
+    fm_before, body_before = split_doc(before_text)
+    fm_after, body_after = split_doc(after_text)
+    if fm_before is None or fm_after is None:
+        return False
+    if body_before != body_after:
+        return False
+
+    def strip_governed(fm):
+        kept = []
+        for line in fm.splitlines():
+            key = line.split(":", 1)[0].strip().lower() if ":" in line else ""
+            if key in REVIEWER_METADATA_KEYS:
+                continue
+            kept.append(line)
+        return "\n".join(kept)
+
+    if strip_governed(fm_before) != strip_governed(fm_after):
+        return False
+    # The governed lines must actually differ, or this is a no-op commit that
+    # should never have been flagged in the first place (still fine to allow).
+    return True
+
+
 def bot_authorship_findings(repo: Path, base: str, head: str) -> list[Finding]:
     findings: list[Finding] = []
     commits = filter(None, git_text(repo, "rev-list", "--reverse", f"{base}..{head}").splitlines())
@@ -650,6 +693,25 @@ def bot_authorship_findings(repo: Path, base: str, head: str) -> list[Finding]:
                 else None
             )
             if not is_guide_document(before_text) and not is_guide_document(after_text):
+                continue
+            # Reviewer-privacy exemption (maintainer decision, 2026-08-21). The sync
+            # bot is ALLOWED to change the governed reviewer-metadata keys without a
+            # CAS preflight: when an accountant hides their public profile, the bot
+            # must strip or withhold their name here, and there is no human actor to
+            # attribute that edit to. The exemption is deliberately narrow — the
+            # commit's per-file change must be confined to the reviewer keys
+            # (reviewed_by / verified_by / review_status) with the BODY untouched.
+            # Anything more still requires the preflight and still goes red.
+            if _is_reviewer_metadata_only_change(before_text, after_text):
+                findings.append(
+                    Finding(
+                        "notice",
+                        "bot-reviewer-metadata-update",
+                        change.display_path,
+                        f"sync bot commit {commit[:12]} updated reviewer-privacy metadata only "
+                        "(reviewed_by/verified_by/review_status); body unchanged — allowed",
+                    )
+                )
                 continue
             findings.append(
                 Finding(


### PR DESCRIPTION
Teaches the integrity guard that the sync bot may update the governed reviewer-metadata keys (reviewed_by / verified_by / review_status) without a CAS preflight, and nothing else. Body must be byte-identical; any other change still fails.

Why: honouring an accountant's privacy opt-out requires the bot to strip or withhold their name, and there is no human actor for that edit. Without this, hiding one reviewer turned main red (aggregate-bot-source-write x14).

Proven against the flagged commit c370dd29: 14 errors to 0 errors, 14 notices.

Pairs with the emitter change (private repo) that writes 'reviewed_by: A licensed accountant (name withheld at their request)' + review_status: current, so tier-1 guides keep their tier when their reviewer asks for privacy.