### PR TITLE
feat(za): add year-keyed South African rate-table guides (YoA 2023-2027)

### DIFF
--- a/skills/international/south-africa/za-capital-gains-tables.md
+++ b/skills/international/south-africa/za-capital-gains-tables.md
@@ -1,0 +1,133 @@
+---
+name: za-capital-gains-tables
+description: >
+  Year-keyed South African capital gains tax rate tables for natural persons, covering five years of assessment (2023 to 2027). Contains the annual exclusion, the increased exclusion in the year of death, the primary residence exclusion and the inclusion rate for individuals, together with the tax-free savings account annual and lifetime contribution limits and the excess contribution penalty rate. Use for any South African CGT exclusion or inclusion rate lookup, primary residence disposal, deceased estate, or tax-free savings account limit question, current or prior year.
+jurisdiction: ZA
+category: international
+tax_year: 2023
+tax_year_notes: "2022/23 to 2026/27 — SARS years of assessment 2023 to 2027"
+tier: 2
+last_updated: 2026-09-02
+version: 0.1
+depends_on:
+  - foundation
+verified_by: pending
+---
+
+# South Africa — Capital Gains Tax Rate Tables (natural persons)
+
+Year-keyed CGT exclusions and inclusion rates for **natural persons**, years of
+assessment 2023 to 2027, plus the tax-free savings account limits. Data only: this
+file does not compute a gain and does not set out base cost determination.
+
+> **Verification status — checked 2 September 2026.**
+>
+> Confirmed against SARS, figure by figure:
+>
+> - **Annual exclusion, year-of-death exclusion and primary residence exclusion for
+>   YoA 2027** — R50,000 / R440,000 / R3,000,000
+> - **Maximum effective rate for individuals and special trusts, YoA 2027** — 18%
+>
+> **Still to confirm** — carried from the same reconciled source, but not
+> independently re-checked:
+>
+> - The same four CGT figures for **YoA 2023 to 2026**
+> - The **tax-free savings account** limits and penalty rate, all five years
+
+## How South African years of assessment are labelled
+
+SARS numbers a year of assessment by the calendar year in which it **ends**. The tax
+year runs 1 March to the last day of February. So the year of assessment ending
+28 February 2027 is **YoA 2027**, and it is the year commonly written "2026/27".
+
+| Year of assessment | Commonly written | Period |
+| --- | --- | --- |
+| 2023 | 2022/23 | 1 March 2022 – 28 February 2023 |
+| 2024 | 2023/24 | 1 March 2023 – 29 February 2024 |
+| 2025 | 2024/25 | 1 March 2024 – 28 February 2025 |
+| 2026 | 2025/26 | 1 March 2025 – 28 February 2026 |
+| 2027 | 2026/27 | 1 March 2026 – 28 February 2027 |
+
+Getting this wrong by one year is the single most common error in South African rate
+lookups. Every table below is keyed by **year of assessment**.
+
+
+## Section 1 — Scope
+
+This file covers, for each year of assessment 2023-2027:
+
+- Annual exclusion (Eighth Schedule para 5)
+- Annual exclusion in the year of death (Eighth Schedule para 5(2))
+- Primary residence exclusion (Eighth Schedule para 45)
+- Inclusion rate for natural persons (s 26A read with Eighth Schedule para 10)
+- Tax-free savings account annual and lifetime limits and penalty rate (s 12T)
+
+Not covered here: inclusion rates for companies and trusts; base cost rules;
+the small business asset exclusion under s 10(1)(zJ); roll-overs; or any
+computation rule.
+
+---
+
+## Section 2 — CGT exclusions and inclusion rate (natural persons)
+
+| YoA | Annual exclusion | Annual exclusion (year of death) | Primary residence exclusion | Inclusion rate |
+| --- | --- | --- | --- | --- |
+| 2023 (2022/23) | R40,000 | R300,000 | R2,000,000 | 40% |
+| 2024 (2023/24) | R40,000 | R300,000 | R2,000,000 | 40% |
+| 2025 (2024/25) | R40,000 | R300,000 | R2,000,000 | 40% |
+| 2026 (2025/26) | R40,000 | R300,000 | R2,000,000 | 40% |
+| 2027 (2026/27) | R50,000 | R440,000 | R3,000,000 | 40% |
+
+_Source: Income Tax Act 58 of 1962 s 26A; Eighth Schedule paras 5, 10 and 45. YoA 2027 confirmed against SARS, Capital Gains Tax (CGT) rate tables dated 25 February 2026: <https://www.sars.gov.za/tax-rates/income-tax/capital-gains-tax-cgt/>, 2026-09-02. Earlier years not re-checked._
+
+**Effective rate.** The inclusion rate is 40% in every year in this file, so the
+maximum effective CGT rate for a natural person is 40% of the top marginal rate of
+45%, being 18%.
+
+---
+
+## Section 3 — Tax-free savings accounts
+
+| YoA | Annual contribution limit | Lifetime contribution limit | Penalty on excess |
+| --- | --- | --- | --- |
+| 2023 (2022/23) | R36,000 | R500,000 | 40% |
+| 2024 (2023/24) | R36,000 | R500,000 | 40% |
+| 2025 (2024/25) | R36,000 | R500,000 | 40% |
+| 2026 (2025/26) | R36,000 | R500,000 | 40% |
+| 2027 (2026/27) | R46,000 | R500,000 | 40% |
+
+_Source: Income Tax Act 58 of 1962 s 12T._
+
+---
+
+## Section 4 — Edge cases and traps
+
+- **The YoA 2027 increases are easy to miss.** The annual exclusion, the death
+  exclusion and the primary residence exclusion all increased with effect from
+  1 March 2026. A guide still quoting the prior figures for YoA 2027 is wrong, and
+  the error is most dangerous inside a home-office warning, where the superseded
+  annual exclusion understates the relief available on a tainted portion.
+- **The primary residence exclusion applies to the first portion of the GAIN**, not
+  the first portion of the proceeds.
+- **Home-office tainting.** Where part of a residence is used for trade, the primary
+  residence exclusion does not apply to the tainted portion, which falls back on the
+  annual exclusion only. Use the annual exclusion **for the year of disposal**.
+- **The lifetime TFSA limit has not moved** while the annual limit has. Do not infer
+  one from the other.
+- **The death exclusion replaces the annual exclusion** in the year of death; the two
+  are not cumulative.
+
+## Section 5 — Self-checks
+
+1. **Year of disposal.** The exclusion is the one for the year of assessment in which
+   disposal occurred, not the year of assessment in which the return is filed.
+2. **Death exclusion is larger than the annual exclusion** in every year. If it is
+   not, the two have been transposed.
+3. **Inclusion rate is for natural persons only.** Companies and trusts differ and
+   are out of scope here.
+
+---
+
+## Disclaimer
+
+> **General reference only.** This file is general tax reference material for AI-assisted workflows. It has not been reviewed for any specific person's facts, documents, elections, deadlines, residency, filing status or local procedures. Do not rely on it to file, pay, amend or take a tax position without review by a qualified professional in South Africa.

