### PR TITLE
fix: repair mojibake in the South Korea and Kenya guides

### DIFF
--- a/skills/international/kenya/ke-income-tax-2.md
+++ b/skills/international/kenya/ke-income-tax-2.md
@@ -25,14 +25,8 @@ CONTENT
 Act-
 PAGE
 The Finance Act, 2026 ................................. .......... .................. ........................ 349
-/(r=-
-NATIONAL COUNCIL FOR !/ LAW REPORTING
-ll usn􀀇
-0
-R􀀣 u􀀃:􀀄1
-􀀈,ve
-\.."=========£1
-PRINTED AND PUBLISHED BY THE GOVERNMENT PRJNTER, NAIROBI
+NATIONAL COUNCIL FOR LAW REPORTING
+PRINTED AND PUBLISHED BY THE GOVERNMENT PRINTER, NAIROBI
 349
 THE FINANCE ACT, 2026
 No. 19 of 2026

--- a/skills/international/south-korea/simplified-business-operator-registration-under-vat-act.md
+++ b/skills/international/south-korea/simplified-business-operator-registration-under-vat-act.md
@@ -21,17 +21,17 @@ Under the Korean VAT regime for electronic services from overseas suppliers, the
 
 2. Scope of Electronic Services
 Electronic services generally include the following:
-	Digitally delivered content, including games, audio and video files, software, and other electronically processed digital products, as well as services related to the enhancement of such products;
-	Online advertising services;
-	Cloud computing services; and
-	Platform or intermediary services that facilitate the lease, use, consumption, or supply of goods and services within Korea.
+- Digitally delivered content, including games, audio and video files, software, and other electronically processed digital products, as well as services related to the enhancement of such products;
+- Online advertising services;
+- Cloud computing services; and
+- Platform or intermediary services that facilitate the lease, use, consumption, or supply of goods and services within Korea.
 
 3. Simplified VAT Registration for Foreign Service Providers
 Foreign suppliers are required to apply for simplified VAT registration through the NTS Hometax system within 20 days of commencing business activities by providing the information set out below.
-	The names of business operator or representative, telephone numbers, mail addresses, email addresses, website addresses and other contact information of the businesses and representative. In such cases, if a corporate business uses a name, other than the corporate name, in transactions, such name shall be included.
-	The country of registration, address, registration number and other information on registration of business in a country in which the place of business supplying services is located.
-	The types of electronic services supplied, the date the business commences a business supplying electronic services in Korea.
-	Tax manager’s name, resident number, tax registration number, telephone number, email address(where a tax manager is hired).
+- The names of business operator or representative, telephone numbers, mail addresses, email addresses, website addresses and other contact information of the businesses and representative. In such cases, if a corporate business uses a name, other than the corporate name, in transactions, such name shall be included.
+- The country of registration, address, registration number and other information on registration of business in a country in which the place of business supplying services is located.
+- The types of electronic services supplied, the date the business commences a business supplying electronic services in Korea.
+- Tax manager’s name, resident number, tax registration number, telephone number, email address(where a tax manager is hired).
 
 4. VAT Filing and Payment Deadlines
 
@@ -45,10 +45,10 @@ The 2nd Final Return	10.1 ~ 12.31	Next year 1.1 ~ 1.25
 
 Information Required for VAT Filing
 Taxpayers are required to file VAT returns by reporting the following information through the NTS Hometax system:
-	Business name and simplified VAT registration number;
-	Total value of electronic services supplied during the relevant filing period;
-	Input VAT eligible for deduction; and
-	Net VAT payable.
+- Business name and simplified VAT registration number;
+- Total value of electronic services supplied during the relevant filing period;
+- Input VAT eligible for deduction; and
+- Net VAT payable.
 Where consideration for electronic services supplied in Korea is received in a foreign currency, the taxable amount may be converted into Korean won using the basic exchange rate as of the last day of the relevant filing period.
 The basic exchange rate published by the Seoul Money Brokerage Services (SMBS) is used for this purpose. If the last day of the filing period falls on a Saturday or a public holiday, the exchange rate applicable on the immediately preceding business day should be used.
 
@@ -57,12 +57,12 @@ Taxpayers registered under the simplified VAT registration regime may claim only
 
 VAT Payment Procedures
 VAT payable must be remitted to a designated foreign exchange bank account prescribed by the Commissioner of the National Tax Service (NTS).
-	The designated VAT payment account number is provided to the taxpayer (or its tax agent) via email and is also available in the Basic Information of Simplified Business Operator section of the NTS Hometax system.
-	As a general rule, VAT must be paid in Korean won (KRW).
-	For payments remitted from overseas, taxpayers may pay VAT in U.S. dollars (USD) to the designated VAT account using the basic exchange rate applicable as of the last day of the relevant taxable period.
-	The basic exchange rate published by the Seoul Money Brokerage Services (SMBS) is used for this purpose.
-	If the last day of the taxable period falls on a Saturday or public holiday, the exchange rate applicable on the immediately preceding business day should be used.
-	Any bank remittance charges are borne by the taxpayer.
+- The designated VAT payment account number is provided to the taxpayer (or its tax agent) via email and is also available in the Basic Information of Simplified Business Operator section of the NTS Hometax system.
+- As a general rule, VAT must be paid in Korean won (KRW).
+- For payments remitted from overseas, taxpayers may pay VAT in U.S. dollars (USD) to the designated VAT account using the basic exchange rate applicable as of the last day of the relevant taxable period.
+- The basic exchange rate published by the Seoul Money Brokerage Services (SMBS) is used for this purpose.
+- If the last day of the taxable period falls on a Saturday or public holiday, the exchange rate applicable on the immediately preceding business day should be used.
+- Any bank remittance charges are borne by the taxpayer.
 
 > Contributed by Yeong Min Lee, 16491.
 


### PR DESCRIPTION
## What this PR does

Removes private-use Unicode characters that no font renders from two guides, which currently breaks list rendering in the South Korea guide and leaves unreadable debris in the Kenya guide.

## Country/jurisdiction affected

South Korea (`KR`) and Kenya (`KE`).

## Detail

**`skills/international/south-korea/simplified-business-operator-registration-under-vat-act.md`**

Eighteen list items begin with `U+F09F` followed by a tab. That codepoint is a Wingdings bullet in the Windows private-use area, the usual artefact of pasting from a PDF or a Word document. Markdown does not treat those lines as list items, so sections 2, 3, "Information Required for VAT Filing" and the payment notes each render as a single run-on paragraph. Replaced every occurrence with a hyphen bullet.

**`skills/international/kenya/ke-income-tax-2.md`**

Five characters in the supplementary private-use area (`U+100003`, `U+100004`, `U+100007`, `U+100008`, `U+100023`) sit inside six lines of OCR debris scanned from the gazette emblem. Removed those lines and corrected the two adjacent OCR errors they obscured:

- `NATIONAL COUNCIL FOR !/ LAW REPORTING` to `NATIONAL COUNCIL FOR LAW REPORTING`
- `GOVERNMENT PRJNTER` to `GOVERNMENT PRINTER`

No legal content, rate, threshold, citation or frontmatter field is altered. The diff is 20 insertions and 26 deletions.

## Note for maintainers, not changed here

The Kenya guide keeps further OCR noise above the block I touched (`SPECIAL ISSUE`, `N A`, `TtoN A, cot r.c, t. cnR I`, `LAW REPORT! NG`, `·. UBRAEY`). I left it alone because it renders as legible text rather than as missing glyphs, and cleaning a scanned masthead felt outside the scope of a character-encoding fix. Happy to take it in a follow-up if you want it gone.

Both files also exist under `packages/`. Per CONTRIBUTING.md I have not touched the generated trees.

## Legal - Contributor License Agreement (CLA)

- [x] **I have read [CLA.md](https://github.com/openaccountants/openaccountants/blob/main/CLA.md) and agree to the Contributor License Agreement** for everything included in this pull request.

I agree to the CLA at CLA.md.

## Checklist

### Repo & sync (required)

- [x] File is in `skills/` (not only `packages/`)
- [x] Jurisdiction is clear (folder path or `jurisdiction:` in frontmatter)
- [x] I only edited files under `skills/**` (generated trees rebuild automatically)
- [x] **Name for attribution** (as it should appear on the guide): Ryan Duguid
- [ ] My OpenAccountants profile GitHub username matches this account (optional)

### Content quality

Not applicable: this is a character-encoding repair, not a content change. No rate, threshold, citation, example or disclaimer is added or modified.
