### PR TITLE
feat(za): add s10(1)(o)(ii) foreign employment and s20A ring-fencing guides

### DIFF
--- a/skills/international/south-africa/za-assessed-loss-ring-fencing.md
+++ b/skills/international/south-africa/za-assessed-loss-ring-fencing.md
@@ -1,0 +1,200 @@
+---
+name: za-assessed-loss-ring-fencing
+description: >
+  South African section 20A ring-fencing of assessed losses for natural persons, and
+  the section 20 carry-forward rules it sits on. Covers the income threshold that
+  triggers ring-fencing and the change from the 45% to the 39% marginal rate from
+  1 March 2026, the list of suspect trades, the three-out-of-five-years test, the
+  escapes in section 20A(3) and the letting exception, and the company 80% limitation
+  under section 20. Use for questions about ring-fenced losses, suspect trades, hobby
+  farming, rental losses, side businesses, or offsetting a trade loss against salary.
+jurisdiction: ZA
+category: international
+tax_year: 2027
+tax_year_notes: "2026/27 (SARS year of assessment 2027), with prior-year thresholds tabled"
+tier: 2
+last_updated: 2026-09-02
+version: 0.1
+depends_on:
+  - foundation
+verified_by: pending
+---
+
+# South Africa — Ring-fencing of Assessed Losses, s 20A
+
+> **What changed, and why this file exists.** For years of assessment commencing on or
+> after **1 March 2026**, s 20A bites from the **39%** marginal rate, not the 45% maximum
+> marginal rate. The threshold roughly halves. Ring-fencing stops being a
+> high-income edge case and becomes the **default** for a geared residential rental held
+> by a reasonably paid employee.
+
+---
+
+## Section 1 — Scope
+
+This file covers **s 20A ring-fencing for natural persons**, and enough of **s 20** to
+place it.
+
+Not covered: assessed losses of trusts; the s 20(1)(a) company rules beyond the summary in
+Section 6; capital losses, which are an Eighth Schedule matter and not assessed losses at
+all.
+
+---
+
+## Section 2 — The two-stage test
+
+Ring-fencing under s 20A applies only where **both** stages are met.
+
+**Stage 1 — the income test.** The taxpayer's taxable income, *before* setting off the
+loss in question, equals or exceeds the amount at which the relevant marginal rate begins.
+
+**Stage 2 — the trade test.** Either
+- the trade is a **listed suspect trade** (Section 4), **or**
+- the trade has made an assessed loss in **at least three of the last five** years of
+  assessment, counting the current year.
+
+If stage 1 fails, s 20A does not apply at all, whatever the trade. If stage 1 is met, a
+listed suspect trade is caught **immediately** — it never needs the three-in-five test.
+
+_Source: Income Tax Act 58 of 1962 s 20A(2)._
+
+---
+
+## Section 3 — The income threshold, by year of assessment
+
+The threshold is **not a fixed rand amount**. It is defined by reference to a marginal
+rate, so it moves every year with the bracket table.
+
+| Year of assessment | Rate the threshold keys off | Taxable income threshold |
+| --- | --- | --- |
+| 2023 (2022/23) | 45% — maximum marginal rate | R1,731,600 |
+| 2024 (2023/24) | 45% — maximum marginal rate | R1,817,000 |
+| 2025 (2024/25) | 45% — maximum marginal rate | R1,817,000 |
+| 2026 (2025/26) | 45% — maximum marginal rate | R1,817,000 |
+| **2027 (2026/27)** | **39%** | **R695,800** |
+
+**Do not hard-code the rand figure.** Read it off the bracket table for the year in
+question as the floor of the band carrying the relevant rate. See `za-income-tax-tables`.
+
+⚠️ **A common error in commentary written during 2025** quotes the new threshold as
+**R673,000**. That was the 39% bracket floor for the *2026* year of assessment, current
+when the amendment was proposed. Because the amendment only takes effect for years of
+assessment commencing on or after 1 March 2026, the first year it applies is 2027, whose
+39% floor is **R695,800**. Using R673,000 for 2027 is wrong.
+
+_Source: Income Tax Act 58 of 1962 s 20A(2)(a), as amended with effect for years of
+assessment commencing on or after 1 March 2026; SARS Rates of Tax for Individuals for the
+bracket floors._
+
+---
+
+## Section 4 — The listed suspect trades
+
+Under s 20A(2)(b), these are caught on the income test alone:
+
+- Any sport practised by the taxpayer or a relative
+- Any dealing in collectibles
+- **The rental of residential accommodation**, unless the letting exception in Section 5
+  applies
+- The rental of vehicles, aircraft or boats
+- Animal showing by the taxpayer or a relative
+- Farming or animal breeding, unless carried on on a full-time basis
+- Any form of performing or creative arts
+- Any form of gambling or betting
+- Any trade in respect of which a tax benefit scheme applies
+
+_Source: Income Tax Act 58 of 1962 s 20A(2)(b)._
+
+---
+
+## Section 5 — The escapes
+
+A trade that is otherwise caught is **not** ring-fenced where one of these applies.
+
+**The letting exception — s 20A(2)(b)(iii).** Residential accommodation is not a suspect
+trade where **at least 80%** of the accommodation is used by persons who are **not
+relatives** of the taxpayer for **at least half** the year of assessment. Note both limbs:
+the 80% is about who occupies it, and the half-year is about duration.
+
+**Reasonable prospect of profit — s 20A(3).** The trade escapes if it constitutes a
+business with a reasonable prospect of deriving taxable income within a reasonable period,
+having regard to the s 20A(3) factors — among them the proportion of gross income to
+allowable deductions, the commercial manner in which the trade is carried on, the number
+of years of losses, the business plan, and whether assets are available for private use.
+
+This is a facts-and-evidence test, not an assertion. A business plan, arm's length
+pricing, separate banking and a credible route to profitability are what carry it.
+
+_Source: Income Tax Act 58 of 1962 s 20A(2)(b)(iii), s 20A(3)._
+
+---
+
+## Section 6 — Section 20, for context
+
+Ring-fencing modifies an ordinary carry-forward. The underlying rules:
+
+- An assessed loss carries forward and may be set off against income from **any** trade,
+  subject to s 20(2A), which requires the taxpayer to have carried on a trade in the year
+  of set-off.
+- **Companies** are separately limited: for years of assessment commencing on or after
+  1 April 2022, the balance of assessed loss that may be set off is capped at the **greater
+  of R1,000,000 and 80%** of taxable income before the set-off. **This 80% cap does not
+  apply to natural persons.**
+
+_Source: Income Tax Act 58 of 1962 s 20, s 20(2A)._
+
+---
+
+## Section 7 — What ring-fencing actually does
+
+A ring-fenced loss is **not disallowed**. It is quarantined: it may only be set off against
+income from **that same trade** in future years, not against salary, not against other
+trades.
+
+So the cash effect is a deferral, sometimes indefinite. A rental that never turns a taxable
+profit carries a ring-fenced loss forward permanently without ever relieving anything.
+
+---
+
+## Section 8 — Edge cases
+
+- **Test the income threshold before anything else.** Below it, s 20A is irrelevant and no
+  amount of suspect-trade analysis matters.
+- **"Taxable income before the set-off"** is the measure — not gross income, not
+  remuneration, and not taxable income after the loss.
+- **A geared residential rental is now the standard case, not an exotic one.** A salaried
+  taxpayer over the 39% threshold with a bonded rental producing an interest-driven loss is
+  ring-fenced by default from 2026/27 unless the letting exception or s 20A(3) applies.
+  Practitioners who learned this section when it began at 45% will misjudge it.
+- **Relatives occupying the property** count against the 80% limb of the letting exception.
+  Letting to a child at market rent still fails it.
+- **Farming is caught only where it is not full-time.** Full-time farming falls outside the
+  list, and has its own regime in the First Schedule.
+- **The election is not annual.** Once ring-fenced, the loss stays ring-fenced to that trade
+  until it is absorbed by profits of that trade.
+
+---
+
+## Section 9 — Self-checks
+
+1. **Threshold from the right year's bracket table.** Confirm the taxable income threshold
+   is the floor of the band carrying the relevant rate for that year of assessment — not a
+   figure carried over from a prior year, and not R673,000 for YoA 2027.
+2. **Right rate for the right year.** 45% for years of assessment up to 2026; 39% from
+   2027. Applying 39% to a 2026 return, or 45% to a 2027 return, both give the wrong answer.
+3. **Suspect trade first, three-in-five second.** If the trade is listed, the three-in-five
+   test is irrelevant. Running it anyway produces a false negative.
+4. **Both limbs of the letting exception.** 80% non-relative occupation **and** at least
+   half the year. One without the other fails.
+5. **Ring-fenced, not lost.** Confirm the loss is carried forward against that trade and
+   not written off.
+
+---
+
+## Disclaimer
+
+> **General reference only.** This file is general tax reference material for AI-assisted
+> workflows. It has not been reviewed for any specific person's facts, documents,
+> elections, deadlines, residency, filing status or local procedures. Do not rely on it to
+> file, pay, amend or take a tax position without review by a qualified professional in
+> South Africa.

