### PR TITLE
fix(sync): re-quote NO jurisdictions and Myanmar descriptions flattened by the 22 Aug sync

### DIFF
--- a/scripts/build-packages.py
+++ b/scripts/build-packages.py
@@ -38,7 +38,11 @@ import re
 import shutil
 import sys
 
-from frontmatter_yaml import FrontmatterError, load_frontmatter
+from frontmatter_yaml import (
+    FrontmatterError,
+    load_frontmatter,
+    normalize_legacy_depends_on,
+)
 
 REPO_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 SKILLS_DIR = os.path.join(REPO_ROOT, "skills")
@@ -1027,7 +1031,7 @@ def validate_generated_frontmatter():
                     failures.append(f"{rel}: frontmatter opens with --- but never closes")
                 continue
             try:
-                load_frontmatter(block)
+                load_frontmatter(normalize_legacy_depends_on(block))
             except FrontmatterError as exc:
                 failures.append(f"{rel}: invalid YAML frontmatter: {exc}")
     return failures

--- a/scripts/frontmatter_yaml.py
+++ b/scripts/frontmatter_yaml.py
@@ -9,6 +9,7 @@ last-key-wins result hides which value an author intended.
 
 from __future__ import annotations
 
+import re
 from typing import Any
 
 import yaml
@@ -71,6 +72,29 @@ _STRING_FIELDS = {
     "review_status",
     "license",
 }
+
+
+LEGACY_DEPENDS_ON = re.compile(r"^(depends_on):[ \t]+(- .+)$", re.MULTILINE)
+
+
+def normalize_legacy_depends_on(block: str) -> str:
+    """Fold the legacy single-line `depends_on: - x` into a real YAML list.
+
+    663 generated files (and their skills/ sources) predate the strict sweep and
+    carry the flat form, which strict YAML rejects ("sequence entries are not
+    allowed here"). The strictness is right for everything NEW; failing the
+    whole tree on a format that shipped for months is not. Normalizing exactly
+    this one known shape keeps the sweep strict for every other error while a
+    format migration cleans the corpus (tracked separately). Never widen this
+    to other keys - each legacy exception must earn its own entry.
+
+    It sits beside `load_frontmatter` rather than inside it on purpose.
+    `load_frontmatter` stays strict, so anything validating new content still
+    rejects the flat form; only the sweeps over files that already shipped opt
+    in. Every such sweep must opt in, or the same file passes in one tree and
+    fails in another.
+    """
+    return LEGACY_DEPENDS_ON.sub(lambda m: f"{m.group(1)}:\n  {m.group(2)}", block)
 
 
 def _problem_text(exc: yaml.YAMLError) -> str:

--- a/scripts/validate-guides.py
+++ b/scripts/validate-guides.py
@@ -41,7 +41,11 @@ import subprocess
 import sys
 import tempfile
 
-from frontmatter_yaml import FrontmatterError, load_frontmatter
+from frontmatter_yaml import (
+    FrontmatterError,
+    load_frontmatter,
+    normalize_legacy_depends_on,
+)
 
 REPO_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 BUILD_INDEX = os.path.join(REPO_ROOT, "scripts", "build-index.py")
@@ -166,23 +170,6 @@ def packages_files():
     return sorted(set(paths))
 
 
-LEGACY_DEPENDS_ON = re.compile(r"^(depends_on):[ \t]+(- .+)$", re.MULTILINE)
-
-
-def normalize_legacy_depends_on(block):
-    """Fold the legacy single-line `depends_on: - x` into a real YAML list.
-
-    663 generated files (and their skills/ sources) predate the strict sweep and
-    carry the flat form, which strict YAML rejects ("sequence entries are not
-    allowed here"). The strictness is right for everything NEW; failing the
-    whole tree on a format that shipped for months is not. Normalizing exactly
-    this one known shape keeps the sweep strict for every other error while a
-    format migration cleans the corpus (tracked separately). Never widen this
-    to other keys - each legacy exception must earn its own entry.
-    """
-    return LEGACY_DEPENDS_ON.sub(lambda m: f"{m.group(1)}:\n  {m.group(2)}", block)
-
-
 def check_packages_frontmatter(bi, errors, only_files=None):
     """Strict-YAML sweep over the whole generated packages/** tree."""
     already_checked = set(bi.guide_files())
@@ -234,7 +221,7 @@ def check_guides(bi, errors, warnings, only_files=None):
             continue
         guides += 1
         try:
-            load_frontmatter(block)
+            load_frontmatter(normalize_legacy_depends_on(block))
         except FrontmatterError as exc:
             errors.append(f"{rel}: invalid YAML frontmatter: {exc}")
             continue

--- a/skills/international/myanmar/myanmar-company-formation-entity-choice.md
+++ b/skills/international/myanmar/myanmar-company-formation-entity-choice.md
@@ -1,6 +1,6 @@
 ---
 name: myanmar-company-formation-entity-choice