--- a/skills/international/south-africa/za-income-tax-tables.md
+++ b/skills/international/south-africa/za-income-tax-tables.md
@@ -1,0 +1,265 @@
+---
+name: za-income-tax-tables
+description: >
+  Year-keyed South African income tax rate tables for individuals and special trusts, covering five years of assessment (2023 to 2027). Contains the progressive tax brackets with base amounts, the primary, secondary and tertiary rebates, tax thresholds by age, medical scheme fees tax credits, the section 11F retirement contribution cap and percentage, the section 18A donations limit, the interest exemption, the foreign dividend fraction and the section 10(1)(o)(ii) foreign employment cap. Use for any South African bracket, rebate, threshold or credit lookup, current year or prior year, including amended assessments and late returns.
+jurisdiction: ZA
+category: international
+tax_year: 2023
+tax_year_notes: "2022/23 to 2026/27 — SARS years of assessment 2023 to 2027"
+tier: 2
+last_updated: 2026-09-02
+version: 0.1
+depends_on:
+  - foundation
+verified_by: pending
+---
+
+# South Africa — Income Tax Rate Tables (individuals)
+
+Year-keyed rate tables for **natural persons and special trusts**, years of
+assessment 2023 to 2027. This file is data only: it states what the figures are
+and where they come from. It does not compute tax and does not set out the
+ordering of deductions — those belong to the computation guides that consume it.
+
+> **Verification status — checked 2 September 2026.**
+>
+> Confirmed against SARS, figure by figure:
+>
+> - **Progressive tax brackets and base amounts, all five years** — every band, every
+>   base amount, matches SARS exactly
+> - **Primary, secondary and tertiary rebates, all five years**
+> - **Tax thresholds, all three age bands** — and they reconcile against the rebates
+> - SARS confirms **no change to brackets or rebates across YoA 2024, 2025 and 2026**
+>
+> **Still to confirm** — carried from the same reconciled source, but not
+> independently re-checked:
+>
+> - Medical scheme fees tax credits (s 6A)
+> - The s 11F retirement cap and percentage, and the s 18A donations limit
+> - Interest exemption, foreign dividend fraction, s 10(1)(o)(ii) cap
+
+## How South African years of assessment are labelled
+
+SARS numbers a year of assessment by the calendar year in which it **ends**. The tax
+year runs 1 March to the last day of February. So the year of assessment ending
+28 February 2027 is **YoA 2027**, and it is the year commonly written "2026/27".
+
+| Year of assessment | Commonly written | Period |
+| --- | --- | --- |
+| 2023 | 2022/23 | 1 March 2022 – 28 February 2023 |
+| 2024 | 2023/24 | 1 March 2023 – 29 February 2024 |
+| 2025 | 2024/25 | 1 March 2024 – 28 February 2025 |
+| 2026 | 2025/26 | 1 March 2025 – 28 February 2026 |
+| 2027 | 2026/27 | 1 March 2026 – 28 February 2027 |
+
+Getting this wrong by one year is the single most common error in South African rate
+lookups. Every table below is keyed by **year of assessment**.
+
+
+## Section 1 — Scope
+
+This file covers, for each year of assessment 2023-2027:
+
+- Progressive tax brackets for individuals and special trusts (s 5, read with the
+  annual Rates and Monetary Amounts and Amendment of Revenue Laws Act)
+- Rebates: primary, secondary (65+), tertiary (75+) (s 6)
+- Tax thresholds by age band (derived from the rebates)
+- Medical scheme fees tax credits (s 6A)
+- Retirement fund contribution deduction: percentage and annual cap (s 11F)
+- Donations to public benefit organisations: annual limit (s 18A)
+- Interest exemption by age (s 10(1)(i))
+- Foreign dividend exempt fraction (s 10B(3))
+- Foreign employment remuneration exemption cap (s 10(1)(o)(ii))
+
+Not covered here: company, trust (other than special trusts) and turnover tax
+rates; capital gains tax (see `za-capital-gains-tables`); travel allowance and
+logbook tables (see `za-travel-allowance-tables`); any computation rule.
+
+---
+
+## Section 2 — Progressive tax brackets
+
+Each band states the **base amount** payable at the bottom of the band plus the
+**marginal rate** on the excess above the band floor. Amounts are rand.
+
+### Year of assessment 2023 (2022/23)
+
+| Taxable income | Base amount | Rate on excess |
+| --- | --- | --- |
+| 1 – 226,000 | — | 18% |
+| 226,001 – 353,100 | R40,680 | 26% above R226,000 |
+| 353,101 – 488,700 | R73,726 | 31% above R353,100 |
+| 488,701 – 641,400 | R115,762 | 36% above R488,700 |
+| 641,401 – 817,600 | R170,734 | 39% above R641,400 |
+| 817,601 – 1,731,600 | R239,452 | 41% above R817,600 |
+| 1,731,601 and above | R614,192 | 45% above R1,731,600 |
+
+_Source: SARS, Rates of Tax for Individuals — 2023 tax year. <https://www.sars.gov.za/tax-rates/income-tax/rates-of-tax-for-individuals/> Confirmed 2026-09-02._
+
+### Year of assessment 2024 (2023/24)
+
+| Taxable income | Base amount | Rate on excess |
+| --- | --- | --- |
+| 1 – 237,100 | — | 18% |
+| 237,101 – 370,500 | R42,678 | 26% above R237,100 |
+| 370,501 – 512,800 | R77,362 | 31% above R370,500 |
+| 512,801 – 673,000 | R121,475 | 36% above R512,800 |
+| 673,001 – 857,900 | R179,147 | 39% above R673,000 |
+| 857,901 – 1,817,000 | R251,258 | 41% above R857,900 |
+| 1,817,001 and above | R644,489 | 45% above R1,817,000 |
+
+_Source: SARS, Rates of Tax for Individuals — 2024 tax year. <https://www.sars.gov.za/tax-rates/income-tax/rates-of-tax-for-individuals/> Confirmed 2026-09-02._
+
+### Year of assessment 2025 (2024/25)
+
+| Taxable income | Base amount | Rate on excess |
+| --- | --- | --- |
+| 1 – 237,100 | — | 18% |
+| 237,101 – 370,500 | R42,678 | 26% above R237,100 |
+| 370,501 – 512,800 | R77,362 | 31% above R370,500 |
+| 512,801 – 673,000 | R121,475 | 36% above R512,800 |
+| 673,001 – 857,900 | R179,147 | 39% above R673,000 |
+| 857,901 – 1,817,000 | R251,258 | 41% above R857,900 |
+| 1,817,001 and above | R644,489 | 45% above R1,817,000 |
+
+_Source: SARS, Rates of Tax for Individuals — 2025 tax year. <https://www.sars.gov.za/tax-rates/income-tax/rates-of-tax-for-individuals/> Confirmed 2026-09-02._
+
+### Year of assessment 2026 (2025/26)
+
+| Taxable income | Base amount | Rate on excess |
+| --- | --- | --- |
+| 1 – 237,100 | — | 18% |
+| 237,101 – 370,500 | R42,678 | 26% above R237,100 |
+| 370,501 – 512,800 | R77,362 | 31% above R370,500 |
+| 512,801 – 673,000 | R121,475 | 36% above R512,800 |
+| 673,001 – 857,900 | R179,147 | 39% above R673,000 |
+| 857,901 – 1,817,000 | R251,258 | 41% above R857,900 |
+| 1,817,001 and above | R644,489 | 45% above R1,817,000 |
+
+_Source: SARS, Rates of Tax for Individuals — 2026 tax year. <https://www.sars.gov.za/tax-rates/income-tax/rates-of-tax-for-individuals/> Confirmed 2026-09-02._
+
+### Year of assessment 2027 (2026/27)
+
+| Taxable income | Base amount | Rate on excess |
+| --- | --- | --- |
+| 1 – 245,100 | — | 18% |
+| 245,101 – 383,100 | R44,118 | 26% above R245,100 |
+| 383,101 – 530,200 | R79,998 | 31% above R383,100 |
+| 530,201 – 695,800 | R125,599 | 36% above R530,200 |
+| 695,801 – 887,000 | R185,215 | 39% above R695,800 |
+| 887,001 – 1,878,600 | R259,783 | 41% above R887,000 |
+| 1,878,601 and above | R666,339 | 45% above R1,878,600 |
+
+_Source: SARS, Rates of Tax for Individuals — 2027 tax year. <https://www.sars.gov.za/tax-rates/income-tax/rates-of-tax-for-individuals/> Confirmed 2026-09-02._
+
+---
+
+## Section 3 — Rebates and tax thresholds
+
+Rebates are credits against tax, not deductions from income. The secondary and
+tertiary rebates are **additional** to the primary rebate, not replacements for it.
+
+| YoA | Primary | Secondary (65+, additional) | Tertiary (75+, additional) |
+| --- | --- | --- | --- |
+| 2023 (2022/23) | R16,425 | R9,000 | R2,997 |
+| 2024 (2023/24) | R17,235 | R9,444 | R3,145 |
+| 2025 (2024/25) | R17,235 | R9,444 | R3,145 |
+| 2026 (2025/26) | R17,235 | R9,444 | R3,145 |
+| 2027 (2026/27) | R17,820 | R9,765 | R3,249 |
+
+**Cumulative rebate by age band:**
+
+| YoA | Under 65 | 65 to 74 | 75 and over |
+| --- | --- | --- | --- |
+| 2023 (2022/23) | R16,425 | R25,425 | R28,422 |
+| 2024 (2023/24) | R17,235 | R26,679 | R29,824 |
+| 2025 (2024/25) | R17,235 | R26,679 | R29,824 |
+| 2026 (2025/26) | R17,235 | R26,679 | R29,824 |
+| 2027 (2026/27) | R17,820 | R27,585 | R30,834 |
+
+**Tax thresholds** — the income below which no tax is payable. Each threshold is
+the cumulative rebate divided by the lowest marginal rate (18% in every year below).
+
+| YoA | Under 65 | 65 to 74 | 75 and over |
+| --- | --- | --- | --- |
+| 2023 (2022/23) | R91,250 | R141,250 | R157,900 |
+| 2024 (2023/24) | R95,750 | R148,217 | R165,689 |
+| 2025 (2024/25) | R95,750 | R148,217 | R165,689 |
+| 2026 (2025/26) | R95,750 | R148,217 | R165,689 |
+| 2027 (2026/27) | R99,000 | R153,250 | R171,300 |
+
+_Source: Income Tax Act 58 of 1962 s 6; SARS Rates of Tax for Individuals._
+
+---
+
+## Section 4 — Medical scheme fees tax credits
+
+Monthly credits under s 6A. "Principal member" and "first dependant" carry the
+same amount; every further dependant carries the "additional" amount.
+
+| YoA | Principal member | First dependant | Each additional dependant |
+| --- | --- | --- | --- |
+| 2023 (2022/23) | R347 pm | R347 pm | R234 pm |
+| 2024 (2023/24) | R364 pm | R364 pm | R246 pm |
+| 2025 (2024/25) | R364 pm | R364 pm | R246 pm |
+| 2026 (2025/26) | R364 pm | R364 pm | R246 pm |
+| 2027 (2026/27) | R376 pm | R376 pm | R254 pm |
+
+_Source: Income Tax Act 58 of 1962 s 6A; SARS Medical Tax Credit Rates._
+
+---
+
+## Section 5 — Other annual limits and thresholds
+
+| YoA | s 11F retirement cap | s 11F percentage | s 18A donations limit |
+| --- | --- | --- | --- |
+| 2023 (2022/23) | R350,000 | 27.5% of the greater of remuneration or taxable income | 10% of taxable income |
+| 2024 (2023/24) | R350,000 | 27.5% of the greater of remuneration or taxable income | 10% of taxable income |
+| 2025 (2024/25) | R350,000 | 27.5% of the greater of remuneration or taxable income | 10% of taxable income |
+| 2026 (2025/26) | R350,000 | 27.5% of the greater of remuneration or taxable income | 10% of taxable income |
+| 2027 (2026/27) | R430,000 | 27.5% of the greater of remuneration or taxable income | 10% of taxable income |
+
+| YoA | Interest exemption (under 65) | Interest exemption (65+) | Foreign dividend exempt fraction | s 10(1)(o)(ii) cap |
+| --- | --- | --- | --- | --- |
+| 2023 (2022/23) | R23,800 | R34,500 | 25/45 | R1,250,000 |
+| 2024 (2023/24) | R23,800 | R34,500 | 25/45 | R1,250,000 |
+| 2025 (2024/25) | R23,800 | R34,500 | 25/45 | R1,250,000 |
+| 2026 (2025/26) | R23,800 | R34,500 | 25/45 | R1,250,000 |
+| 2027 (2026/27) | R23,800 | R34,500 | 25/45 | R1,250,000 |
+
+_Source: Income Tax Act 58 of 1962 s 11F, s 18A, s 10(1)(i), s 10B(3), s 10(1)(o)(ii)._
+
+---
+
+## Section 6 — Edge cases and traps
+
+- **No bracket adjustment for three consecutive years.** Years of assessment 2024,
+  2025 and 2026 share identical brackets, rebates and medical credits. This is not a
+  transcription error in this file — no inflation adjustment was made across those
+  years. Do not "correct" one year to differ from the others.
+- **Base amounts must reconcile.** Each band's base amount equals the previous
+  band's base plus the previous band's width times its rate. If a table fails this
+  check, the table is wrong. See the self-check below.
+- **Rebates are age-based on the taxpayer's age at any time during the year of
+  assessment**, not at year end.
+- **Secondary and tertiary rebates are additive.** A 76-year-old receives all three.
+- **Prior-year lookups matter.** Amended assessments, late returns and objections are
+  computed on the rates for the year of assessment concerned, never the current year.
+
+## Section 7 — Self-checks
+
+Run these before relying on any bracket table, including this one:
+
+1. **Base-amount reconciliation.** For every band after the first,
+   `base(n) = base(n-1) + (floor(n) - floor(n-1)) x rate(n-1)`. Every year in this
+   file satisfies this exactly.
+2. **Threshold reconciliation.** `threshold = cumulative rebate / lowest marginal
+   rate`. For YoA 2027: 17,820 / 0.18 = 99,000.
+3. **Year check.** Confirm the year of assessment, not the calendar year. A return
+   for the year ended 28 February 2027 uses YoA 2027.
+
+---
+
+## Disclaimer
+
+> **General reference only.** This file is general tax reference material for AI-assisted workflows. It has not been reviewed for any specific person's facts, documents, elections, deadlines, residency, filing status or local procedures. Do not rely on it to file, pay, amend or take a tax position without review by a qualified professional in South Africa.