--- a/skills/international/south-africa/za-foreign-employment-exemption.md
+++ b/skills/international/south-africa/za-foreign-employment-exemption.md
@@ -1,0 +1,223 @@
+---
+name: za-foreign-employment-exemption
+description: >
+  South African section 10(1)(o)(ii) foreign employment income exemption for tax
+  residents rendering services outside the Republic. Covers the day tests that gate
+  the exemption, the work-day apportionment formula SARS actually applies, the annual
+  cap, how to choose the twelve month window, how to count full days across border
+  stamps and overnight flights, how the IRP5 must be coded, and the ITR12 containers.
+  Use for any question about working abroad, seconded employees, expatriates,
+  contractors on foreign assignment, touring professionals, the 183 and 60 day tests,
+  code 4041, or the R1.25 million foreign employment cap.
+jurisdiction: ZA
+category: international
+tax_year: 2027
+tax_year_notes: "2026/27 (SARS year of assessment 2027)"
+tier: 2
+last_updated: 2026-09-02
+version: 0.1
+depends_on:
+  - foundation
+verified_by: pending
+---
+
+# South Africa — Foreign Employment Income Exemption, s 10(1)(o)(ii)
+
+> **The single most misunderstood point.** The exemption is **not** "the first
+> R1,250,000 of foreign remuneration is exempt". SARS applies a work-day ratio to the
+> foreign-service remuneration **first**, and caps the result **second**. On most
+> facts the ratio binds long before the cap does, and a return prepared on the
+> "first R1.25m" assumption will overstate the exemption, sometimes by a very large
+> amount.
+
+---
+
+## Section 1 — Scope
+
+This file covers the s 10(1)(o)(ii) exemption for a South African **tax resident** who
+renders services outside the Republic as an **employee** (holder of an office or
+employment).
+
+Covered: the day tests, the apportionment formula, the annual cap, the twelve month
+window, day counting, IRP5 coding, ITR12 containers.
+
+**Not covered:** s 10(1)(o)(i), the separate and **uncapped** exemption for officers and
+crew of ships — a different container and a different test. Independent contractors, who
+are not employees and cannot use this section. Tax residency itself (see
+`za-tax-residency`). Foreign tax credits under s 6*quat*. Double tax agreement relief,
+which is a separate and sometimes better route.
+
+---
+
+## Section 2 — Three quantities, three different jobs
+
+Almost every error in this area is a confusion between these three. They are not
+alternatives; all three apply, in order.
+
+| Quantity | What it is | What it does |
+| --- | --- | --- |
+| **Full days outside the Republic** | More than 183 days in aggregate, **and** a continuous period of more than 60 full days, in any 12 consecutive months | **The gate, and only the gate.** It decides whether the exemption is available at all. It never touches a rand of the calculation. |
+| **Work days outside ÷ total work days** | The apportionment ratio | **The money.** It determines how much of the remuneration is exempt. |
+| **R1,250,000** | The statutory ceiling per year of assessment | Applied **last**, to the result of the ratio. |
+
+A taxpayer can pass the gate comfortably and still receive a small exemption, because
+the gate and the money are computed from different things.
+
+_Source: Income Tax Act 58 of 1962 s 10(1)(o)(ii); SARS Interpretation Note 16._
+
+---
+
+## Section 3 — The computation
+
+```
+exemption = ( work days outside RSA ÷ total work days )
+              × foreign-service remuneration per the IRP5
+          then limited to R1 250 000
+```
+
+### Worked example
+
+An employee with a foreign assignment, remuneration attributable to the assignment
+period of **R1,200,000**, who rendered services on **120** work days outside the
+Republic out of **200** total work days in the year:
+
+```
+ratio       120 ÷ 200                        = 0.60
+apportioned 0.60 × R1,200,000                = R720,000
+cap         R720,000 is below R1,250,000     → no limiting
+exemption                                      R720,000
+```
+
+Note what this means: the remuneration exceeded the cap, but the exemption is
+**R720,000, not R1,250,000**. To reach the cap on this base the taxpayer would have
+needed a ratio above 104%, which is impossible.
+
+### The general point
+
+For the cap to bind at all, the ratio must exceed `R1,250,000 ÷ remuneration`. Work out
+that number before assuming the cap is the operative limit. On a base of R1,350,000 the
+ratio would need to exceed **92.6%** — effectively unattainable for anyone who spends any
+material time working in South Africa.
+
+---
+
+## Section 4 — The IRP5 must carry the remuneration UN-apportioned
+
+This is where the largest errors are made, and they are made by the employer, before the
+practitioner ever sees the certificate.
+
+SARS applies the ratio to **whatever the foreign-service codes disclose**. If the employer
+has already apportioned the remuneration before coding it, the remuneration is apportioned
+**twice** — once by the payroll, once again by SARS — and the exemption collapses.
+
+**So the foreign-service codes must carry the remuneration for the assignment period in
+full, un-apportioned, and let the SARS ratio do the work.** That is how Interpretation
+Note 16's own worked example behaves.
+
+**Practical consequence:** an under-coded certificate silently caps the taxpayer out
+*below* the statutory limit, and no amount of correct work on the return will recover it.
+Where the coding is wrong, the fix is a corrected IRP5 from the employer, not a
+re-computation. Check the certificate before doing anything else.
+
+---
+
+## Section 5 — Choosing the twelve month window
+
+The period is **any 12 consecutive months**. It need **not** be the year of assessment,
+and choosing it deliberately is part of the work.
+
+An assignment that straddles a year end will often produce a comfortable margin on one
+window and a dangerous margin on another. A window giving 185 days against a 183 day
+requirement is a margin of two days — one contested border stamp from failing. Shifting
+the window to capture a tour that crosses the year end can turn that into a margin of
+several weeks on identical underlying facts.
+
+Test more than one window before settling. Record which window was used and why.
+
+---
+
+## Section 6 — Counting full days
+
+A **full day** outside the Republic is a day spent **wholly** outside it. Both the
+departure day and the return day are therefore excluded from the count.
+
+- **Overnight flights.** Where the RSA exit stamp and the foreign entry stamp fall on
+  different dates, the arrival day is a full day abroad. Where the flight departs and
+  lands on the same date — common on short regional hops — only one day is lost.
+- **Foreign-to-foreign travel.** A day spent travelling between two foreign countries is
+  a full day outside the Republic. The absence is not broken by transiting a third country.
+- **Evidence.** Build the count from passport stamps, boarding passes and the assignment
+  schedule, date by date. A count asserted from memory will not survive verification.
+
+---
+
+## Section 7 — Work days are not automatically Monday to Friday
+
+The ratio uses days on which services were **actually rendered**, not a calendar
+weekday proxy.
+
+For many assignments the two are close enough. For others they are not: touring
+professionals, shift workers, events staff and anyone on duty for the whole of a
+deployment routinely render services at weekends. Applying a weekday proxy in those cases
+can understate the foreign work days by a third or more, and understate the exemption in
+the same proportion.
+
+Build the date-by-date schedule of days actually worked, inside and outside the Republic,
+and use it for both the numerator and the denominator.
+
+_Source: SARS Interpretation Note 16 §4.3._
+
+---
+
+## Section 8 — ITR12 containers
+
+| Field | What it is | Use it? |
+| --- | --- | --- |
+| **4041** | The s 10(1)(o)(ii) exempt amount | ✅ **This is the claim field.** |
+| 4033 | The s 10(1)(o)(i) container — officers and crew of ships | ❌ A different, uncapped exemption. Not this one. |
+| 4587 | An IRP5 information code | ❌ Not a claim field. |
+| 4259 | Foreign income **not** reflected on a South African IRP5 | Mandatory. Enter **0** where all foreign remuneration is on an SA IRP5. |
+
+Placing the claim in the wrong container is a common cause of a verification request even
+where the underlying computation is correct.
+
+---
+
+## Section 9 — Edge cases
+
+- **Passing the gate does not size the exemption.** Treat them as separate questions and
+  compute them separately.
+- **The cap is per year of assessment**, applied after the ratio, not before.
+- **Employees only.** An independent contractor cannot use this section, whatever the
+  contract is called. Test the relationship, not the label.
+- **Residency first.** A non-resident has no need of this exemption; a resident who has
+  ceased residency mid-year has a different problem. Settle residency before computing.
+- **A double tax agreement may give a better result** than s 10(1)(o)(ii) on the same
+  facts. Where a DTA applies, compare the two before claiming.
+- **Where the exemption is partial**, the non-exempt balance stays in gross income and is
+  taxed normally, and s 6*quat* foreign tax credit relief may apply to it.
+
+---
+
+## Section 10 — Self-checks
+
+1. **Compute the ratio threshold.** `R1,250,000 ÷ foreign-service remuneration`. If the
+   work-day ratio is below that number, the **cap is not the operative limit** — the ratio
+   is. Stating the exemption as R1,250,000 in that case is wrong.
+2. **Check the certificate for double apportionment.** Does the foreign-service
+   remuneration on the IRP5 look like it has already been reduced by a time ratio? If so,
+   applying the SARS ratio again understates the exemption. Get it corrected.
+3. **Test a second twelve month window** before accepting a thin margin on the day tests.
+4. **Reconcile the day counts.** Work days outside plus work days inside must equal total
+   work days. Full days outside is a different count and will not tie to it.
+5. **Confirm the container is 4041**, and that 4259 carries a figure.
+
+---
+
+## Disclaimer
+
+> **General reference only.** This file is general tax reference material for AI-assisted
+> workflows. It has not been reviewed for any specific person's facts, documents,
+> elections, deadlines, residency, filing status or local procedures. Do not rely on it to
+> file, pay, amend or take a tax position without review by a qualified professional in
+> South Africa.


