### PR TITLE
AU 2026-27 HELP bands, G1 GST-inclusive default, and STSL example

### DIFF
--- a/skills/international/australia/au-individual-return.md
+++ b/skills/international/australia/au-individual-return.md
@@ -1,10 +1,10 @@
 ---
 name: au-individual-return
 description: Use this skill whenever asked about Australian individual income tax for sole traders. Trigger on phrases like "how much tax do I pay in Australia", "Australian tax return", "sole trader tax", "ABN tax", "Medicare levy", "LITO", "PAYG", "tax brackets Australia", "BAS", "instant asset write-off", "home office deduction", "HELP repayment", "HECS debt", "small business income tax offset", "motor vehicle deduction", or any question about filing or computing income tax for an Australian sole trader. Covers 2024-25 Stage 3 tax rates, Medicare levy and surcharge, LITO, business income computation, allowable deductions, depreciation, instant asset write-off, small business income tax offset, HELP/HECS repayments, and final tax computation. ALWAYS read this skill before touching any Australian income tax work.
-version: 2.1
+version: 2.2
 jurisdiction: AU
 tax_year: 2024
-last_updated: 2026-08-28
+last_updated: 2026-08-31
 review_status: pending_review
 depends_on:
   - income-tax-workflow-base
@@ -89,7 +89,7 @@ license: AGPL-3.0-or-later (code) / OpenAccountants Guide License v1.0 (content)
 | Home office -- fixed rate method | 70 cents per hour (2024-25 and 2025-26) | T2 -- method choice, hours, and records/substantiation required |
 | Motor vehicle -- cents per km method | 88 cents per km (max 5,000 km) | T2 -- method choice and business-km support required |
 | Instant asset write-off (small business) | $20,000 threshold (assets under $20,000 immediately deductible) | T1 if small-business eligibility and asset cost are clear; otherwise escalate |
-| Superannuation (deductible personal contribution) | Up to $30,000 concessional cap | T1 rate-cap lookup; notice of intent must be lodged before claiming |
+| Superannuation (deductible personal contribution) | Up to concessional cap ($30,000 in 2025-26; $32,500 in 2026-27) | T1 rate-cap lookup; notice of intent must be lodged before claiming |
 
 ### Conservative Defaults [T1]
 
@@ -171,7 +171,7 @@ license: AGPL-3.0-or-later (code) / OpenAccountants Guide License v1.0 (content)
 | TRAINING, COURSE, SELF-EDUCATION | Self-education (D4) | T1 | Deductible if directly related to current income-producing activity. NOT deductible if for new career. |
 | COMPUTER, LAPTOP, EQUIPMENT (under $20,000) | Instant asset write-off | T1 | Immediately deductible if small business entity and cost < $20,000 |
 | COMPUTER, LAPTOP, EQUIPMENT (over $20,000) | Depreciation (D2 business) | T1 | Depreciate over effective life per ATO table |
-| SUPER CONTRIBUTION, SUNSUPER, AUSTRALIAN SUPER | Deduction (Item D12) | T1 | Personal deductible super contribution up to $30,000 concessional cap. Must lodge notice of intent. |
+| SUPER CONTRIBUTION, SUNSUPER, AUSTRALIAN SUPER | Deduction (Item D12) | T1 | Personal deductible super contribution up to the concessional cap ($30,000 in 2025-26; $32,500 in 2026-27). Must lodge notice of intent. |
 | ATO TAX, INCOME TAX, PAYG INSTALMENT | EXCLUDE | Not deductible | Tax payments are not deductions |
 | GST PAYMENT, BAS PAYMENT | EXCLUDE from income tax | T1 | GST is separate. Report net of GST if registered. |
 | PRIVATE HEALTH, MEDIBANK, BUPA, NIB, HCF | NOT a deduction (but affects MLS) | T1 | Private health insurance is NOT tax deductible. But having it avoids Medicare Levy Surcharge. PHI rebate claimed separately. |
@@ -267,18 +267,22 @@ license: AGPL-3.0-or-later (code) / OpenAccountants Guide License v1.0 (content)
 
 ### 5.4 Superannuation [T1]
 
