### PR TITLE
docs: add Related open-source projects section to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,6 +102,19 @@ API and platform integrations: [openaccountants.com/for-developers](https://www.
 
 ---
 
+## Related open-source projects
+
+Independent, open-source review aids and calculation tools that complement the OpenAccountants guide library:
+
+- **[payday-super-checker](https://github.com/ryanduguid/payday-super-checker)** (MIT) — Verifies superannuation contributions against Australian Payday Super deadlines (in force since 1 July 2026) and estimates SG charge exposure on late payments, with all workings and statutory assumptions disclosed.
+- **[div7a-loan-review](https://github.com/ryanduguid/div7a-loan-review)** (MIT) — Reviews Division 7A loan terms and minimum yearly repayments against the ATO benchmark interest rate, with fabricated inputs and explicit refusal boundaries.
+- **[xero-trial-balance-export](https://github.com/ryanduguid/xero-trial-balance-export)** (MIT) — Exports a Xero trial balance to CSV only when month-movement and YTD column pairs both balance exactly.
+- **[ato-benchmark-compare](https://github.com/ryanduguid/ato-benchmark-compare)** (MIT) — Evaluates business P&L statements locally against the Australian Taxation Office (ATO) small business performance benchmarks, surfacing variance flags and ratio analyses.
+
+*(External tools provide computational review assistance and do not constitute tax or legal advice.)*
+
+---
+
 ## License
 
 - **Code** (mcp/, scripts/, tools/): [AGPL-3.0](LICENSE)


### PR DESCRIPTION
## What this PR does

Fixes #108 by introducing a curated "Related open-source projects" section in the README for open-source review aids and computation tools that complement the OpenAccountants guides.

Featured projects:
- **[payday-super-checker](https://github.com/ryanduguid/payday-super-checker)** (MIT) — Verifies superannuation contributions against Australian Payday Super deadlines (1 July 2026) and estimates SG charge exposure.
- **[div7a-loan-review](https://github.com/ryanduguid/div7a-loan-review)** (MIT) — Reviews Division 7A loan terms and minimum yearly repayments against the ATO benchmark interest rate, with fabricated inputs and explicit refusal boundaries.
- **[xero-trial-balance-export](https://github.com/ryanduguid/xero-trial-balance-export)** (MIT) — Exports a Xero trial balance to CSV only when month-movement and YTD column pairs both balance exactly.
- **[ato-benchmark-compare](https://github.com/ryanduguid/ato-benchmark-compare)** (MIT) — Evaluates business P&L statements locally against ATO small business benchmarks.

Includes clear positioning as computational review aids rather than formal tax/legal advice.

Rebased onto current `main` so the README insertion still applies after recent platform syncs.

## Country/jurisdiction affected

Global / Australia

## Legal — Contributor License Agreement (CLA)

- [x] **I have read [CLA.md](https://github.com/openaccountants/openaccountants/blob/main/CLA.md) and agree to the Contributor License Agreement** for everything included in this pull request. *(Checking this box is your explicit opt-in.)*

## Checklist

- [x] I only edited source files (README.md)
- [x] **Name for attribution**: Ryan Duguid