### PR TITLE
fix(validate): grandfather the flat depends_on in the skills sweep too

### DIFF
--- a/scripts/build-packages.py
+++ b/scripts/build-packages.py
@@ -38,7 +38,11 @@ import re
 import shutil
 import sys
 
-from frontmatter_yaml import FrontmatterError, load_frontmatter
+from frontmatter_yaml import (
+    FrontmatterError,
+    load_frontmatter,
+    normalize_legacy_depends_on,
+)
 
 REPO_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 SKILLS_DIR = os.path.join(REPO_ROOT, "skills")
@@ -1027,7 +1031,7 @@ def validate_generated_frontmatter():
                     failures.append(f"{rel}: frontmatter opens with --- but never closes")
                 continue
             try:
-                load_frontmatter(block)
+                load_frontmatter(normalize_legacy_depends_on(block))
             except FrontmatterError as exc:
                 failures.append(f"{rel}: invalid YAML frontmatter: {exc}")
     return failures

--- a/scripts/frontmatter_yaml.py
+++ b/scripts/frontmatter_yaml.py
@@ -9,6 +9,7 @@ last-key-wins result hides which value an author intended.
 
 from __future__ import annotations
 
+import re
 from typing import Any
 
 import yaml
@@ -71,6 +72,29 @@ _STRING_FIELDS = {
     "review_status",
     "license",
 }
+
+
+LEGACY_DEPENDS_ON = re.compile(r"^(depends_on):[ \t]+(- .+)$", re.MULTILINE)
+
+
+def normalize_legacy_depends_on(block: str) -> str:
+    """Fold the legacy single-line `depends_on: - x` into a real YAML list.
+
+    663 generated files (and their skills/ sources) predate the strict sweep and
+    carry the flat form, which strict YAML rejects ("sequence entries are not
+    allowed here"). The strictness is right for everything NEW; failing the
+    whole tree on a format that shipped for months is not. Normalizing exactly
+    this one known shape keeps the sweep strict for every other error while a
+    format migration cleans the corpus (tracked separately). Never widen this
+    to other keys - each legacy exception must earn its own entry.
+
+    It sits beside `load_frontmatter` rather than inside it on purpose.
+    `load_frontmatter` stays strict, so anything validating new content still
+    rejects the flat form; only the sweeps over files that already shipped opt
+    in. Every such sweep must opt in, or the same file passes in one tree and
+    fails in another.
+    """
+    return LEGACY_DEPENDS_ON.sub(lambda m: f"{m.group(1)}:\n  {m.group(2)}", block)
 
 
 def _problem_text(exc: yaml.YAMLError) -> str:

--- a/scripts/validate-guides.py
+++ b/scripts/validate-guides.py
@@ -41,7 +41,11 @@ import subprocess
 import sys
 import tempfile
 
-from frontmatter_yaml import FrontmatterError, load_frontmatter
+from frontmatter_yaml import (
+    FrontmatterError,
+    load_frontmatter,
+    normalize_legacy_depends_on,
+)
 
 REPO_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 BUILD_INDEX = os.path.join(REPO_ROOT, "scripts", "build-index.py")
@@ -166,23 +170,6 @@ def packages_files():
     return sorted(set(paths))
 
 
-LEGACY_DEPENDS_ON = re.compile(r"^(depends_on):[ \t]+(- .+)$", re.MULTILINE)
-
-
-def normalize_legacy_depends_on(block):
-    """Fold the legacy single-line `depends_on: - x` into a real YAML list.
-
-    663 generated files (and their skills/ sources) predate the strict sweep and
-    carry the flat form, which strict YAML rejects ("sequence entries are not
-    allowed here"). The strictness is right for everything NEW; failing the
-    whole tree on a format that shipped for months is not. Normalizing exactly
-    this one known shape keeps the sweep strict for every other error while a
-    format migration cleans the corpus (tracked separately). Never widen this
-    to other keys - each legacy exception must earn its own entry.
-    """
-    return LEGACY_DEPENDS_ON.sub(lambda m: f"{m.group(1)}:\n  {m.group(2)}", block)
-
-
 def check_packages_frontmatter(bi, errors, only_files=None):
     """Strict-YAML sweep over the whole generated packages/** tree."""
     already_checked = set(bi.guide_files())
@@ -234,7 +221,7 @@ def check_guides(bi, errors, warnings, only_files=None):
             continue
         guides += 1
         try:
-            load_frontmatter(block)
+            load_frontmatter(normalize_legacy_depends_on(block))
         except FrontmatterError as exc:
             errors.append(f"{rel}: invalid YAML frontmatter: {exc}")
             continue

--- a/tests/test_frontmatter_yaml.py
+++ b/tests/test_frontmatter_yaml.py
@@ -8,7 +8,11 @@ from pathlib import Path
 SCRIPTS = Path(__file__).resolve().parents[1] / "scripts"
 sys.path.insert(0, str(SCRIPTS))
 
-from frontmatter_yaml import FrontmatterError, load_frontmatter  # noqa: E402
+from frontmatter_yaml import (  # noqa: E402
+    FrontmatterError,
+    load_frontmatter,
+    normalize_legacy_depends_on,
+)
 
 
 class FrontmatterYamlTests(unittest.TestCase):