-- **Personal deductible super contributions** — Personal deductible contributions up to $30,000 concessional cap (combined with employer contributions if also employed). Must lodge a valid "Notice of intent to claim" with the super fund AND receive acknowledgment BEFORE lodging the tax return or rolling over.
+- **Personal deductible super contributions** — Personal deductible contributions up to the concessional cap (combined with employer contributions if also employed): $30,000 in 2025-26, **$32,500 in 2026-27**. Must lodge a valid "Notice of intent to claim" with the super fund AND receive acknowledgment BEFORE lodging the tax return or rolling over.  _(ATO contributions caps QC 18123; au-rates-2026-27)_
 
 ### 5.5 HELP/HECS Repayment [T1]
 
 **5.5 HELP/HECS Repayment [T1]**
 
-| Repayment Income (2025-26, marginal system) | Rate |
+Use the 2026-27 bands unless the return year is 2025-26. Both years are marginal: nil at or below the minimum threshold; 15c then 17c on the excess; the top band is 10% of **total** repayment income. Do not use the old 1%--10% of whole-of-income rates.
+
+| Repayment income (2026-27) | Repayment |
 | --- | --- |
-| $67,000 or below | Nil |
-| $67,001 -- $125,000 | 15c per $1 over $67,000 |
-| $125,001 -- $179,285 | $8,700 plus 17c per $1 over $125,000 |
-| $179,286 and over | 10% of total repayment income |
+| $0 -- $69,528 | Nil |
+| $69,529 -- $129,717 | 15c for each $1 over $69,528 |
+| $129,718 -- $186,050 | $9,028 + 17c for each $1 over $129,717 |
+| $186,051+ | 10% of total repayment income |
+
+2025-26: nil to $67,000; 15c over $67,000 to $125,000; $8,700 + 17c over $125,000 to $179,285; 10% of total repayment income from $179,286. _(ATO QC 16176)_
 
 - **Marginal basis (from 2025-26)** — From 2025-26 compulsory repayments are calculated on a marginal basis (only the income above the minimum repayment threshold), substituted by the Universities Accord (Cutting Student Debt by 20 Per Cent) Act 2025.  _(Universities Accord (Cutting Student Debt by 20 Per Cent) Act 2025)_
 - **Repayment income** — Repayment income = taxable income + reportable fringe benefits + net investment losses + reportable super. HELP repayments are NOT deductible.  _(Higher Education Support Act 2003)_

--- a/skills/international/australia/au-rates-2026-27.md
+++ b/skills/international/australia/au-rates-2026-27.md
@@ -1,22 +1,22 @@
 ---
 name: au-rates-2026-27
 description: Use this skill whenever you need a current Australian tax rate, threshold, cap or due date for the 2026-27 or 2025-26 income year -- individual brackets, HELP repayment, Medicare levy and surcharge, super guarantee and contribution caps, Division 296, company rates, Div 7A benchmark, FBT, CGT caps and concessions, GST, PAYG instalment uplift, cents-per-km, car limits, penalty units, payroll tax, minimum wage or ASIC fees. Single-page rates card; every figure carries its source. Trigger on "what is the current rate", "2026-27 threshold", "how much is the cap", or any AU figure lookup. Load alongside the topic guide.
-version: "1.0"
+version: "1.1"
 jurisdiction: AU
 tax_year: 2026
 tax_year_notes: "2026-27 primary; 2025-26 retained for lodgment-season work"
-last_updated: 2026-08-20
+last_updated: 2026-08-31
 review_status: pending_review
 category: international
 tier: 2
 license: AGPL-3.0-or-later (code) / OpenAccountants Guide License v1.0 (content)
 ---
 
-# Australia Rates Card 2026-27 (with 2025-26) v1.0
+# Australia Rates Card 2026-27 (with 2025-26) v1.1
 
 > **General reference only.** This skill is general tax/accounting reference material for AI-assisted workflows. It has not been reviewed for any specific person's facts, documents, elections, deadlines, residency, filing status, or local procedures. Do not rely on it to file, pay, amend, or take a tax position without review by a qualified professional in the relevant jurisdiction.
 