### PR DESCRIPTION
## What this PR does

Adds two South African guides covering rules that are commonly stated backwards — both drawn from practice rather than from a rate table.

## Country/jurisdiction affected

South Africa (`ZA`)

## Legal — Contributor License Agreement (CLA)

- [x] **I have read [CLA.md](https://github.com/openaccountants/openaccountants/blob/main/CLA.md) and agree to the Contributor License Agreement** for everything included in this pull request. *(Signed via the CLA bot on #146.)*

## Checklist

### Repo & sync (required)

- [x] File is in `skills/` (not only `packages/`)
- [x] Jurisdiction is clear — `jurisdiction: ZA` and the folder path
- [x] I only edited files under `skills/**`
- [x] **Name for attribution**: **Brandon Iverach, Professional Accountant (SA)** — SAIPA, ZA-approved on the platform
- [x] My OpenAccountants profile GitHub username matches this account (`iverachb`)

### Content quality

- [x] Rates and thresholds cite a primary source
- [x] No inline [T1]/[T2]/[T3] tags
- [x] Worked examples included
- [x] Disclaimer present at the end of each file
- [x] `scripts/validate-guides.py` reports no errors or warnings on either file

---

## `za-foreign-employment-exemption` — s 10(1)(o)(ii)

The exemption is widely described as *"the first R1,250,000 of foreign remuneration is exempt"*. **It isn't.** SARS applies a work-day ratio to the foreign-service remuneration **first** and caps the result **second**, so on most facts the ratio binds long before the cap does. A return prepared on the "first R1.25m" assumption overstates the exemption, sometimes heavily.

The guide separates the three quantities that get conflated:

| | What it does |
| --- | --- |
| Day tests (183 aggregate / 60 continuous) | **The gate only.** Never touches a rand. |
| Work days outside ÷ total work days | **The money.** Sizes the exemption. |
| R1,250,000 | The ceiling, applied **last**. |

It also covers a payroll trap that cannot be fixed on the return: where the employer pre-apportions the remuneration before coding it, the amount is apportioned **twice** — once by payroll, once by SARS — and the exemption collapses. The foreign-service codes must carry the assignment remuneration un-apportioned. Where the coding is wrong the fix is a corrected IRP5, not a re-computation.

Plus: choosing the twelve month window deliberately (it need not be the year of assessment, and a straddling assignment can turn a two-day margin into several weeks), counting full days across border stamps and overnight flights, why work days are not a Monday-to-Friday proxy for touring and shift work, and the ITR12 containers — **4041**, not 4033 (the uncapped ship's-officer container) or 4587 (an information code).

## `za-assessed-loss-ring-fencing` — s 20A

For years of assessment commencing on or after **1 March 2026**, s 20A applies from the **39%** marginal rate rather than the 45% maximum marginal rate. The threshold roughly halves, and ring-fencing becomes the **default** for a geared residential rental held by a reasonably paid employee rather than a high-income edge case. Practitioners who learned this section when it began at 45% will misjudge it.

**The threshold is not a fixed rand amount.** It is the floor of the band carrying the relevant rate, so it moves with the bracket table every year. Tabled for YoA 2023–2027:

| YoA | Keys off | Threshold |
| --- | --- | --- |
| 2023 | 45% | R1,731,600 |
| 2024–2026 | 45% | R1,817,000 |
| **2027** | **39%** | **R695,800** |

⚠️ **A recurring error in published commentary** quotes the new threshold as **R673,000**. That was the 39% floor for the *2026* year of assessment, current when the amendment was proposed. Since the change first applies to YoA 2027, the operative figure is **R695,800**. Anyone working from those articles today gets it wrong.

Also covers the two-stage test, the listed suspect trades, both limbs of the letting exception (80% non-relative occupation **and** at least half the year), the s 20A(3) reasonable-prospect-of-profit escape as a facts-and-evidence test, and the s 20 company 80% limitation for contrast — which does **not** apply to natural persons.

## Notes for maintainers

**On the s 20A citation.** I've cited the amendment by effect — "as amended with effect for years of assessment commencing on or after 1 March 2026" — rather than by amending act and section, because I did not want to assert a specific act number I hadn't confirmed to my own satisfaction. If you'd like the precise amending instrument in the source line, say so and I'll add it.

**Both files are tier 2** pending review, which is what that status is for. The s 10(1)(o)(ii) content in particular is practice knowledge — it comes from working the section against SARS's own calculator, not from a published table — so it warrants a reviewer's eye rather than a rubber stamp.

**No client data.** Worked examples use round illustrative figures. Nothing in either file is traceable to a taxpayer.

Related: #146 (corrections to `za-income-tax`) and #147 (year-keyed rate tables).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
