### PR TITLE
Remove a contributor's name at their request

### DIFF
--- a/agent-skills/ga-income-tax/SKILL.md
+++ b/agent-skills/ga-income-tax/SKILL.md
@@ -9,7 +9,6 @@ metadata:
   quality: source-cited draft
   openaccountants_url: "https://openaccountants.com/skills/ga-income-tax"
   obligation: IT
-  reviewed_by: "Charlie Barmore, CPA (Georgia)"
 ---
 
 # Georgia Individual Income Tax Skill — Self-Employed / Sole Proprietor
@@ -203,4 +202,4 @@ The most up-to-date, verified version of this skill is maintained at [openaccoun
 
 ---
 
-_Source: [OpenAccountants](https://openaccountants.com/skills/ga-income-tax) — open tax Guides for AI, reviewed by named CPAs/CAs/EAs. Quality: **source-cited draft**. Reviewed by Charlie Barmore, CPA (Georgia). For always-current figures and named-accountant backing, connect the OpenAccountants MCP server (`openaccountants-mcp`)._
+_Source: [OpenAccountants](https://openaccountants.com/skills/ga-income-tax) — open tax Guides for AI, reviewed by named CPAs/CAs/EAs. Quality: **source-cited draft**. For always-current figures and named-accountant backing, connect the OpenAccountants MCP server (`openaccountants-mcp`)._

--- a/packages/us-ga/ga-estimated-tax-depth.md
+++ b/packages/us-ga/ga-estimated-tax-depth.md
@@ -13,7 +13,7 @@ license: AGPL-3.0-or-later (code) / OpenAccountants Guide License v1.0 (content)
 
 ## Georgia Estimated Tax — Depth Skill (Tax Year 2025)
 
-> **Companion to `ga-income-tax.md`**: That skill establishes the GA personal income tax framework — the 5.19% flat rate (2025), residency rules, retirement income exclusion, and Form 500 mechanics. Charlie Barmore noted (Nov 2025 review) that the estimated-tax discussion in `ga-income-tax.md` was thin: it stated the basic $1,000 threshold but did not address the high-income 110% safe harbor, the annualized income method, the underpayment penalty mechanics, or the interaction with the PTE election under O.C.G.A. §48-7-23. This skill fills those gaps.
+> **Companion to `ga-income-tax.md`**: That skill establishes the GA personal income tax framework — the 5.19% flat rate (2025), residency rules, retirement income exclusion, and Form 500 mechanics. A Georgia CPA noted (Nov 2025 review) that the estimated-tax discussion in `ga-income-tax.md` was thin: it stated the basic $1,000 threshold but did not address the high-income 110% safe harbor, the annualized income method, the underpayment penalty mechanics, or the interaction with the PTE election under O.C.G.A. §48-7-23. This skill fills those gaps.
 >
 > **Statutory basis**: O.C.G.A. §48-7-114 through §48-7-126 (individual estimated tax and underpayment penalty); O.C.G.A. §48-7-21 (corporate estimated tax); O.C.G.A. §48-7-23 (PTE election); Georgia Department of Revenue Regulation 560-7-8-.34 (estimated tax administration); Form 500-ES instructions (TY 2025); Form 500-UET (Underpayment of Estimated Tax by Individuals); Form 600-ES (Corporate); GA-8453 (electronic filing declaration that also captures penalty computation references).
 >
@@ -379,7 +379,7 @@ Before signing off on a Georgia estimated tax plan, the reviewer must affirmativ
 
 ## End of document footer
 
-*End of ga-estimated-tax-depth.md (v0.1, 2025-11-15). Pending review by Charlie Barmore and at least one additional Georgia-credentialed contributor per the multi-accountant verification model.*
+*End of ga-estimated-tax-depth.md (v0.1, 2025-11-15). Pending review by at least two Georgia-credentialed contributors per the multi-accountant verification model.*
 
 ## Talk to a verified accountant
 

--- a/packages/us-ga/ga-net-worth-tax.md
+++ b/packages/us-ga/ga-net-worth-tax.md
@@ -99,7 +99,7 @@ Cite to the O.C.G.A. section in any reviewer brief — Georgia Department of Rev
 
 - **S-corps pay net worth tax** — Yes, S-corporations pay Georgia Net Worth Tax. This is one of the most common mistakes made by out-of-state CPAs preparing Georgia returns. Federal S-corp status (an income tax election under IRC § 1362) has no effect on Georgia's net worth tax. The net worth tax is imposed on the corporate entity, not on its income. The S-corp computes net worth tax on Form 600S Part III using the same graduated schedule as a C-corp. There is no "small S-corp" exception, no "single-shareholder" exception, no "S-corp with QBI passthrough" exception.  _(IRC § 1362)_
 
-[AUDIT FLASH POINT — S-CORP OWNERS SURPRISED BY NET-WORTH TAX] The most frequent client complaint Charlie Barmore flagged is the S-corp owner who:
+[AUDIT FLASH POINT — S-CORP OWNERS SURPRISED BY NET-WORTH TAX] The most frequent client complaint a Georgia CPA flagged is the S-corp owner who:
 
 1. Forms a Georgia S-corp expecting to save self-employment tax
 2. Receives an audit-style notice from GA DOR a year later for unpaid net worth tax

--- a/skills/us-states/ga/ga-estimated-tax-depth.md
+++ b/skills/us-states/ga/ga-estimated-tax-depth.md
@@ -13,7 +13,7 @@ license: AGPL-3.0-or-later (code) / OpenAccountants Guide License v1.0 (content)
 
 ## Georgia Estimated Tax — Depth Skill (Tax Year 2025)
 
-> **Companion to `ga-income-tax.md`**: That skill establishes the GA personal income tax framework — the 5.19% flat rate (2025), residency rules, retirement income exclusion, and Form 500 mechanics. Charlie Barmore noted (Nov 2025 review) that the estimated-tax discussion in `ga-income-tax.md` was thin: it stated the basic $1,000 threshold but did not address the high-income 110% safe harbor, the annualized income method, the underpayment penalty mechanics, or the interaction with the PTE election under O.C.G.A. §48-7-23. This skill fills those gaps.
+> **Companion to `ga-income-tax.md`**: That skill establishes the GA personal income tax framework — the 5.19% flat rate (2025), residency rules, retirement income exclusion, and Form 500 mechanics. A Georgia CPA noted (Nov 2025 review) that the estimated-tax discussion in `ga-income-tax.md` was thin: it stated the basic $1,000 threshold but did not address the high-income 110% safe harbor, the annualized income method, the underpayment penalty mechanics, or the interaction with the PTE election under O.C.G.A. §48-7-23. This skill fills those gaps.
 >
 > **Statutory basis**: O.C.G.A. §48-7-114 through §48-7-126 (individual estimated tax and underpayment penalty); O.C.G.A. §48-7-21 (corporate estimated tax); O.C.G.A. §48-7-23 (PTE election); Georgia Department of Revenue Regulation 560-7-8-.34 (estimated tax administration); Form 500-ES instructions (TY 2025); Form 500-UET (Underpayment of Estimated Tax by Individuals); Form 600-ES (Corporate); GA-8453 (electronic filing declaration that also captures penalty computation references).
 >
@@ -379,7 +379,7 @@ Before signing off on a Georgia estimated tax plan, the reviewer must affirmativ
 
 ## End of document footer
 
-*End of ga-estimated-tax-depth.md (v0.1, 2025-11-15). Pending review by Charlie Barmore and at least one additional Georgia-credentialed contributor per the multi-accountant verification model.*
+*End of ga-estimated-tax-depth.md (v0.1, 2025-11-15). Pending review by at least two Georgia-credentialed contributors per the multi-accountant verification model.*
 
 ## Talk to a verified accountant
 

--- a/skills/us-states/ga/ga-net-worth-tax.md
+++ b/skills/us-states/ga/ga-net-worth-tax.md
@@ -99,7 +99,7 @@ Cite to the O.C.G.A. section in any reviewer brief — Georgia Department of Rev
 
 - **S-corps pay net worth tax** — Yes, S-corporations pay Georgia Net Worth Tax. This is one of the most common mistakes made by out-of-state CPAs preparing Georgia returns. Federal S-corp status (an income tax election under IRC § 1362) has no effect on Georgia's net worth tax. The net worth tax is imposed on the corporate entity, not on its income. The S-corp computes net worth tax on Form 600S Part III using the same graduated schedule as a C-corp. There is no "small S-corp" exception, no "single-shareholder" exception, no "S-corp with QBI passthrough" exception.  _(IRC § 1362)_
 
-[AUDIT FLASH POINT — S-CORP OWNERS SURPRISED BY NET-WORTH TAX] The most frequent client complaint Charlie Barmore flagged is the S-corp owner who:
+[AUDIT FLASH POINT — S-CORP OWNERS SURPRISED BY NET-WORTH TAX] The most frequent client complaint a Georgia CPA flagged is the S-corp owner who:
 
 1. Forms a Georgia S-corp expecting to save self-employment tax
 2. Receives an audit-style notice from GA DOR a year later for unpaid net worth tax


### PR DESCRIPTION
A contributor asked to be removed from OpenAccountants. This clears their name from the public repo.

**What changed (7 mentions across 5 files):**

| File | Change |
|---|---|
| `agent-skills/ga-income-tax/SKILL.md` | dropped `reviewed_by` from frontmatter and from the footer line |
| `packages/us-ga/ga-net-worth-tax.md` | name → "a Georgia CPA" |
| `packages/us-ga/ga-estimated-tax-depth.md` | name → "a Georgia CPA"; "pending review by X and one additional" → "by at least two Georgia-credentialed contributors" |
| `skills/us-states/ga/*` | same two files, other tree |

No tax content changed. Every sentence keeps its meaning.

**Two things worth knowing:**

1. The `reviewed_by: "…CPA (Georgia)"` on `ga-income-tax` was **not supported by the database** — there is no review record for that Guide by anyone, and the same file declares `quality: source-cited draft` two lines above. So this also removes a false verification claim, not only a name.

2. **This could not have been fixed by cleaning the database alone.** `scripts/publish-to-public-repo.ts` preserves a name already present in a file when the DB has no review record (`reviewedBy = verifiedByDb ?? preservable`). Its only strip path is `isHiddenName`, which reads live `accountant_applications` — so once the account is deleted, the name can never be stripped automatically. The file edit had to come first. `agent-skills/` is generated by no script at all, so it would never have self-corrected regardless.

Git history still contains the old content; only the current tree is cleaned.