-Single-page lookup for the figures every other Australian guide relies on. Each row names its primary source. Verified against those sources on 20 August 2026. Deeper rules live in the topic guides named in each section; this card never overrides them.
+Single-page lookup for the figures every other Australian guide relies on. Each row names its primary source. HELP 2026-27 bands verified 31 August 2026; remaining rows verified 20 August 2026. Deeper rules live in the topic guides named in each section; this card never overrides them.
 
 ## Individual income tax
 
@@ -45,18 +45,29 @@ Tax on full bands: 2025-26 -- $4,288 at $45,000, $31,288 at $135,000, $51,638 at
 | Cents per km | 88c (2025-26); **91c (2026-27)**, cap 5,000 business km | ATO cents-per-km rates |
 | Car limit (depreciation) | $69,674 (2025-26); **$69,883 (2026-27)** | ATO car thresholds |
 
-## HELP/study loans (2025-26 onwards: marginal system)
+## HELP/study loans (marginal system from 2025-26)
 
-Repayment income = taxable income + reportable fringe benefits + reportable super + exempt foreign income + net investment losses.
+Repayment income = taxable income + reportable fringe benefits + reportable super + exempt foreign employment income + net investment losses. From 2025-26, compulsory repayments are marginal: only income above the minimum threshold is charged, except the top band which is 10% of **total** repayment income.
 
-| Repayment income (2025-26) | Marginal repayment rate |
+**2026-27** _(ATO study and training support loans rates and repayment thresholds, QC 16176)_
+
+| Repayment income | Repayment |
 | --- | --- |
-| Below $67,000 | Nil |
-| $67,001 -- $125,000 | 15% of excess over $67,000 |
-| $125,001 -- $179,285 | $8,700 + 17% of excess over $125,000 |
-| $179,286+ | 10% of repayment income (cap rule) |
+| $0 -- $69,528 | Nil |
+| $69,529 -- $129,717 | 15c for each $1 over $69,528 |
+| $129,718 -- $186,050 | $9,028 + 17c for each $1 over $129,717 |
+| $186,051+ | 10% of total repayment income |
 
-One-off 20% debt reduction applied before 1 June 2026 indexation; thresholds index for 2026-27 (confirm current-year bands at ATO study loan repayment thresholds before computing). _(Education and Other Legislation Amendment (VET Fee Protection and Other Measures) Act 2025; ATO QC 103927)_
+**2025-26** (lodgment-season prior year)
+
+| Repayment income | Repayment |
+| --- | --- |
+| $0 -- $67,000 | Nil |
+| $67,001 -- $125,000 | 15c for each $1 over $67,000 |
+| $125,001 -- $179,285 | $8,700 + 17c for each $1 over $125,000 |
+| $179,286+ | 10% of total repayment income |
+
+Do not apply the old 1%--10% of whole-of-income Schedule 8 rates to 2025-26 or 2026-27. Income at or below the minimum threshold is nil, not a small percentage. One-off 20% debt reduction applied before 1 June 2026 indexation. Keep this card in step with `au-foreign-income` (already on the 2026-27 bands) and `au-individual-return`.
 
 ## Medicare
 
@@ -146,7 +157,7 @@ This card is the single place indexed figures live outside their topic guides. W
 
 ## Provenance
 
-All figures verified 20 August 2026 directly against: ato.gov.au rate pages (QC 73320, 27031, 71196, 73746, 103578, 103927, contributions caps, key super rates, car thresholds, Div 7A rates, GDP adjustment), Department of Health PHI Circular 12/26, Revenue NSW / SRO Vic / QRO current-rates pages, FWC Annual Wage Review 2025-26 decision, ASIC fee indexation page (1 July 2026), and the amending Acts named inline.
+HELP 2026-27 and 2025-26 bands verified 31 August 2026 against ATO QC 16176 (study and training support loans rates and repayment thresholds). Remaining figures verified 20 August 2026 against: ato.gov.au rate pages (QC 73320, 27031, 71196, 73746, 103578, contributions caps, key super rates, car thresholds, Div 7A rates, GDP adjustment), Department of Health PHI Circular 12/26, Revenue NSW / SRO Vic / QRO current-rates pages, FWC Annual Wage Review 2025-26 decision, ASIC fee indexation page (1 July 2026), and the amending Acts named inline.
 
 <!-- openaccountants-cta-block -->
 