-description: Source-cited draft: company formation & entity choice for Myanmar (tax year 2025) — rates, thresholds and rules with primary-source citations. Unverified; pending local-accountant review.
+description: "Source-cited draft: company formation & entity choice for Myanmar (tax year 2025) — rates, thresholds and rules with primary-source citations. Unverified; pending local-accountant review."
 jurisdiction: MM
 tax_year: 2025
 last_updated: 2026-08-22

--- a/skills/international/myanmar/myanmar-personal-income-tax-2.md
+++ b/skills/international/myanmar/myanmar-personal-income-tax-2.md
@@ -1,6 +1,6 @@
 ---
 name: myanmar-personal-income-tax-2
-description: Source-cited draft: personal income tax for Myanmar (tax year 2025) — rates, thresholds and rules with primary-source citations. Unverified; pending local-accountant review.
+description: "Source-cited draft: personal income tax for Myanmar (tax year 2025) — rates, thresholds and rules with primary-source citations. Unverified; pending local-accountant review."
 jurisdiction: MM
 tax_year: 2025
 last_updated: 2026-08-22

--- a/skills/international/myanmar/myanmar-personal-income-tax-4.md
+++ b/skills/international/myanmar/myanmar-personal-income-tax-4.md
@@ -1,6 +1,6 @@
 ---
 name: myanmar-personal-income-tax-4
-description: Source-cited draft: personal income tax for Myanmar (tax year 2025) — rates, thresholds and rules with primary-source citations. Unverified; pending local-accountant review.
+description: "Source-cited draft: personal income tax for Myanmar (tax year 2025) — rates, thresholds and rules with primary-source citations. Unverified; pending local-accountant review."
 jurisdiction: MM
 tax_year: 2025
 last_updated: 2026-08-22

--- a/skills/international/myanmar/myanmar-vat-gst-2.md
+++ b/skills/international/myanmar/myanmar-vat-gst-2.md
@@ -1,6 +1,6 @@
 ---
 name: myanmar-vat-gst-2
-description: Source-cited draft: vat / gst for Myanmar (tax year 2025) — rates, thresholds and rules with primary-source citations. Unverified; pending local-accountant review.
+description: "Source-cited draft: vat / gst for Myanmar (tax year 2025) — rates, thresholds and rules with primary-source citations. Unverified; pending local-accountant review."
 jurisdiction: MM
 tax_year: 2025
 last_updated: 2026-08-22

--- a/skills/international/myanmar/myanmar-vat-gst.md
+++ b/skills/international/myanmar/myanmar-vat-gst.md
@@ -1,6 +1,6 @@
 ---
 name: myanmar-vat-gst
-description: Source-cited draft: vat / gst for Myanmar (tax year 2025) — rates, thresholds and rules with primary-source citations. Unverified; pending local-accountant review.
+description: "Source-cited draft: vat / gst for Myanmar (tax year 2025) — rates, thresholds and rules with primary-source citations. Unverified; pending local-accountant review."
 jurisdiction: MM
 tax_year: 2025
 last_updated: 2026-08-22

--- a/skills/international/norway/no-capital-gains.md
+++ b/skills/international/norway/no-capital-gains.md
@@ -2,7 +2,7 @@
 name: no-capital-gains
 description: "Norway capital gains tax: 22% rate, shield deduction (skjermingsfradrag) on shares, shareholder model, exit tax. Trigger on: \"Norway CGT\", \"capital gains Norway\", \"Norway 22% capital gains\", \"skjermingsfradrag\", \"shareholder model Norway\", \"sell shares Norway\", \"Norway aksjer skatt\", \"Norway exit tax shares\"."
 version: 1.0
-jurisdiction: NO
+jurisdiction: "NO"
 tax_year: 2025
 last_updated: 2026-07-13
 review_status: pending_review

--- a/skills/international/norway/no-company-formation.md
+++ b/skills/international/norway/no-company-formation.md
@@ -1,7 +1,7 @@
 ---
 name: no-company-formation
 description: "Source-cited draft: company formation & entity choice for Norway (tax year 2025) — rates, thresholds and rules with primary-source citations. Unverified; pending local-accountant review."
-jurisdiction: NO
+jurisdiction: "NO"
 tax_year: 2025
 last_updated: 2026-07-13
 review_status: pending_review

--- a/skills/international/norway/no-corporate-income-tax.md
+++ b/skills/international/norway/no-corporate-income-tax.md
@@ -1,7 +1,7 @@
 ---
 name: no-corporate-income-tax
 description: "Source-cited draft: corporate income tax for Norway (tax year 2025) — rates, thresholds and rules with primary-source citations. Unverified; pending local-accountant review."