@@ -52,6 +56,26 @@ class FrontmatterYamlTests(unittest.TestCase):
     def test_depends_on_must_be_string_list(self) -> None:
         with self.assertRaisesRegex(FrontmatterError, "non-empty strings"):
             load_frontmatter("name: example\ndepends_on: [workflow-base, false]\n")
+
+
+class LegacyDependsOnTests(unittest.TestCase):
+    """The grandfathering has to stay opt-in, and it has to fold only this key."""
+
+    def test_folded_block_parses_as_a_list(self) -> None:
+        block = normalize_legacy_depends_on(
+            "name: example\ndepends_on: - workflow-base\n"
+        )
+        self.assertEqual(["workflow-base"], load_frontmatter(block)["depends_on"])
+
+    def test_loader_alone_still_rejects_the_flat_form(self) -> None:
+        # Callers validating new content must keep failing on it; only the
+        # sweeps over files that already shipped opt in.
+        with self.assertRaisesRegex(FrontmatterError, "sequence entries"):
+            load_frontmatter("name: example\ndepends_on: - workflow-base\n")
+
+    def test_other_keys_are_left_alone(self) -> None:
+        block = "name: example\nqualifier: - not-a-list\n"
+        self.assertEqual(block, normalize_legacy_depends_on(block))
 
 
 if __name__ == "__main__":

--- a/tests/test_validate_guides.py
+++ b/tests/test_validate_guides.py
@@ -117,6 +117,15 @@ class StrictFrontmatterTests(_ValidatorCase):
         self.assertEqual(len(errors), 1, errors)
         self.assertIn("invalid YAML frontmatter", errors[0])
 
+    def test_legacy_flat_depends_on_is_grandfathered(self) -> None:
+        # The grandfathering landed on the packages sweep only, so the same
+        # file passed as a generated copy and failed as its skills/ source.
+        # Every pull request touching one of those sources then failed on
+        # shipped history it did not introduce.
+        self.assertEqual(
+            self._check_guides({"skills/legacy.md": LEGACY_FLAT_DEPENDS}), []
+        )
+
 
 class MisplacedFrontmatterTests(_ValidatorCase):
     """`---` must be at byte 0. Otherwise extract_frontmatter returns None and


### PR DESCRIPTION
#129 folded the legacy `depends_on: - x` shape into a real list before the strict parse, and its docstring covers "663 generated files (and their `skills/` sources)". Only one of the three sweeps over already-shipped files actually opted in:

| sweep | before |
|---|---|
| `validate-guides.py` → `check_packages_frontmatter` | `normalize_legacy_depends_on(block)` |
| `validate-guides.py` → `check_guides` | `load_frontmatter(block)` |
| `build-packages.py` → frontmatter sweep | `load_frontmatter(block)` |

So the same bytes pass as `packages/<x>/y.md` and fail as `skills/.../y.md`.

## Why it bites now

`f713b442` (`sync: 582 files updated from openaccountants.com`, 2026-08-22) wrote the flat shape into **469 guides** under `skills/`:

```
$ git grep -c '^depends_on: -' main -- 'skills/**/*.md' | wc -l
469
```

Any pull request touching one of those now fails `validate` on history it did not introduce, pointing at a frontmatter line the author never wrote. I hit it on #126, which edits one line of prose in `skills/international/australia/australia-formation.md`:

```
ERROR: skills/international/australia/australia-formation.md: invalid YAML
frontmatter: line 8, column 13: sequence entries are not allowed here
```

Before/after, running `check_guides` over one synthetic guide carrying the flat shape:

```
upstream/main -> ['skills/legacy.md: invalid YAML frontmatter: line 8, column 13: sequence entries are not allowed here']
this branch   -> NO ERRORS
```

## What this changes

`normalize_legacy_depends_on` and its pattern move from `validate-guides.py` into `frontmatter_yaml.py`, beside `load_frontmatter`, so all three sweeps can reach it. It is applied in the two that were missing it.

`load_frontmatter` is **unchanged**. It still rejects the flat form, so anything validating new content keeps failing on it, and `test_inline_dash_after_mapping_key_is_rejected` still passes. Only sweeps over files that already shipped opt in, which is what the grandfathering was for. A new test pins that split so the helper cannot quietly migrate into the loader.

## What this deliberately does not change

`check-sync-integrity.py` stays strict. Its `frontmatter-repaired` notice is how a legacy file gets migrated, and `test_invalid_yaml_fails_before_metadata_comparison` and `test_invalid_legacy_base_can_be_repaired` pin that. Relaxing it there would delete the migration path, not fix a bug.

If you would rather scope this to `check_guides` alone, the `build-packages.py` line is easy to drop. It is included because that sweep covers the same generated tree `check_packages_frontmatter` already grandfathers, and two sweeps over one tree disagreeing is the bug being fixed.

## Tests

`python3 -m unittest discover -s tests -p "test_*.py"` → 86 tests, OK. Four new:

- `test_legacy_flat_depends_on_is_grandfathered` in `StrictFrontmatterTests`, mirroring the existing `GeneratedPackagesTreeTests` case
- `LegacyDependsOnTests`: the folded block parses as a list, the loader alone still rejects the raw flat form, and no other key is folded

## Separate, not fixed here

`validate` on `main` is also red for a different reason: `packages/norway/*.md` carry `jurisdiction: NO`, which YAML 1.1 resolves to boolean false, and `frontmatter_yaml` rejects that coercion on purpose. That is a content fix (quote the code), so it is not in this pull request.