--- a/skills/international/south-africa/za-travel-allowance-tables.md
+++ b/skills/international/south-africa/za-travel-allowance-tables.md
@@ -1,0 +1,201 @@
+---
+name: za-travel-allowance-tables
+description: >
+  Year-keyed South African travel allowance and logbook rate tables, covering five years of assessment (2023 to 2027). Contains the SARS fixed cost table used for the deemed-cost method (fixed cost, fuel cost and maintenance cost by vehicle value band) and the prescribed reimbursive rate per kilometre for each year. Use for any South African travel claim, logbook computation, deemed cost lookup, reimbursive travel allowance, code 3701, 3702 or 3703 question, or company car and business travel deduction, for the current year or a prior year.
+jurisdiction: ZA
+category: international
+tax_year: 2023
+tax_year_notes: "2022/23 to 2026/27 — SARS years of assessment 2023 to 2027"
+tier: 2
+last_updated: 2026-09-02
+version: 0.1
+depends_on:
+  - foundation
+verified_by: pending
+---
+
+# South Africa — Travel Allowance and Logbook Rate Tables
+
+The SARS fixed cost table and prescribed reimbursive rate, years of assessment
+2023 to 2027. Data only: this file states the rates and where they come from. It
+does not set out how to apportion business kilometres or which claim method to use.
+
+> **Verification status — checked 2 September 2026.**
+>
+> Confirmed against SARS, figure by figure:
+>
+> - **YoA 2027 fixed cost table** — all 9 bands match SARS exactly.
+> - **YoA 2027 reimbursive rate** — SARS: 495 c/km. Matches.
+> - **YoA 2025 fixed cost table** — all 9 bands match SARS exactly.
+> - **YoA 2025 reimbursive rate** — SARS: 484 c/km. Matches.
+>
+> **Still to confirm** — carried from the same reconciled source, but not
+> independently re-checked:
+>
+> - The **YoA 2023, 2024 and 2026** fixed cost tables and reimbursive rates. SARS
+>   publishes only the current schedule and one archived revision at a stable URL; the
+>   superseded annexures for those years could not be retrieved.
+
+## How South African years of assessment are labelled
+
+SARS numbers a year of assessment by the calendar year in which it **ends**. The tax
+year runs 1 March to the last day of February. So the year of assessment ending
+28 February 2027 is **YoA 2027**, and it is the year commonly written "2026/27".
+
+| Year of assessment | Commonly written | Period |
+| --- | --- | --- |
+| 2023 | 2022/23 | 1 March 2022 – 28 February 2023 |
+| 2024 | 2023/24 | 1 March 2023 – 29 February 2024 |
+| 2025 | 2024/25 | 1 March 2024 – 28 February 2025 |
+| 2026 | 2025/26 | 1 March 2025 – 28 February 2026 |
+| 2027 | 2026/27 | 1 March 2026 – 28 February 2027 |
+
+Getting this wrong by one year is the single most common error in South African rate
+lookups. Every table below is keyed by **year of assessment**.
+
+
+## Section 1 — Scope
+
+This file covers, for each year of assessment 2023-2027:
+
+- The **fixed cost table** (s 8(1)(b)(iii)) — fixed cost, fuel cost and maintenance
+  cost by determined value of the vehicle, used for the deemed-cost travel claim
+- The **prescribed reimbursive rate per kilometre** (s 8(1)(b)(ii))
+
+Not covered here: whether a logbook is required, how to apportion business versus
+private kilometres, the 80/20 PAYE inclusion on a travel allowance, or the
+interaction with codes 3701/3702/3703. Those are computation rules.
+
+---
+
+## Section 2 — Fixed cost table (deemed-cost method)
+
+Fuel and maintenance are stated in **cents per kilometre**, as SARS publishes them.
+Fixed cost is an annual rand amount. The band is set by the **determined value** of
+the vehicle.
+
+### Year of assessment 2023 (2022/23)
+
+| Determined value of vehicle | Fixed cost (per year) | Fuel cost | Maintenance cost |
+| --- | --- | --- | --- |
+| 0 – 95,000 | R29,504 | 141.6 c/km | 45.0 c/km |
+| 95,001 – 190,000 | R52,226 | 158.1 c/km | 56.3 c/km |
+| 190,001 – 285,000 | R75,039 | 171.8 c/km | 62.0 c/km |
+| 285,001 – 380,000 | R95,086 | 184.7 c/km | 67.7 c/km |
+| 380,001 – 475,000 | R115,140 | 197.4 c/km | 79.4 c/km |
+| 475,001 – 570,000 | R136,366 | 226.6 c/km | 93.2 c/km |
+| 570,001 – 665,000 | R157,564 | 234.2 c/km | 115.6 c/km |
+| exceeding 665,000 | R157,564 | 234.2 c/km | 115.6 c/km |
+
+_Source: SARS Fixed Cost Table, YoA 2023, published under Income Tax Act s 8(1)(b)(iii) as PAYE-GEN-01-G03-A01. Annexure for this year not retrievable; not independently confirmed._
+
+### Year of assessment 2024 (2023/24)
+
+| Determined value of vehicle | Fixed cost (per year) | Fuel cost | Maintenance cost |
+| --- | --- | --- | --- |
+| 0 – 100,000 | R33,760 | 141.0 c/km | 43.6 c/km |
+| 100,001 – 200,000 | R60,329 | 157.5 c/km | 54.6 c/km |
+| 200,001 – 300,000 | R86,958 | 171.2 c/km | 60.1 c/km |
+| 300,001 – 400,000 | R110,554 | 184.0 c/km | 65.6 c/km |
+| 400,001 – 500,000 | R134,150 | 196.8 c/km | 77.0 c/km |
+| 500,001 – 600,000 | R158,856 | 225.7 c/km | 90.4 c/km |
+| 600,001 – 700,000 | R183,611 | 233.4 c/km | 112.2 c/km |
+| exceeding 700,000 | R183,611 | 233.4 c/km | 112.2 c/km |
+
+_Source: SARS Fixed Cost Table, YoA 2024, published under Income Tax Act s 8(1)(b)(iii) as PAYE-GEN-01-G03-A01. Annexure for this year not retrievable; not independently confirmed._
+
+### Year of assessment 2025 (2024/25)
+
+| Determined value of vehicle | Fixed cost (per year) | Fuel cost | Maintenance cost |
+| --- | --- | --- | --- |
+| 0 – 100,000 | R34,480 | 151.7 c/km | 46.0 c/km |
+| 100,001 – 200,000 | R61,770 | 169.4 c/km | 57.6 c/km |
+| 200,001 – 300,000 | R89,119 | 184.0 c/km | 63.5 c/km |
+| 300,001 – 400,000 | R113,436 | 197.9 c/km | 69.3 c/km |
+| 400,001 – 500,000 | R137,752 | 211.8 c/km | 81.5 c/km |
+| 500,001 – 600,000 | R163,178 | 243.0 c/km | 95.6 c/km |
+| 600,001 – 700,000 | R188,653 | 247.1 c/km | 107.3 c/km |
+| 700,001 – 800,000 | R215,447 | 251.2 c/km | 118.9 c/km |
+| exceeding 800,000 | R215,447 | 251.2 c/km | 118.9 c/km |
+
+_Source: SARS Fixed Cost Table, YoA 2025, published under Income Tax Act s 8(1)(b)(iii) as PAYE-GEN-01-G03-A01. Confirmed 2026-09-02 against PAYE-GEN-01-G03-A01, Revision 17, effective 29 February 2024 — all 9 bands._
+
+### Year of assessment 2026 (2025/26)
+
+| Determined value of vehicle | Fixed cost (per year) | Fuel cost | Maintenance cost |
+| --- | --- | --- | --- |
+| 0 – 100,000 | R33,940 | 146.7 c/km | 47.4 c/km |
+| 100,001 – 200,000 | R60,688 | 163.8 c/km | 59.3 c/km |
+| 200,001 – 300,000 | R87,497 | 177.9 c/km | 65.4 c/km |
+| 300,001 – 400,000 | R111,273 | 191.4 c/km | 71.4 c/km |
+| 400,001 – 500,000 | R135,048 | 204.8 c/km | 83.9 c/km |
+| 500,001 – 600,000 | R159,934 | 234.9 c/km | 98.5 c/km |
+| 600,001 – 700,000 | R184,867 | 238.9 c/km | 110.5 c/km |
+| 700,001 – 800,000 | R211,121 | 242.9 c/km | 122.5 c/km |
+| exceeding 800,000 | R211,121 | 242.9 c/km | 122.5 c/km |
+
+_Source: SARS Fixed Cost Table, YoA 2026, published under Income Tax Act s 8(1)(b)(iii) as PAYE-GEN-01-G03-A01. Annexure for this year not retrievable; not independently confirmed._
+
+### Year of assessment 2027 (2026/27)
+
+| Determined value of vehicle | Fixed cost (per year) | Fuel cost | Maintenance cost |
+| --- | --- | --- | --- |
+| 0 – 115,000 | R38,344 | 132.9 c/km | 49.1 c/km |
+| 115,001 – 230,000 | R68,487 | 148.4 c/km | 61.4 c/km |
+| 230,001 – 345,000 | R98,689 | 161.2 c/km | 67.8 c/km |
+| 345,001 – 460,000 | R125,393 | 173.4 c/km | 74.0 c/km |
+| 460,001 – 575,000 | R152,097 | 185.5 c/km | 86.9 c/km |
+| 575,001 – 690,000 | R180,078 | 212.8 c/km | 102.0 c/km |
+| 690,001 – 805,000 | R208,106 | 216.5 c/km | 114.5 c/km |
+| 805,001 – 920,000 | R237,679 | 220.1 c/km | 126.1 c/km |
+| exceeding 920,000 | R237,679 | 220.1 c/km | 126.9 c/km |
+
+_Source: SARS Fixed Cost Table, YoA 2027, published under Income Tax Act s 8(1)(b)(iii) as PAYE-GEN-01-G03-A01. Confirmed 2026-09-02 against PAYE-GEN-01-G03-A01, Revision 19, effective 1 March 2026 — all 9 bands._
+
+---
+
+## Section 3 — Prescribed reimbursive rate per kilometre
+
+| YoA | Rate per kilometre | Effective from |
+| --- | --- | --- |
+| 2023 (2022/23) | R4.18 | 1 March 2022 |
+| 2024 (2023/24) | R4.64 | 1 March 2023 |
+| 2025 (2024/25) | R4.84 | 1 March 2024 |
+| 2026 (2025/26) | R4.76 | 1 March 2025 |
+| 2027 (2026/27) | R4.95 | 1 March 2026 |
+
+_Source: SARS Rate per Kilometre Schedule, **PAYE-GEN-01-G03-A01**, para 1.4 (simplified method), linked from <https://www.sars.gov.za/tax-rates/employers/subsistence-allowances-and-advances/>. YoA 2027 (495 c/km) and YoA 2025 (484 c/km) confirmed 2026-09-02 against Revisions 19 and 17 respectively. YoA 2023, 2024 and 2026 not independently confirmed — those annexures are superseded and no longer published at a stable URL._
+
+---
+
+## Section 4 — Edge cases and traps
+
+- **The rate can go down.** The reimbursive rate fell from R4.84 (YoA 2025) to R4.76
+  (YoA 2026) before rising again. A table that only ever increases is wrong.
+- 🔴 **The open top band does NOT always repeat the band below it.** It does in
+  YoA 2025 — all three columns identical, confirmed against SARS. It does **not** in
+  YoA 2027, where SARS gives the open band a maintenance cost of 126.9 c/km against
+  126.1 c/km for the band below, with fixed cost and fuel unchanged. Never "tidy" a
+  top band to match the one beneath it — read the schedule for that year. This is a
+  known trap: an earlier transcription of the YoA 2027 table was "corrected" from
+  126.9 to 126.1 on exactly that false assumption.
+- **Fixed cost is apportioned** where the vehicle is used for part of a year.
+- **Determined value, not market value**, sets the band.
+- **Band widths changed in YoA 2027.** Bands moved from R100,000 steps to R115,000
+  steps. Do not carry a prior-year band structure forward.
+
+## Section 5 — Self-checks
+
+1. **Top-band check — read, do not infer.** The open top band usually repeats the
+   band below on all three columns, but not always (YoA 2027 breaks it). Where the
+   two differ, confirm against that year's published schedule rather than assuming
+   a transcription error in either direction.
+2. **Band continuity.** Each band floor equals the previous band ceiling.
+3. **Year check.** Rates are keyed to the year of assessment, and the reimbursive
+   rate changes on 1 March.
+
+---
+
+## Disclaimer
+
+> **General reference only.** This file is general tax reference material for AI-assisted workflows. It has not been reviewed for any specific person's facts, documents, elections, deadlines, residency, filing status or local procedures. Do not rely on it to file, pay, amend or take a tax position without review by a qualified professional in South Africa.