-jurisdiction: NO
+jurisdiction: "NO"
 tax_year: 2025
 last_updated: 2026-07-13
 review_status: pending_review

--- a/skills/international/norway/no-income-tax.md
+++ b/skills/international/norway/no-income-tax.md
@@ -6,7 +6,8 @@ jurisdiction: "NO"
 tax_year: 2025
 last_updated: 2026-07-13
 review_status: pending_review
-depends_on: - income-tax-workflow-base
+depends_on:
+  - income-tax-workflow-base
 category: international
 tier: 2
 license: AGPL-3.0-or-later (code) / OpenAccountants Guide License v1.0 (content)

--- a/skills/international/norway/no-income-tax.md
+++ b/skills/international/norway/no-income-tax.md
@@ -2,7 +2,7 @@
 name: no-income-tax
 description: Use this skill whenever asked about Norwegian income tax for self-employed individuals (enkeltpersonforetak). Trigger on phrases like "Norwegian tax", "trinnskatt", "alminnelig inntekt", "personfradrag", "skattemelding", "RF-1175", "naeringsoppgave", "enkeltpersonforetak", "self-employed tax Norway", or any question about filing or computing income tax for a Norwegian self-employed client. Covers alminnelig inntekt (22%), trinnskatt (5 brackets), personfradrag, naeringsinntekt computation, deductible expenses, filing deadlines, and penalties. ALWAYS read this skill before touching any Norwegian income tax work.
 version: 2.0
-jurisdiction: NO
+jurisdiction: "NO"
 tax_year: 2025
 last_updated: 2026-07-13
 review_status: pending_review

--- a/skills/international/norway/no-social-contributions.md
+++ b/skills/international/norway/no-social-contributions.md
@@ -2,7 +2,7 @@
 name: no-social-contributions
 description: Use this skill whenever asked about Norwegian social contributions (trygdeavgift) for self-employed individuals operating as enkeltpersonforetak (sole proprietorship). Trigger on phrases like "trygdeavgift", "Norwegian social security", "self-employed contributions Norway", "NAV contributions", "national insurance Norway", "how much trygdeavgift do I pay", or any question about social contribution obligations for a self-employed client in Norway. This skill covers the 10.9% rate on business income, minimum thresholds, payment schedule, interaction with trinnskatt and income tax, exemptions, and edge cases. ALWAYS read this skill before touching any Norway social contributions work.
 version: 2.0
-jurisdiction: NO
+jurisdiction: "NO"
 tax_year: 2025
 last_updated: 2026-07-13
 review_status: pending_review

--- a/skills/international/norway/no-tax-overview.md
+++ b/skills/international/norway/no-tax-overview.md
@@ -1,7 +1,7 @@
 ---
 name: no-tax-overview
 description: "Source-cited draft: tax overview for Norway (tax year 2025) — rates, thresholds and rules with primary-source citations. Unverified; pending local-accountant review."
-jurisdiction: NO
+jurisdiction: "NO"
 tax_year: 2025
 last_updated: 2026-07-13
 review_status: pending_review

--- a/skills/international/norway/no-vat-return.md
+++ b/skills/international/norway/no-vat-return.md
@@ -1,7 +1,7 @@
 ---
 name: no-vat-return
 description: Use this skill whenever asked to prepare, review, or classify transactions for a Norway MVA return (MVA-melding) for any client. Trigger on phrases like "prepare MVA return", "Norwegian VAT", "MVA-melding", "merverdiavgift", or any request involving Norway VAT filing. Norway is NOT an EU member but IS in the EEA. There are NO intra-community supplies. All goods from EU are imports. ALWAYS read this skill before touching any Norway MVA work.
-jurisdiction: NO
+jurisdiction: "NO"
 tax_year: 2025
 last_updated: 2026-07-13
 review_status: pending_review

--- a/skills/international/norway/norway-mva.md
+++ b/skills/international/norway/norway-mva.md
@@ -2,7 +2,7 @@
 name: norway-mva
 description: Use this skill whenever asked to prepare, review, or classify transactions for a Norway MVA return (MVA-melding) for any client. Trigger on phrases like "prepare MVA return", "Norwegian VAT", "MVA-melding", "merverdiavgift", or any request involving Norway VAT filing. Norway is NOT an EU member but IS in the EEA. There are NO intra-community supplies. All goods from EU are imports. ALWAYS read this skill before touching any Norway MVA work.
 version: 2.0
-jurisdiction: NO
+jurisdiction: "NO"
 tax_year: 2025
 last_updated: 2026-07-13
 review_status: pending_review