--- a/skills/international/australia/australia-gst.md
+++ b/skills/international/australia/australia-gst.md
@@ -1,10 +1,10 @@
 ---
 name: australia-gst
 description: Use this skill whenever asked to prepare, review, or classify transactions for an Australian GST return (Business Activity Statement / BAS) for any client. Trigger on phrases like "prepare BAS", "do the GST", "fill in BAS", "create the return", "GST return", "Activity Statement", or any request involving Australian GST filing. Also trigger when classifying transactions for GST purposes from bank statements, invoices, or other source data. This skill covers Australia only and covers both Simpler BAS and full BAS reporting. GST groups, margin scheme, partial exemption complex, and going concern are all in the refusal catalogue. ALWAYS read this skill before touching any GST-related work.
-version: 2.1
+version: 2.2
 jurisdiction: AU
 tax_year: 2025
-last_updated: 2026-08-28
+last_updated: 2026-08-31
 review_status: pending_review
 tier: 2
 license: AGPL-3.0-or-later (code) / OpenAccountants Guide License v1.0 (content)
@@ -41,7 +41,7 @@ license: AGPL-3.0-or-later (code) / OpenAccountants Guide License v1.0 (content)
 
 | Label | Meaning |
 | --- | --- |
-| G1 | Total sales (GST-exclusive for taxable sales; include GST-free and input taxed) |
+| G1 | Total sales (GST-free + input taxed + taxable). Calculation worksheet method: **GST-inclusive** (ATO requires this). Accounts method: GST-inclusive or GST-exclusive -- mark the Yes/No box under G1. G1 is not GST-exclusive by default. |
 | G2 | Export sales (GST-free, Division 38-E) |
 | G3 | Other GST-free sales (food, health, education -- Division 38-A to 38-D, 38-F+) |
 | G4 | Input taxed sales (financial supplies, residential rent -- Division 40) |
@@ -60,8 +60,8 @@ license: AGPL-3.0-or-later (code) / OpenAccountants Guide License v1.0 (content)
 | 1A | GST on sales (output GST) |
 | 1B | GST on purchases (input tax credits) |
 
-- **Simpler BAS reporting scope** — Simpler BAS (turnover < $10M, default since 1 July 2017): Report only G1, 1A, 1B. No need for G2-G18.
-- **Full BAS reporting scope** — Full BAS: Report all G labels plus 1A, 1B, and PAYG/FBT labels as applicable.
+- **Simpler BAS reporting scope** — Simpler BAS (turnover < $10M, default since 1 July 2017): Report only G1, 1A, 1B. No need for G2-G18. At G1, mark whether the amount includes GST. Calculation worksheet / most software exports are GST-inclusive.  _(ATO -- Completing your BAS, Step 1: Sales; Simpler BAS GST bookkeeping guide)_
+- **Full BAS reporting scope** — Full BAS: Report all G labels plus 1A, 1B, and PAYG/FBT labels as applicable. G10 and G11 are GST-inclusive. G1 follows the same inclusive/exclusive choice as the method in use.
 - **GST calculation formulas** — GST = GST-inclusive price x 1/11; GST = GST-exclusive price x 10%; GST-inclusive = GST-exclusive x 1.1; GST-exclusive = GST-inclusive / 1.1
 
 **Conservative defaults -- Australian-specific**
@@ -69,6 +69,7 @@ license: AGPL-3.0-or-later (code) / OpenAccountants Guide License v1.0 (content)
 | Ambiguity | Default |
 | --- | --- |
 | Unknown GST status of a sale | Taxable at 10% |