### PR DESCRIPTION
## What this PR does

Adds three data-only reference guides giving South African rate tables keyed by year of assessment, covering five years (YoA 2023–2027).

## Country/jurisdiction affected

South Africa (`ZA`)

## Legal — Contributor License Agreement (CLA)

- [x] **I have read [CLA.md](https://github.com/openaccountants/openaccountants/blob/main/CLA.md) and agree to the Contributor License Agreement** for everything included in this pull request. *(Also signed via the CLA bot on #146.)*

## Checklist

### Repo & sync (required)

- [x] File is in `skills/` (not only `packages/`)
- [x] Jurisdiction is clear — `jurisdiction: ZA` in frontmatter and the folder path
- [x] I only edited files under `skills/**`
- [x] **Name for attribution**: **Brandon Iverach, Professional Accountant (SA)** — SAIPA, ZA-approved on the platform
- [x] My OpenAccountants profile GitHub username matches this account (`iverachb`)

### Content quality

- [x] Rates and thresholds cite a primary source
- [x] No inline [T1]/[T2]/[T3] tags
- [x] Disclaimer present at the end of each file
- [x] `scripts/validate-guides.py` reports no errors or warnings on any of the three files

---

## Why

South Africa has no year-keyed historical rate tables. The existing guides carry current-year figures inline, so a prior-year lookup — an amended assessment, a late return, an objection — has nowhere to go. Those are computed on the rates for the year of assessment concerned, never the current year.

| File | Covers |
| --- | --- |
| `za-income-tax-tables` | Brackets and base amounts, rebates, tax thresholds, s6A medical credits, s11F cap and percentage, s18A donations limit, s10(1)(i) interest exemption, s10B(3) foreign dividend fraction, s10(1)(o)(ii) cap |
| `za-travel-allowance-tables` | s8(1)(b)(iii) fixed cost table and the s8(1)(b)(ii) prescribed rate per kilometre |
| `za-capital-gains-tables` | Eighth Schedule exclusions and inclusion rate for natural persons, s12T TFSA limits |

**Data only.** No computation rules, no ordering of deductions, no method — those belong to the guides that consume these.

## How the figures were produced

Generated mechanically from a source reconciled to issued SARS assessments rather than retyped, then verified by re-parsing the emitted markdown — so a transcription fault in the generator is caught rather than hidden. Three checks, all passing:

- All **35 bracket bands** satisfy `base(n) = base(n-1) + (floor(n) − floor(n-1)) × rate(n-1)`
- The rebates reproduce SARS's published thresholds at 18% in **every** year
- The death exclusion exceeds the annual exclusion in every year

## Verification status — stated per file, not assumed

Each file carries a verification block naming exactly which figures were confirmed against a published SARS schedule on 2 September 2026 and which were not. Nothing claims more than was checked.

| File | Confirmed against SARS | Not yet confirmed |
| --- | --- | --- |
| `za-income-tax-tables` | Brackets, base amounts, rebates and thresholds — **all five years** | s6A credits; s11F cap; s18A limit; interest exemption; s10(1)(o)(ii) cap |
| `za-capital-gains-tables` | The four CGT figures for **YoA 2027** | CGT for YoA 2023–2026; all TFSA limits |
| `za-travel-allowance-tables` | Fixed cost table and rate per km for **YoA 2025 and 2027** (PAYE-GEN-01-G03-A01 revisions 17 and 19) | YoA 2023, 2024 and 2026 — those annexures are superseded and no longer published at a stable URL |

All three are `tier: 2` pending review, which is what that status is for.

## Two traps the tables make explicit

**YoA 2024, 2025 and 2026 share one bracket table and one set of rebates.** That is not a copy-paste fault — SARS made no adjustment across those three years. A reviewer seeing three identical years should not "fix" one.

**The deemed-cost open top band does NOT always repeat the band below.** It does in YoA 2025 — confirmed against revision 17, all three columns identical — and it does **not** in YoA 2027, where SARS raised maintenance to 126.9 c/km against 126.1 c/km below, with fixed cost and fuel unchanged. This one is worth flagging: the assumption that the bands always mirror is exactly what turns a correct figure into a wrong one, and it caught me on my own source before I checked the annexure.

## One frontmatter judgment call

`tax_year: 2023` is the earliest **year of assessment** covered, matching how every table in these files is keyed. Reading it as the calendar year would give 2022, which is defensible under "coverage start year" but displays as an applicable period of 2022 and reads as stale. `tax_year_notes` states the full span either way. Happy to flip it if you'd rather.

## Sources

- SARS, *Rates of Tax for Individuals*: https://www.sars.gov.za/tax-rates/income-tax/rates-of-tax-for-individuals/
- SARS, *Capital Gains Tax (CGT)* rate tables, 25 February 2026: https://www.sars.gov.za/tax-rates/income-tax/capital-gains-tax-cgt/
- SARS, *Rate per Kilometre Schedule*, PAYE-GEN-01-G03-A01, revisions 17 and 19

Related: #146 corrects the YoA 2027 figures in `za-income-tax`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