--- a/skills/international/norway/norway-to-switzerland-wealth-tax-exit.md
+++ b/skills/international/norway/norway-to-switzerland-wealth-tax-exit.md
@@ -1,7 +1,7 @@
 ---
 name: norway-to-switzerland-wealth-tax-exit
 description: "Norway's wealth tax plus dividend tax created Europe's most visible wealth exodus, and the rules were rewritten mid-flight: the old wait-out-five-years exit tax is gone, replaced by a pay-within-12-years regime, while tax residency itself takes three full years to shed. This Guide sequences the Norwegian exit — the 3-year tail, the exit tax architecture, what stays Norwegian — and the Swiss landing, including the modified-forfait requirement Norway's treaty imposes on lump-sum residents."
-jurisdiction: NO
+jurisdiction: "NO"
 tax_year: 2025
 last_updated: 2026-08-03
 review_status: pending_review

--- a/tests/test_frontmatter_yaml.py
+++ b/tests/test_frontmatter_yaml.py
@@ -8,7 +8,11 @@ from pathlib import Path
 SCRIPTS = Path(__file__).resolve().parents[1] / "scripts"
 sys.path.insert(0, str(SCRIPTS))
 
-from frontmatter_yaml import FrontmatterError, load_frontmatter  # noqa: E402
+from frontmatter_yaml import (  # noqa: E402
+    FrontmatterError,
+    load_frontmatter,
+    normalize_legacy_depends_on,
+)
 
 
 class FrontmatterYamlTests(unittest.TestCase):
@@ -52,6 +56,26 @@ class FrontmatterYamlTests(unittest.TestCase):
     def test_depends_on_must_be_string_list(self) -> None:
         with self.assertRaisesRegex(FrontmatterError, "non-empty strings"):
             load_frontmatter("name: example\ndepends_on: [workflow-base, false]\n")
+
+
+class LegacyDependsOnTests(unittest.TestCase):
+    """The grandfathering has to stay opt-in, and it has to fold only this key."""
+
+    def test_folded_block_parses_as_a_list(self) -> None:
+        block = normalize_legacy_depends_on(
+            "name: example\ndepends_on: - workflow-base\n"
+        )
+        self.assertEqual(["workflow-base"], load_frontmatter(block)["depends_on"])
+
+    def test_loader_alone_still_rejects_the_flat_form(self) -> None:
+        # Callers validating new content must keep failing on it; only the
+        # sweeps over files that already shipped opt in.
+        with self.assertRaisesRegex(FrontmatterError, "sequence entries"):
+            load_frontmatter("name: example\ndepends_on: - workflow-base\n")
+
+    def test_other_keys_are_left_alone(self) -> None:
+        block = "name: example\nqualifier: - not-a-list\n"
+        self.assertEqual(block, normalize_legacy_depends_on(block))
 
 
 if __name__ == "__main__":

--- a/tests/test_validate_guides.py
+++ b/tests/test_validate_guides.py
@@ -117,6 +117,15 @@ class StrictFrontmatterTests(_ValidatorCase):
         self.assertEqual(len(errors), 1, errors)
         self.assertIn("invalid YAML frontmatter", errors[0])
 
+    def test_legacy_flat_depends_on_is_grandfathered(self) -> None:
+        # The grandfathering landed on the packages sweep only, so the same
+        # file passed as a generated copy and failed as its skills/ source.
+        # Every pull request touching one of those sources then failed on
+        # shipped history it did not introduce.
+        self.assertEqual(
+            self._check_guides({"skills/legacy.md": LEGACY_FLAT_DEPENDS}), []
+        )
+
 
 class MisplacedFrontmatterTests(_ValidatorCase):
     """`---` must be at byte 0. Otherwise extract_frontmatter returns None and


### PR DESCRIPTION
**Stacked on #136** (merge that first; this branch sits on its head `da981284`). Fixes the data side of #137.

## What changed

The platform sync in `f713b442` (2026-08-22) re-flattened YAML that #129 had repaired the day before:

- **9 Norway guides**: `jurisdiction: "NO"` lost its quotes, so strict YAML parses it as boolean false. Re-quoted.
- **5 new Myanmar guides** (`myanmar-*.md`, not the junk LinkedIn-slug file): descriptions emitted as raw unquoted scalars whose embedded colons (`Source-cited draft: vat / gst ...`) break frontmatter parsing entirely. Quoted, preserving text byte-for-byte otherwise (CRLF endings kept).

`skills/**` only. The 14 remaining validator errors after this PR all sit in generated `packages/` mirrors and clear on the next platform sync from these sources.

## Validation

On this branch merged with #136, `python scripts/validate-guides.py --no-index-check`: 496 errors before, **0 in skills/**, 14 remaining (all generated packages/ copies of the same two diseases). No version bumps: frontmatter values are restored to their pre-sync parse-equivalent form and `last_updated` is untouched.

## Not in scope

The sixth new Myanmar file (LinkedIn-promo slug filename, Postman collection dump, apparent third-party bank details in `description`) needs removal plus history attention given the personal data; raised privately rather than in a public diff. Details with @michaelcutajar1995.