+| Unknown G1 inclusive/exclusive method | GST-inclusive (calculation worksheet default). Flag the G1 Yes/No box for reviewer. |
 | Unknown GST status of a purchase | No input tax credit claimed |
 | Unknown business-use proportion (vehicle, phone, home office) | 0% credit |
 | Unknown whether food is basic or prepared | Taxable at 10% (prepared food) |

--- a/skills/international/australia/australia-payroll.md
+++ b/skills/international/australia/australia-payroll.md
@@ -11,10 +11,10 @@ description: >
   "activity statement", "annual leave", "long service leave",
   "minimum wage Australia", or any question about running payroll in Australia.
   ALWAYS read this skill before processing any Australian payroll work.
-version: 2.1
+version: 2.2
 jurisdiction: AU
 tax_year: 2025
-last_updated: 2026-08-28
+last_updated: 2026-08-31
 review_status: pending_review
 category: payroll
 tier: 2
@@ -82,7 +82,7 @@ PAYG withholding is calculated per pay period using ATO tax tables (Schedule 1 -
 
 ### Study and Training Support Loans (STSL)
 
-- **STSL description** — Formerly HECS-HELP. Compulsory repayments are withheld via PAYG based on Schedule 8 thresholds. Updated STSL repayment thresholds apply from 24 September 2025, reducing compulsory repayments for most borrowers.  _(Schedule 8)_
+- **STSL description** — Study and training support loans (HELP, VSL, AASL and related). Compulsory repayments are withheld via PAYG using the **marginal** system from 2025-26: nil at or below the minimum repayment threshold; 15c then 17c on the excess; 10% of **total** repayment income in the top band. 2026-27 minimum threshold is $69,528. Do not use the old 1%--10% of whole-of-income Schedule 8 rates. Current bands: `au-rates-2026-27`.  _(ATO QC 16176)_
 
 ## Section 3 -- Social Security: Employee Deductions
 
@@ -95,23 +95,21 @@ Australia does not have a separate employee social security contribution. The Me
 | Deduction | Rate | Ceiling | Notes |
 | --- | --- | --- | --- |
 | PAYG income tax | Progressive (see above) | No ceiling | Includes Medicare levy in tax tables |
-| STSL repayment | 1%--10% (income-based) | No ceiling | Only if employee has HELP/STSL debt |
+| STSL repayment | Marginal (nil below threshold) | No ceiling | 2026-27: nil to $69,528; then 15c / 17c / 10% of total. See au-rates-2026-27 |
 | Salary sacrifice (super) | Voluntary | Concessional cap $32,500/year (2026-27) | Pre-tax; reduces PAYG withholding base |
 
 There is no employee-paid social insurance premium equivalent to NIC (UK) or social security tax (US).
 
-**Superannuation Guarantee summary**
+**Superannuation Guarantee summary (2026-27)**
 
-| State/Territory | Threshold (Annual) | Rate |
-| --- | --- | --- |
-| NSW | $1,200,000 | 4.85% |
-| VIC | $900,000 | 4.85% |
-| QLD | $1,300,000 | 4.75% |
-| WA | $1,000,000 | 5.50% |
-| SA | $1,500,000 | Varies (0%--4.95%) |
-| TAS | $1,250,000 | 4.00% |
-| ACT | $2,000,000 | 6.85% |
-| NT | $1,500,000 | 5.50% |
+| Item | Value |
+| --- | --- |
+| SG rate | 12% (terminal since 1 July 2025) |
+| Deadline | Fund receipt within 7 business days of payday (20 business days for a first contribution to a new fund) |
+| Maximum contribution base | $270,830 **annual** of qualifying earnings (max SG $32,499.60) |
+| Sole trader SG to self | None -- voluntary only |
+
+State **payroll tax** is not SG. NSW 2026-27: 5.45% above $1,200,000 (Revenue NSW). Other states: `au-rates-2026-27`. Full SG rules: `au-super-guarantee`.
 
 **Deadline exceptions:** new employee / new fund -- 20 business days for the first contribution; out-of-cycle payments (bonuses) ride with the next regular payday's deadline; ATO exceptional-circumstances determinations -- 20 business days.
 
@@ -336,7 +334,9 @@ Annual salary $120,000. Sacrifices $10,000/year to super.
 
 ### Pattern 4 -- STSL Repayment
 
-Employee earning $65,000 with HELP debt. STSL repayment rate from Schedule 8 tables: approximately 4.5%. Annual repayment: $65,000 × 4.5% = $2,925, withheld progressively via PAYG.
+Employee earning $65,000 with HELP debt, 2026-27. Repayment income $65,000 is below the $69,528 minimum threshold. Compulsory repayment = **nil**. PAYG should not withhold STSL. (Same result in 2025-26: threshold was $67,000.) Do not apply a 4.5% whole-of-income rate.
+
+Employee earning $90,000 with HELP debt, 2026-27. Repayment = ($90,000 - $69,528) x 0.15 = $3,070.80, withheld progressively via PAYG. _(ATO QC 16176)_
 
 ## Section 10 -- Interaction with Other Skills
 


### PR DESCRIPTION
## What this PR does

Puts the published 2026-27 HELP/STSL bands on the Australia rates card and individual-return guide, stops G1 being treated as GST-exclusive by default, and replaces a payroll STSL worked example that charged 4.5% on $65,000 (below the minimum threshold).

## Country/jurisdiction affected

Australia

## Legal — Contributor License Agreement (CLA)

OpenAccountants is dual-licensed (AGPL-3.0 + commercial). We need a clear **yes** from you before we can merge your contribution.

- [x] **I have read [CLA.md](https://github.com/openaccountants/openaccountants/blob/main/CLA.md) and agree to the Contributor License Agreement** for everything included in this pull request. *(Checking this box is your explicit opt-in.)*

## Checklist

### Repo & sync (required)

- [x] File is in `skills/` (not only `packages/`)
- [x] Jurisdiction is clear (folder path or `jurisdiction:` in frontmatter)
- [x] I only edited files under `skills/**` (generated trees rebuild automatically)
- [x] **Name for attribution** (as it should appear on the guide): Ryan Duguid
- [x] My OpenAccountants profile GitHub username matches this account (optional — set it at openaccountants.com/profile for full credit)

### Content quality

- [x] Rates and thresholds cite a primary source (statute, tax authority website)
- [x] No inline [T1]/[T2]/[T3] tags (tiers are sections, not inline tags)
- [ ] Supplier/transaction pattern library included (if content skill) — not changed in this PR except G1 label text
- [x] Worked examples included
- [x] Disclaimer present at the end
- [ ] Tested: uploaded to an LLM and it produced correct output

## Why

`au-foreign-income` already used the ATO 2026-27 HELP bands ($69,528 / $129,717 / $186,050). The rates card and `au-individual-return` still had 2025-26 ($67,000) and told the model to "confirm current-year bands" instead of stating them. An agent loading the rates card would understate the 2026-27 threshold by $2,528.

`australia-gst` described G1 as "GST-exclusive for taxable sales". ATO completing-your-BAS Step 1: calculation worksheet method **must** include GST; accounts method may choose either and must mark the G1 Yes/No box. G10/G11 were already GST-inclusive, so the labels disagreed with each other.

`australia-payroll` Pattern 4 computed $65,000 × 4.5% = $2,925. That income is below the minimum repayment threshold in **both** 2025-26 and 2026-27, so compulsory repayment is nil. The same file labelled a state payroll-tax table as Superannuation Guarantee and gave NSW 4.85% (Revenue NSW 2026-27 is 5.45% above $1.2m).

## Sources

- ATO QC 16176 — Study and training support loans rates and repayment thresholds (2026-27 Table 1; 2025-26 Table 2)
- ATO — Completing your BAS, Step 1: Sales (G1 inclusive vs exclusive)
- ATO QC 18123 — Contributions caps ($32,500 concessional in 2026-27)
- Revenue NSW — Payroll tax thresholds and rates 2026-27 (5.45%, $1,200,000)

Edits are `skills/**` only. Packages rebuild after ingest.