### PR TITLE
Correct Australian guide calculations and tax-year handling

### DIFF
--- a/skills/international/australia/au-div7a.md
+++ b/skills/international/australia/au-div7a.md
@@ -2,17 +2,18 @@
 name: au-div7a
 description: >
   Use this skill whenever asked about Division 7A of the ITAA 1936 -- private company loans, payments or debt forgiveness to shareholders or their associates, complying loan agreements, minimum yearly repayments, the benchmark interest rate, distributable surplus, unpaid present entitlements (UPEs) to corporate beneficiaries after Bendel, use of company assets by shareholders, or deemed dividends. Trigger on phrases like "Div 7A", "Division 7A", "shareholder loan", "director loan account", "debit loan", "minimum yearly repayment", "benchmark interest rate", "complying loan", "deemed dividend", "distributable surplus", "UPE", "bucket company", "unpaid present entitlement", or when a GL shows debit balances in shareholder/director accounts. ALWAYS read this skill before touching any Div 7A work.
-version: 1.0
+version: 1.1
 jurisdiction: AU
-tax_year: 2025
-last_updated: 2026-08-02
+tax_year: 2026
+tax_year_notes: "2026–27"
+last_updated: 2026-09-10
 review_status: pending_review
 category: international
 tier: 2
 license: AGPL-3.0-or-later (code) / OpenAccountants Guide License v1.0 (content)
 ---
 
-# Australia Division 7A -- Private Company Loans Skill v1.0
+# Australia Division 7A -- Private Company Loans Skill v1.1
 
 > **General reference only.** This skill is general tax/accounting reference material for AI-assisted workflows. It has not been reviewed for any specific person's facts, documents, elections, deadlines, residency, filing status, or local procedures. Do not rely on it to file, pay, amend, or take a tax position without review by a qualified professional in the relevant jurisdiction.
 

--- a/skills/international/australia/au-fbt.md
+++ b/skills/international/australia/au-fbt.md
@@ -2,17 +2,18 @@
 name: au-fbt
 description: >
   Use this skill whenever asked about Australian Fringe Benefits Tax -- identifying fringe benefits in a general ledger, car fringe benefits (statutory formula or operating cost), the electric vehicle exemption, meal entertainment, minor benefits, expense payments and the otherwise-deductible rule, LAFHA, loan benefits, employee contributions, reportable fringe benefits amounts (RFBA), FBT gross-up and return preparation. Trigger on phrases like "FBT", "fringe benefits tax", "car fringe benefit", "novated lease FBT", "EV FBT exemption", "entertainment FBT", "minor benefit", "50/50 method", "LAFHA", "living away from home", "gross-up", "Type 1 Type 2", "RFBA", "reportable fringe benefits", or when sweeping a GL for FBT exposure. The FBT year runs 1 April to 31 March. ALWAYS read this skill before touching any FBT work.
-version: 1.0
+version: 1.1
 jurisdiction: AU
-tax_year: 2025
-last_updated: 2026-08-02
+tax_year: 2026
+tax_year_notes: "FBT year 1 April 2026 to 31 March 2027"
+last_updated: 2026-09-10
 review_status: pending_review
 category: international
 tier: 2
 license: AGPL-3.0-or-later (code) / OpenAccountants Guide License v1.0 (content)
 ---
 
-# Australia Fringe Benefits Tax (FBT) -- Employer Skill v1.0
+# Australia Fringe Benefits Tax (FBT) -- Employer Skill v1.1
 
 > **General reference only.** This skill is general tax/accounting reference material for AI-assisted workflows. It has not been reviewed for any specific person's facts, documents, elections, deadlines, residency, filing status, or local procedures. Do not rely on it to file, pay, amend, or take a tax position without review by a qualified professional in the relevant jurisdiction.
 
@@ -177,7 +178,7 @@ A car parking benefit needs, on the same day: parking > 4 hours between 7am-7pm 
 
 ### Rule 7 -- Minor benefits (s 58P)
 
-Notional taxable value < $300 (not indexed; per benefit, per occasion) AND unreasonable to treat as a fringe benefit having regard to infrequency/irregularity and the other s 58P(1)(f) criteria (TR 2007/12: no fixed number of occasions). Screening heuristic: quarterly or less frequent = presumptively infrequent; monthly or more = flag for review. Exempt entertainment gets no deduction and no GST credit.
+Notional taxable value < $300 (not indexed; per benefit, per occasion) AND unreasonable to treat as a fringe benefit having regard to infrequency/irregularity and the other s 58P(1)(f) criteria (TR 2007/12: no fixed number of occasions). Assess all s 58P factors for the actual benefits and associated benefits. Frequency is a screening input, not a quarterly safe harbour; document the conclusion under TR 2007/12. Exempt entertainment gets no deduction and no GST credit.
 
 ### Rule 8 -- Meal entertainment methods
 

--- a/skills/international/australia/au-gst-bas.md
+++ b/skills/international/australia/au-gst-bas.md
@@ -1,10 +1,11 @@
 ---
 name: au-gst-bas
 description: Australian Business Activity Statement (BAS) — non-GST sections. Covers PAYG withholding (labels W1-W5), PAYG income tax instalments (labels T1-T9), FBT instalments (label F1), and PAYG withholding reconciliation. Complements australia-gst.md which covers GST labels (1A-9).
-version: 1.2
+version: 1.3
 jurisdiction: AU
 tax_year: 2025
-last_updated: 2026-08-11
+tax_year_notes: "2025–26"
+last_updated: 2026-09-10
 review_status: pending_review
 category: international
 tier: 2
@@ -15,7 +16,7 @@ license: AGPL-3.0-or-later (code) / OpenAccountants Guide License v1.0 (content)
 
 ## AU GST Bas
 
-## Australia BAS — Non-GST Sections v1.1
+## Australia BAS: Non-GST Sections v1.3
 
 ## What this file is
 
@@ -25,7 +26,7 @@ license: AGPL-3.0-or-later (code) / OpenAccountants Guide License v1.0 (content)
 
 This file covers the non-GST sections of the Business Activity Statement. For GST labels (1A through 9), see `australia-gst.md` in this directory.
 
-**Tax year coverage.** This skill targets the **2024-25 income year** (1 July 2024 to 30 June 2025).
+**Tax year coverage.** This skill targets the **2025–26 income year** (1 July 2025 to 30 June 2026).
 
 **The reviewer is the customer of this output.** This skill assumes a credentialed reviewer reviews and signs the return. The skill produces working papers and a brief, not a return.
 
@@ -59,8 +60,8 @@ This skill does NOT cover:
 
 | Situation | BAS frequency | Source |
 | --- | --- | --- |
-| GST turnover < $10M, no monthly election | Quarterly | TAA 1953 Sch 1 s 31-5 |
-| GST turnover >= $10M | Monthly | TAA 1953 Sch 1 s 31-5 |
+| GST turnover < $20M, no monthly election | Quarterly | TAA 1953 Sch 1 s 31-5 |
+| GST turnover >= $20M | Monthly | TAA 1953 Sch 1 s 31-5 |
 | Voluntary monthly reporter | Monthly | ATO election |
 | PAYG withholding-only (no GST) | Quarterly | TAA 1953 Sch 1 Div 16 |
 
@@ -98,7 +99,7 @@ This skill does NOT cover:
 | --- | --- | --- |
 | Automatic entry — individuals (including sole traders) | The ATO uses the latest tax return. Automatic entry requires all of: instalment income of $4,000 or more; tax payable on the latest notice of assessment of $1,000 or more; and estimated (notional) tax of $500 or more. | [ATO — Starting PAYG instalments](https://www.ato.gov.au/businesses-and-organisations/income-deductions-and-concessions/payg-instalments/starting-payg-instalments) |
 | Instalment rate | As notified by the ATO (varies per taxpayer) | ATO instalment rate notice |
-| GDP-adjusted rate | ATO may adjust the instalment rate annually by a GDP uplift factor | TAA 1953 Sch 1 s 45-405 |
+| GDP-adjusted amount | GDP adjustment is part of the notified instalment-amount calculation, not an automatic increase in T2 | [ATO PAYG variation instructions](https://www.ato.gov.au/businesses-and-organisations/income-deductions-and-concessions/payg-instalments/how-to-vary-your-payg-instalments) |
 | GDP uplift factor 2024-25 | 6% | [ATO — GDP adjustment for 2024-25 GST and PAYG instalments](https://softwaredevelopers.ato.gov.au/gdp-adjustment-2024-25-gst-and-payg-instalments) |
 | Voluntary entry | A person new to business, or expecting business and investment income over the threshold, can request voluntary entry to PAYG instalments. | [ATO — Starting PAYG instalments](https://www.ato.gov.au/businesses-and-organisations/income-deductions-and-concessions/payg-instalments/starting-payg-instalments) |
 
@@ -124,12 +125,14 @@ Two methods are available:
 
 #### Method A — Instalment amount method (label T7)
 
-- **Instalment amount method steps** — **Step 1.** ATO notifies the instalment amount on the pre-filled BAS. **Step 2.** The taxpayer reports the notified amount at T7 (or varies it). **Step 3.** If varying, the taxpayer calculates estimated tax for the year divided by the number of remaining quarters and reports at T7 with a reason for variation at T3.  _(TAA 1953 Sch 1 s 45-5)_
+- **Instalment amount method steps:** Use the notified T7 amount unless varying. For a standard quarterly amount variation, enter estimated annual tax at T8; calculate the cumulative 25%, 50%, 75% or 100% share for the quarter, subtracting earlier instalments and applying the form’s treatment of earlier credits; enter the varied amount at T9, reason at T4 and payable amount at 5A. A zero or negative result needs the ATO credit instructions, including 5B where applicable. Do not divide annual tax by the remaining quarters. [ATO PAYG variation instructions](https://www.ato.gov.au/businesses-and-organisations/income-deductions-and-concessions/payg-instalments/how-to-vary-your-payg-instalments).
+
+Example: at the third standard quarterly instalment, an annual estimate of $8,000 gives a cumulative $6,000 target (75%). If earlier instalments total $3,000 and there are no earlier credits, the current varied amount is $3,000. This is not $8,000 divided by two remaining quarters. Follow the ATO variation instructions above.
 
 #### Method B — Instalment rate method (labels T1-T2)
 
-- **Instalment rate method steps** — **Step 1.** Calculate instalment income for the quarter (T1). Instalment income = gross business and investment income. It does NOT include salary/wages (already subject to PAYG withholding), GST, or capital gains. **Step 2.** Multiply T1 by the ATO-notified instalment rate (T2). **Step 3.** Result = T1 x T2 = instalment amount payable (T9). **Step 4.** The taxpayer may vary the rate (enter new rate at T2) if they believe the notified rate will result in over-payment. A general interest charge (GIC) applies if the varied amount is less than 85% of the correct amount.  _(TAA 1953 Sch 1 s 45-120)_
-- **Instalment amount formula** — T1 x T2 = instalment amount payable (T9)  _(TAA 1953 Sch 1 s 45-120)_
+- **Instalment rate method steps:** Establish instalment income at T1 and the notified rate at T2. If varying, enter the new rate at T3 and reason at T4. Multiply T1 by the applicable rate and enter the result at T11 and 5A as instructed. Exclude salary, GST and capital gains from T1. Check the variation shortfall and GIC rules. [ATO PAYG variation instructions](https://www.ato.gov.au/businesses-and-organisations/income-deductions-and-concessions/payg-instalments/how-to-vary-your-payg-instalments).
+- **Rate-method formula:** T11 = T1 × applicable percentage rate, using T3 if validly varied, otherwise T2. Follow the issued statement for 5A. [ATO PAYG variation instructions](https://www.ato.gov.au/businesses-and-organisations/income-deductions-and-concessions/payg-instalments/how-to-vary-your-payg-instalments).
 
 ### 4.3 FBT instalment (label F1)
 
@@ -137,13 +140,13 @@ Two methods are available:
 
 ### 4.4 Net BAS payable / refundable
 
-- **Net BAS payable formula** — Total BAS payable = GST payable (from australia-gst.md labels) + W5 + T9 (or T7) + F1 - any credits.  _(australia-gst.md)_
+- **Net BAS payable:** Sum the completed payment labels, including 1A, 4, 5A and 6A as applicable; subtract credit labels including 1B, 5B and 6B. Use the statement’s total labels and exclude amounts, such as large-withholder payments, paid separately. Do not treat an annual estimate at T8 as a tax payment.
 
 ## Section 5 — Edge cases and special rules
 
 ### 5.1 Variation of PAYG instalments
 
-- **PAYG instalment variation and GIC exposure** — A taxpayer may vary their instalment amount or rate downward if they expect lower income. **GIC exposure:** If the varied amount is less than 85% of the correct instalment, a general interest charge applies on the shortfall. The GIC rate is updated quarterly by the ATO (base rate = 90-day bank bill rate + 7%). **Variation uplift factor:** If the taxpayer varies for two or more consecutive quarters, the ATO may apply a higher GDP uplift factor in the following year.  _(TAA 1953 Sch 1 s 45-205)_
+- **PAYG instalment variation and GIC:** Apply the ATO’s method-specific 85% shortfall test to a variation using expected full-year income and tax. Document the estimate and review it as circumstances change. Repeated variations do not themselves change the published GDP adjustment factor. [ATO PAYG variation instructions](https://www.ato.gov.au/businesses-and-organisations/income-deductions-and-concessions/payg-instalments/how-to-vary-your-payg-instalments).
 
 ### 5.2 First year of business
 
@@ -167,11 +170,11 @@ Before delivering output, verify:
 
 - [ ] Applicable PAYG withholding labels agree with payroll records, STP data and any ATO pre-fill
 - [ ] PAYG instalment income (T1) excludes salary, GST, and capital gains
-- [ ] The instalment rate (T2) matches the ATO notification or is validly varied
+- [ ] T2 matches the notification; any varied rate is at T3, with T4 reason and T11 result
 - [ ] FBT instalment (F1) is 25% of prior year FBT liability or validly varied
 - [ ] Lodgement due date has been correctly identified (including any tax agent extensions)
 - [ ] GST section cross-references to australia-gst.md output
-- [ ] Rates and thresholds match the 2024-25 income year
+- [ ] Rates and thresholds match the 2025–26 income year; the historical GDP row is not a current-year rate
 - [ ] Output format matches the base skill spec
 
 ## Section 7 — Disclaimer

--- a/skills/international/australia/au-individual-return.md
+++ b/skills/international/australia/au-individual-return.md
@@ -1,10 +1,11 @@
 ---
 name: au-individual-return
-description: Use this skill whenever asked about Australian individual income tax for sole traders. Trigger on phrases like "how much tax do I pay in Australia", "Australian tax return", "sole trader tax", "ABN tax", "Medicare levy", "LITO", "PAYG", "tax brackets Australia", "BAS", "instant asset write-off", "home office deduction", "HELP repayment", "HECS debt", "small business income tax offset", "motor vehicle deduction", or any question about filing or computing income tax for an Australian sole trader. Covers 2024-25 Stage 3 tax rates, Medicare levy and surcharge, LITO, business income computation, allowable deductions, depreciation, instant asset write-off, small business income tax offset, HELP/HECS repayments, and final tax computation. ALWAYS read this skill before touching any Australian income tax work.
-version: 2.1
+description: Use this skill whenever asked about Australian individual income tax for sole traders. Trigger on phrases like "how much tax do I pay in Australia", "Australian tax return", "sole trader tax", "ABN tax", "Medicare levy", "LITO", "PAYG", "tax brackets Australia", "BAS", "instant asset write-off", "home office deduction", "HELP repayment", "HECS debt", "small business income tax offset", "motor vehicle deduction", or any question about filing or computing income tax for an Australian sole trader. Covers 2025–26 Stage 3 tax rates, Medicare levy and surcharge, LITO, business income computation, allowable deductions, depreciation, instant asset write-off, small business income tax offset, HELP/HECS repayments, and final tax computation. ALWAYS read this skill before touching any Australian income tax work.
+version: 2.2
 jurisdiction: AU
-tax_year: 2024
-last_updated: 2026-09-02
+tax_year: 2025
+tax_year_notes: "2025–26"
+last_updated: 2026-09-10
 review_status: pending_review
 depends_on:
   - income-tax-workflow-base
@@ -16,6 +17,10 @@ license: AGPL-3.0-or-later (code) / OpenAccountants Guide License v1.0 (content)
 # AU Individual Return
 
 ## AU Individual Return
+
+## Asset-threshold currency
+
+For 2025–26, eligible small business entities using simplified depreciation can deduct assets costing less than $20,000 when first used or installed ready for taxable use. The permanent threshold was enacted on 26 August 2026; schedule 2 commences on 1 October 2026 and applies to specified first use or installation from 1 July 2026. [Tax Reform No. 2 Act 2026, schedules 1–2](https://www.legislation.gov.au/C2026A00071/asmade/text). The acquisition date alone does not establish the first-use year or a second deduction. Check prior claims and business use.
 
 ## Section 1 -- Quick Reference
 
@@ -31,7 +36,7 @@ license: AGPL-3.0-or-later (code) / OpenAccountants Guide License v1.0 (content)
 | Supporting legislation | Tax Administration Act 1953; Medicare Levy Act 1986; Higher Education Support Act 2003 |
 | Tax authority | Australian Taxation Office (ATO) |
 | Filing portal | myTax (via myGov) or registered tax agent |
-| Filing deadline | 31 October 2026 (self-lodged); May 2027 (tax agent) |
+| Filing deadline | 2 November 2026 for standard self-lodgement (31 October is Saturday); tax-agent dates depend on the applicable programme |
 | Contributor | Open Accountants Community |
 | Validated by | Pending -- Australian CPA/CA sign-off required |
 | Skill version | 2.2 |
@@ -176,7 +181,7 @@ license: AGPL-3.0-or-later (code) / OpenAccountants Guide License v1.0 (content)
 | GST PAYMENT, BAS PAYMENT | EXCLUDE from income tax | T1 | GST is separate. Report net of GST if registered. |
 | PRIVATE HEALTH, MEDIBANK, BUPA, NIB, HCF | NOT a deduction (but affects MLS) | T1 | Private health insurance is NOT tax deductible. But having it avoids Medicare Levy Surcharge. PHI rebate claimed separately. |
 | PERSONAL, GROCERY, ENTERTAINMENT | EXCLUDE | Not deductible | Personal expenses |
-| DONATION, CHARITY, DGR | Tax offset (Item D9) | T1 | Deductible if to a deductible gift recipient (DGR). Must be $2+ and genuinely a gift. |
+| DONATION, CHARITY, DGR | Deduction (Item D9) | T1 | Deductible if to a deductible gift recipient (DGR). Must be $2+ and genuinely a gift. |
 
 ### 3.3 SaaS Subscriptions
 
@@ -225,7 +230,7 @@ license: AGPL-3.0-or-later (code) / OpenAccountants Guide License v1.0 (content)
 
 **Input:** Small business entity (turnover < $10M). Purchases laptop AUD 2,800 and monitor AUD 950. Both under $20,000.
 
-**Classification:** Both items are immediately deductible under the instant asset write-off. Total deduction: AUD 3,750 in the year of purchase. No depreciation schedule needed.
+**Classification:** Both items are immediately deductible under the instant asset write-off. Assuming both assets were first used for business in 2025–26, are wholly business-use, qualify for simplified depreciation and were not previously deducted, the total deduction is AUD 3,750. Record the first-use date and prior-claim check in the asset register.
 
 ### Example 3 -- Motor Vehicle (Logbook vs Cents/Km)
 
@@ -263,7 +268,7 @@ license: AGPL-3.0-or-later (code) / OpenAccountants Guide License v1.0 (content)
 - **Diminishing value** — Base value x (days held / 365) x (200% / effective life)  _(ITAA 1997 Div 40)_
 - **Prime cost (straight line)** — Cost x (days held / 365) x (100% / effective life)  _(ITAA 1997 Div 40)_
 - **Small business entity simplified depreciation** — Small business entity (turnover < $10M): can use simplified depreciation -- pool all assets over $20,000 at 15% first year, 30% thereafter.  _(ITAA 1997 Div 40)_
-- **Instant asset write-off** — Assets costing less than $20,000 (assets first used or installed ready for use 1 July 2023 to 30 June 2026; extension made law by the Treasury Laws Amendment (Strengthening Financial Systems and Other Measures) Act 2025) can be immediately deducted by small business entities. Confirm the limit for later years.  _(ITAA 1997 s 328-180)_
+- **Instant asset write-off**: Assets costing less than $20,000 (assets first used or installed ready for use 1 July 2023 to 30 June 2026; extension made law by the Treasury Laws Amendment (Strengthening Financial Systems and Other Measures) Act 2025) can be immediately deducted by small business entities. For later first use, apply the enacted permanent threshold and commencement details in Asset-threshold currency above.  _(ITAA 1997 s 328-180)_
 
 ### 5.4 Superannuation [T1]
 
@@ -273,7 +278,7 @@ license: AGPL-3.0-or-later (code) / OpenAccountants Guide License v1.0 (content)
 
 **5.5 HELP/HECS Repayment [T1]**
 
-Use the 2026-27 bands unless the return year is 2025-26. Both years are marginal: nil at or below the minimum threshold; 15c then 17c on the excess; the top band is 10% of **total** repayment income. Do not use the old 1%--10% of whole-of-income rates.
+Use the 2025–26 thresholds below for this return workflow. Use the separately labelled 2026–27 bands only for that requested year. Both years are marginal: nil at or below the minimum threshold; 15c then 17c on the excess; the top band is 10% of **total** repayment income. Do not use the old 1%--10% of whole-of-income rates.
 
 | Repayment income (2026-27) | Repayment |
 | --- | --- |
@@ -293,9 +298,9 @@ Use the 2026-27 bands unless the return year is 2025-26. Both years are marginal
 
 | Item | Value |
 | --- | --- |
-| Self-lodge deadline | 31 October 2026 |
+| Self-lodge deadline | 2 November 2026 (31 October is Saturday; check extensions) |
 | Tax agent deadline | Varies (typically March-May 2027) |
-| Failure to lodge on time | $330 per 28-day period, up to 5 periods ($1,650 max) |
+| Failure to lodge on time | $364 per 28-day period or part, up to five base units ($1,820) for the applicable period from 1 July 2026; apply relevant multipliers and remission rules. [Crimes (Amount of a Penalty Unit) Instrument 2026](https://www.legislation.gov.au/F2026N00424/asmade/text) |
 | Shortfall penalty (reasonable care not taken) | 25% of shortfall |
 | Shortfall penalty (recklessness) | 50% of shortfall |
 | General Interest Charge (GIC) | Rate set quarterly and published on the ATO website; calculated daily and compounded |
@@ -322,7 +327,7 @@ Use the 2026-27 bands unless the return year is 2025-26. Both years are marginal
 | Cents per km (88c) | Max 5,000 business km. No receipts needed. | Reasonable estimate of business km |
 | Logbook | Business % of actual costs including depreciation | 12-week continuous logbook, valid for 5 years |
 
-- **Cannot claim both methods** — Cannot claim both. Parking, tolls, and roadside assistance are separate and deductible under either method for business trips. Confirm method and km/logbook records.
+- **Cannot claim both methods**: Cannot claim both. Eligible business parking and tolls can be separate deductions. Roadside assistance is a car operating expense covered by the cents-per-kilometre rate; do not claim it again under that method. Confirm method and km/logbook records.
 
 ### 6.3 Private Health Insurance (Medicare Levy Surcharge) [T2]
 

--- a/skills/international/australia/au-medicare-levy.md
+++ b/skills/international/australia/au-medicare-levy.md
@@ -1,10 +1,11 @@
 ---
 name: au-medicare-levy
 description: Use this skill whenever asked about the Australian Medicare Levy, Medicare Levy Surcharge (MLS), low-income reduction thresholds, family thresholds, surcharge tiers, private health insurance (PHI) rebate interaction, or Medicare levy exemptions. Trigger on phrases like "Medicare levy", "Medicare surcharge", "MLS", "do I pay Medicare levy", "low income Medicare", "Medicare levy reduction", "Medicare levy exemption", "private health insurance rebate", "PHI rebate", "M1", "M2", or any question about Medicare-related levies on an Australian tax return. ALWAYS read this skill before touching any Medicare levy work.
-version: 2.1
+version: 2.3
 jurisdiction: AU
-tax_year: 2024
-last_updated: 2026-08-28
+tax_year: 2025
+tax_year_notes: "2025–26"
+last_updated: 2026-09-10
 review_status: pending_review
 category: international
 tier: 2
@@ -15,7 +16,7 @@ license: AGPL-3.0-or-later (code) / OpenAccountants Guide License v1.0 (content)
 
 ## AU Medicare Levy
 
-## Australia Medicare Levy and Medicare Levy Surcharge Skill v2.2
+## Australia Medicare Levy and Medicare Levy Surcharge Skill v2.3
 
 ## Section 1 -- Quick reference
 
@@ -28,7 +29,7 @@ Read this whole section before computing anything.
 | Country | Australia |
 | Jurisdiction Code | AU |
 | Primary Legislation | Medicare Levy Act 1986 (MLA 1986); A New Tax System (Medicare Levy Surcharge -- Fringe Benefits) Act 1999 |
-| Supporting Legislation | ITAA 1997 Div 61 (Medicare levy); ITAA 1997 s 8C-8G (MLS); Health Insurance Act 1973; Private Health Insurance Act 2007 |
+| Supporting Legislation | ITAA 1936 Part VIIB (Medicare levy); Medicare Levy Act 1986 ss 8B–8G (MLS); Health Insurance Act 1973; Private Health Insurance Act 2007 |
 | Tax Authority | Australian Taxation Office (ATO) |
 | Tax Year | 2025-26 (1 July 2025 -- 30 June 2026) |
 | Standard Medicare Levy Rate | 2% of taxable income |
@@ -37,7 +38,7 @@ Read this whole section before computing anything.
 | Currency | AUD only |
 | Contributor | Open Accountants |
 | Validation Date | August 2026 |
-| Skill Version | 2.2 |
+| Skill version | 2.3 |
 | Confidence Coverage | Tier 1: standard levy, low-income reduction, surcharge tiers, family thresholds. Tier 2: half-year exemptions, part-year residents, PHI rebate tier selection. Tier 3: Norfolk Island transitional, diplomatic exemptions, prescribed overseas forces. |
 
 **Low-income reduction thresholds (2025-26)**
@@ -97,7 +98,7 @@ The rebate adjustment factor applies each 1 April (a percentage of the CPI incre
 | Unknown marital status | Single (use individual thresholds) |
 | Unknown PHI status | No appropriate cover (MLS applies if income exceeds threshold) |
 | Unknown SAPTO entitlement | Not entitled (use general thresholds) |
-| Unknown MLS income components | Include only confirmed taxable income |
+| Unknown MLS income components | Obtain the missing amounts; do not treat unknown reportable super, fringe benefits or losses as zero |
 
 ## Section 2 -- Required inputs and refusal catalogue
 
@@ -170,14 +171,18 @@ This is the deterministic pre-classifier for bank statement entries related to M
 - **SAPTO family threshold formula** — For SAPTO-entitled families: Family threshold = $61,623 + ($4,338 x number_of_dependent_children)
 - **Family upper threshold (full levy)** — The reduction phases out entirely at the upper family income threshold: $59,047 (+ $5,423 per dependent child), or $77,028 (+ $5,423 per child) when SAPTO-entitled. Above it the full 2% levy applies.  _(Medicare Levy Act 1986 s 8)_
 - **Family threshold effect** — Family income at or below the family threshold: no Medicare levy payable for either spouse. Family income above the family threshold: each spouse pays their individual share, subject to individual reduction rules.  _(Medicare Levy Act 1986 s 8)_
-- **Family income for Medicare levy purposes** — Family income for Medicare levy purposes = combined taxable income of both spouses + any exempt foreign employment income + any net financial investment loss + reportable super contributions.  _(Medicare Levy Act 1986 s 8)_
+- **Family income for ordinary Medicare levy:** Start with the spouses’ combined taxable incomes, applying the statutory adjustments for this calculation. Do not add reportable super contributions or net investment losses merely because they enter the MLS threshold calculation. Calculate each person’s levy reduction under s 8. [Medicare Levy Act 1986 s 8](https://www.legislation.gov.au/C2004A03351/latest/text).
+
+### MLS computation base
+
+Select the tier using income for surcharge purposes, including the relevant family threshold. Compute each person’s surcharge on their statutory base: taxable income, reportable fringe benefits and relevant family-trust distribution amounts, subject to applicable exclusions. Do not add reportable super or net investment losses to that base merely because they affect the tier. Apply the individual low-income exemption and covered/exempt days: base × rate × liable days / days in year. [ATO MLS income and rates](https://www.ato.gov.au/individuals-and-families/medicare-and-private-health-insurance/medicare-levy-surcharge/medicare-levy-surcharge-income-thresholds-and-rates).
 
 ### 4.4 Medicare Levy Surcharge (Tier 1)
 
-- **MLS overview** — The MLS is a separate levy on top of the standard 2% Medicare levy. It applies to taxpayers who do NOT hold appropriate private patient hospital cover and whose income exceeds the MLS threshold.  _(ITAA 1997 s 8C-8G)_
-- **Income for MLS purposes** — Income for MLS purposes = taxable income + reportable fringe benefits total + total net investment loss (including net financial investment loss and net rental property loss) + super lump sum (taxed element, untaxed element) - child support paid.  _(ITAA 1997 s 8C-8G)_
-- **MLS pro-ration and appropriate cover definition** — MLS is pro-rated for each day the client (and/or dependants) do not have appropriate private hospital cover. Appropriate cover means private patient hospital cover with an excess of no more than $750 for singles or $1,500 for families/couples.  _(ITAA 1997 s 8C-8G)_
-- **Family threshold applies regardless of spouse income** — If married/de facto, the family threshold applies regardless of whether the spouse earns income.  _(ITAA 1997 s 8C-8G)_
+- **MLS overview**: The MLS is a separate levy on top of the standard 2% Medicare levy. It applies to taxpayers who do NOT hold appropriate private patient hospital cover and whose income exceeds the MLS threshold.  _(Medicare Levy Act 1986 ss 8B–8G)_
+- **Income for MLS threshold purposes:** Start with taxable income and add reportable fringe benefits, reportable super contributions, total net financial-investment and rental losses, and relevant family-trust distribution amounts. Apply the statutory exclusions, including relevant super lump-sum and FHSS amounts, without counting taxable amounts twice. Child support paid is not a general deduction from this measure. Establish each spouse’s figures and family circumstances. [ATO MLS income and rates](https://www.ato.gov.au/individuals-and-families/medicare-and-private-health-insurance/medicare-levy-surcharge/medicare-levy-surcharge-income-thresholds-and-rates).
+- **MLS pro-ration and appropriate cover definition**: MLS is pro-rated for each day the client (and/or dependants) do not have appropriate private hospital cover. Appropriate cover means private patient hospital cover with an excess of no more than $750 for singles or $1,500 for families/couples.  _(Medicare Levy Act 1986 ss 8B–8G)_
+- **Family threshold applies regardless of spouse income**: If married/de facto, the family threshold applies regardless of whether the spouse earns income.  _(Medicare Levy Act 1986 ss 8B–8G)_
 
 ### 4.5 PHI rebate interaction (Tier 1)
 
@@ -194,7 +199,7 @@ Planning note: For clients in Tier 1 or Tier 2 MLS, holding private hospital cov
 | Category | Exemption |
 | --- | --- |
 | Foreign residents (for the full year) | Full exemption from Medicare levy for the entire year |
-| Temporary residents not eligible for Medicare | Full exemption (must hold valid visa and not be enrolled in Medicare) |
+| Temporary residents not entitled to Medicare | Obtain the Medicare Entitlement Statement for the dates claimed and apply dependent/full/half exemption conditions; a visa and non-enrolment alone do not establish entitlement |
 
 ### 5.2 Half or partial exemption categories (Tier 2)
 
@@ -203,13 +208,13 @@ Planning note: For clients in Tier 1 or Tier 2 MLS, holding private hospital cov
 | Category | Exemption |
 | --- | --- |
 | Part-year residents | Pro-rata exemption for non-resident days. Flag for reviewer. |
-| Specific medical conditions (Category 1) | Blind persons -- full exemption. Complete Medicare Levy Exemption Statement. |
+| Medical exemption category | Verify the prescribed condition and dependent rules before determining full or half exemption; blindness alone does not settle every family case |
 | Specific medical conditions (Category 2) | Persons in specified care -- partial or full exemption depending on circumstances. Flag for reviewer. |
 
 ### 5.3 Reciprocal Health Care Agreements (Tier 2)
 
 - **Reciprocal health care agreements** — Australia has reciprocal health care agreements with several countries (UK, Ireland, New Zealand, Sweden, Netherlands, Belgium, Finland, Italy, Norway, Slovenia, Malta). Residents of these countries visiting Australia may be entitled to Medicare and therefore NOT exempt from the levy. Flag for reviewer to confirm coverage.
-- **Non-reciprocal foreign residents exemption and M1** — Foreign residents who are NOT covered by a reciprocal agreement and NOT enrolled in Medicare are exempt from the Medicare levy. They must complete item M1 on the tax return.
+- **Foreign-resident exemption and M1:** Establish tax residency and the exempt days under the applicable category. Reciprocal-agreement status or enrolment is not an extra condition on the full-year foreign-resident tax exemption. Complete M1 and relevant spouse/dependent details using the year’s instructions.
 
 ## Section 6 -- Completing the tax return
 
@@ -219,7 +224,15 @@ Planning note: For clients in Tier 1 or Tier 2 MLS, holding private hospital cov
 
 ### 6.2 Item M2 -- Medicare levy surcharge
 
-- **When to complete M2** — Complete M2 if: you (or your spouse/dependants) did not have appropriate private hospital cover for any day during the year; your income for MLS purposes exceeds the relevant threshold ($101,000 singles / $202,000 families for 2025-26). If the client held appropriate cover for the full year, M2 does not need to be completed (no MLS is payable).
+- **When to complete M2:** Complete the compulsory question, including the full-year hospital-cover answer and required days, even if the surcharge is nil. Verify the taxpayer’s and dependants’ appropriate cover. [ATO M2 instructions](https://www.ato.gov.au/api/public/content/0-ef4bc48e-e33e-428b-887f-4d45fc752456).
+
+### Calculation checks for distinct MLS income measures
+
+- Single, full-year liable, no appropriate cover: taxable income $100,000 plus $10,000 reportable super gives threshold income $110,000 but a $100,000 surcharge base. At the 2025–26 1% tier, MLS is $1,000.
+- Single, full-year liable, no cover: taxable income $110,000 plus $15,000 reportable super gives threshold income $125,000 and base $110,000. The 1.25% tier gives $1,375.
+- A combined family threshold income alone does not determine the family’s dollar liability. Calculate each spouse separately using their base, exemption and liable days.
+
+[ATO MLS income and rates](https://www.ato.gov.au/individuals-and-families/medicare-and-private-health-insurance/medicare-levy-surcharge/medicare-levy-surcharge-income-thresholds-and-rates).
 
 ## Section 7 -- Edge case registry
 
@@ -255,7 +268,7 @@ Resolution: Family threshold = $47,238 + ($4,338 x 4) = $64,590. Family income o
 
 ### EC7 -- MLS with private hospital cover held for part of year (Tier 2)
 
-Situation: Client held appropriate PHI for 200 days of the year, no cover for 165 days. Single, income for MLS purposes $120,000.
+Situation: Client held appropriate PHI for 200 days of the year, no cover for 165 days. Single, taxable income, threshold income and surcharge base each $120,000; no other adjustments or exemptions.
 Resolution: MLS is pro-rated for the 165 uncovered days. MLS = $120,000 x 1.25% x (165/365) = $678.08 (approximately). Flag for reviewer -- confirm exact uncovered days.
 
 ## Section 8 -- Reviewer escalation protocol
@@ -303,12 +316,12 @@ Expected output: Medicare levy = $0. Below $28,011 lower threshold.
 
 ### Test 4 -- MLS Tier 1 (single, no PHI)
 
-Input: Single, income for MLS purposes $105,000. No private hospital cover.
+Input: Single, taxable income, threshold income and surcharge base each $105,000. No private hospital cover for the full year; no other adjustments or exemptions.
 Expected output: Medicare levy = $105,000 x 2% = $2,100.00. MLS = $105,000 x 1.0% = $1,050.00. Total Medicare-related charges = $3,150.00.
 
 ### Test 5 -- MLS Tier 3 (single, no PHI)
 
-Input: Single, income for MLS purposes $200,000. No private hospital cover.
+Input: Single, taxable income, threshold income and surcharge base each $200,000. No private hospital cover for the full year; no other adjustments or exemptions.
 Expected output: Medicare levy = $200,000 x 2% = $4,000.00. MLS = $200,000 x 1.5% = $3,000.00. Total = $7,000.00.
 
 ### Test 6 -- Family below family threshold
@@ -323,14 +336,14 @@ Expected output: Full Medicare levy exemption. Levy = $0. Must complete item M1.
 
 ### Test 8 -- MLS family threshold with children
 
-Input: Family, 3 children, combined income for MLS purposes $210,000. No PHI.
-Expected output: Family MLS threshold = $202,000 + ($1,500 x 2 children after the first) = $205,000. Income $210,000 > $205,000. MLS Tier 1 = 1.0% applies, so MLS = $210,000 x 1.0% = $2,100.
+Input: Married couple with 3 dependent children. Each spouse has taxable income, threshold income and surcharge base of $105,000. Both lack appropriate cover all year, with no other adjustments or exemptions. Combined threshold income is $210,000.
+Expected output: Family MLS threshold = $202,000 + ($1,500 x 2 children after the first) = $205,000. Income $210,000 > $205,000. MLS Tier 1 = 1.0% applies, so each spouse pays $105,000 x 1.0% = $1,050, for a combined $2,100. This result depends on the stated separate bases and liability conditions.
 
 ## Section 10 -- Prohibitions and disclaimer
 
 ### Prohibitions
 
-- **Prohibitions list** — - NEVER apply the Medicare levy to a confirmed full-year foreign resident who is not enrolled in Medicare - NEVER ignore the MLS income definition -- it is NOT the same as taxable income (includes reportable fringe benefits and net investment losses) - NEVER tell a client they avoid MLS simply because their taxable income is below $101,000 -- check income for MLS purposes - NEVER apply the general low-income threshold ($28,011) to a SAPTO-entitled senior -- use the SAPTO thresholds ($44,268 / $55,335) - NEVER assume PHI eliminates MLS unless the cover is "appropriate" (private patient hospital cover with excess no more than $750 singles / $1,500 families) - NEVER present Medicare levy figures as definitive -- always label as estimated and direct client to their ATO assessment for confirmation - NEVER advise on diplomatic or prescribed overseas forces exemptions -- escalate - NEVER confuse the Medicare levy (2% on taxable income) with the Medicare Levy Surcharge (1%-1.5% on MLS income for those without PHI) -- they are separate charges
+- **Prohibitions list**: - NEVER apply the Medicare levy to a confirmed full-year foreign resident - NEVER ignore the MLS income definition -- it is NOT the same as taxable income (includes reportable fringe benefits and net investment losses) - NEVER tell a client they avoid MLS simply because their taxable income is below $101,000 -- check income for MLS purposes - NEVER apply the general low-income threshold ($28,011) to a SAPTO-entitled senior -- use the SAPTO thresholds ($44,268 / $55,335) - NEVER assume PHI eliminates MLS unless the cover is "appropriate" (private patient hospital cover with excess no more than $750 singles / $1,500 families) - NEVER present Medicare levy figures as definitive -- always label as estimated and direct client to their ATO assessment for confirmation - NEVER advise on diplomatic or prescribed overseas forces exemptions -- escalate - NEVER confuse the Medicare levy (2% on taxable income) with the Medicare Levy Surcharge (1%–1.5% on the statutory surcharge base, with the tier selected using income for MLS purposes) -- they are separate charges
 
 ### Disclaimer
 

--- a/skills/international/australia/au-rates-2026-27.md
+++ b/skills/international/australia/au-rates-2026-27.md
@@ -1,23 +1,28 @@
 ---
 name: au-rates-2026-27
 description: Use this skill whenever you need a current Australian tax rate, threshold, cap or due date for the 2026-27 or 2025-26 income year -- individual brackets, HELP repayment, Medicare levy and surcharge, super guarantee and contribution caps, Division 296, company rates, Div 7A benchmark, FBT, CGT caps and concessions, GST, PAYG instalment uplift, cents-per-km, car limits, penalty units, payroll tax, minimum wage or ASIC fees. Single-page rates card; every figure carries its source. Trigger on "what is the current rate", "2026-27 threshold", "how much is the cap", or any AU figure lookup. Load alongside the topic guide.
-version: "1.0"
+version: 1.1
 jurisdiction: AU
-tax_year: 2025
-last_updated: 2026-09-02
+tax_year: 2026
+tax_year_notes: "2026–27"
+last_updated: 2026-09-10
 review_status: pending_review
 category: international
 tier: 2
 license: AGPL-3.0-or-later (code) / OpenAccountants Guide License v1.0 (content)
 ---
 
-# Australia Rates Card 2026-27 (with 2025-26) v1.0
+# Australia Rates Card 2026-27 (with 2025-26) v1.1
 
-## Australia Rates Card 2026-27 (with 2025-26) v1.0
+## Australia Rates Card 2026-27 (with 2025-26) v1.1
 
 > **General reference only.** This skill is general tax/accounting reference material for AI-assisted workflows. It has not been reviewed for any specific person's facts, documents, elections, deadlines, residency, filing status, or local procedures. Do not rely on it to file, pay, amend, or take a tax position without review by a qualified professional in the relevant jurisdiction.
 
 Single-page lookup for the figures every other Australian guide relies on. Each row names its primary source. Verified against those sources on 20 August 2026. Deeper rules live in the topic guides named in each section; this card never overrides them.
+
+## Enacted asset and loss relief
+
+For 2025–26, eligible small business entities using simplified depreciation can deduct assets costing less than $20,000 when first used or installed ready for taxable use. The permanent threshold was enacted on 26 August 2026; schedule 2 commences on 1 October 2026 and applies to specified first use or installation from 1 July 2026. [Tax Reform No. 2 Act 2026, schedules 1–2](https://www.legislation.gov.au/C2026A00071/asmade/text). The new corporate loss carry-back rules were enacted in the same Act; distinguish the October commencement from their income-year application.
 
 ## Individual income tax
 
@@ -54,7 +59,7 @@ Tax on full bands: 2025-26 -- $4,288 at $45,000, $31,288 at $135,000, $51,638 at
 
 Repayment income = taxable income + reportable fringe benefits + reportable super + exempt foreign income + net investment losses.
 
-**Marginal repayment rates**  _(Education and Other Legislation Amendment (VET Fee Protection and Other Measures) Act 2025; ATO QC 103927)_
+**Marginal repayment rates**  _(Universities Accord (Cutting Student Debt by 20 per cent) Act 2025; ATO QC 103927)_
 
 | Repayment income (2025-26) | Marginal repayment rate |
 | --- | --- |
@@ -63,7 +68,7 @@ Repayment income = taxable income + reportable fringe benefits + reportable supe
 | $125,001 -- $179,285 | $8,700 + 17% of excess over $125,000 |
 | $179,286+ | 10% of repayment income (cap rule) |
 
-One-off 20% debt reduction applied before 1 June 2026 indexation; thresholds index for 2026-27 (confirm current-year bands at ATO study loan repayment thresholds before computing). _(Education and Other Legislation Amendment (VET Fee Protection and Other Measures) Act 2025; ATO QC 103927)_
+The one-off 20% reduction concerns eligible student-loan debts at 1 June 2025, with the associated 2025 indexation adjustment. It is not a new reduction at 1 June 2026. Use the current repayment-year thresholds separately. [Department of Education](https://www.education.gov.au/higher-education-provider-updates/higher-education-provider-updates-december-2025).
 
 ## Medicare
 
@@ -107,7 +112,7 @@ One-off 20% debt reduction applied before 1 June 2026 indexation; thresholds ind
 | BRE rate | 25% (turnover < $50m AND <= 80% BREPI) | ITRA 1986 ss 23AA-23AB |
 | Standard rate | 30% | ITRA 1986 |
 | Franking | At 25%: credit = distribution / 3. At 30%: x 3/7 | au-company-tax |
-| Loss carry-back | ENDED (2019-20 to 2022-23 claim years only) | former Div 160 |
+| Loss carry-back | New enacted rules apply to income years starting on or after 1 July 2026 for eligible corporate tax entities; test SGE status, earlier tax liabilities, franking balance and other conditions | [Tax Reform No. 2 Act 2026, schedules 1–2](https://www.legislation.gov.au/C2026A00071/asmade/text); commencement 1 October 2026 |
 | Div 7A benchmark | 8.37% (2025-26); **8.77% (2026-27)** | ATO Div 7A rates |
 | PAYG GDP uplift | 4% (2025-26); **5% (2026-27)** | ATO GDP adjustment |
 | Amendment period (SMB) | 4 years for 2024-25+ assessments | ATO amendment periods |
@@ -143,8 +148,8 @@ One-off 20% debt reduction applied before 1 June 2026 indexation; thresholds ind
 
 | Item | Value | Source |
 | --- | --- | --- |
-| Rate / registration | 10% / $75,000 ($150,000 NFP; $1 taxi-rideshare) | GST Act |
-| Instant asset write-off | $20,000 per asset (turnover < $10m) legislated to 30 Jun 2026; permanence from 1 Jul 2026 announced, confirm enactment | ATO QC 103578 |
+| Rate / registration | 10% / $75,000 ($150,000 NFP; taxi/ride-sourcing regardless of turnover) | GST Act |
+| Instant asset write-off | For 2025–26, eligible small business entities using simplified depreciation can deduct assets costing less than $20,000 when first used or installed ready for taxable use. The permanent threshold was enacted on 26 August 2026; schedule 2 commences on 1 October 2026 and applies to specified first use or installation from 1 July 2026. [Tax Reform No. 2 Act 2026, schedules 1–2](https://www.legislation.gov.au/C2026A00071/asmade/text). | ITAA 1997 Subdivision 328-D |
 | Penalty unit | $330 (7 Nov 2024 -- 30 Jun 2026); **$364 from 1 Jul 2026** | ATO QC 71196 |
 | GIC | **Not deductible from 1 Jul 2025** (SIC likewise) | Tax Incentives and Integrity Act 2025; QC 73746 |
 

--- a/skills/international/australia/au-sole-trader-schedule.md
+++ b/skills/international/australia/au-sole-trader-schedule.md
@@ -1,10 +1,11 @@
 ---
 name: au-sole-trader-schedule
-description: Australian sole trader business schedule (Business and Professional Items Schedule for Individuals). Covers assessable business income, allowable deductions, home office (fixed rate 67c/hour or actual), motor vehicle (logbook or cents per km at 85c/km), depreciation (instant asset write-off, simplified pooling, general pooling), prepaid expenses, and trading stock.
-version: 1.0
+description: Australian sole trader business schedule (Business and Professional Items Schedule for Individuals). Covers assessable business income, allowable deductions, home office (fixed rate 70c/hour or actual), motor vehicle (logbook or cents per km at 88c/km), depreciation (instant asset write-off, simplified pooling, general pooling), prepaid expenses, and trading stock.
+version: 1.2
 jurisdiction: AU
 tax_year: 2025
-last_updated: 2026-08-28
+tax_year_notes: "2025–26"
+last_updated: 2026-09-10
 review_status: pending_review
 depends_on:
   - income-tax-workflow-base
@@ -17,7 +18,7 @@ license: AGPL-3.0-or-later (code) / OpenAccountants Guide License v1.0 (content)
 
 ## AU Sole Trader Schedule
 
-## Australia Sole Trader Business Schedule v1.1
+## Australia Sole Trader Business Schedule v1.2
 
 ## What this file is
 
@@ -27,7 +28,7 @@ license: AGPL-3.0-or-later (code) / OpenAccountants Guide License v1.0 (content)
 
 This file covers the Business and Professional Items (BPI) schedule that sole traders attach to their individual income tax return. The BPI schedule feeds into the individual return at "Business income or loss" items.
 
-**Tax year coverage.** This skill targets the **2024-25 income year** (1 July 2024 to 30 June 2025).
+**Tax year coverage:** This skill targets the 2025–26 income year (1 July 2025 to 30 June 2026). Match the intake and assembly year before calculating.
 
 **The reviewer is the customer of this output.** This skill assumes a credentialed reviewer reviews and signs the return. The skill produces working papers and a brief, not a return.
 
@@ -58,12 +59,12 @@ This skill does NOT cover:
 
 | Lodgement type | Due date |
 | --- | --- |
-| Self-lodgers | 31 October 2025 |
-| Tax agent lodgement | Per the ATO tax agent lodgement programme (typically March-May 2026 depending on client category) |
+| Self-lodgers | 2 November 2026 (31 October falls on Saturday; check applicable extensions) |
+| Tax agent lodgement | Per the ATO tax agent lodgement programme (2026–27 programme, depending on client category) |
 
 ### 2.3 ABN requirement
 
-- **ABN requirement** — A sole trader carrying on a business must have an ABN. If they do not have one, they cannot issue valid tax invoices and may face 47% withholding from payers.  _(A New Tax System (Australian Business Number) Act 1999)_
+- **ABN requirement:** Check ABN entitlement, GST registration and withholding consequences separately. An ABN is not compulsory for every business activity. A tax invoice must meet GST requirements, and eligible payments without an ABN can attract 47% withholding subject to exceptions. [ABR](https://www.abr.gov.au/business-super-funds-charities/applying-abn/abn-entitlement).
 
 ## Section 3 — Rates and thresholds
 
@@ -71,21 +72,21 @@ This skill does NOT cover:
 
 | Item | Amount / Rate | Source |
 | --- | --- | --- |
-| Instant asset write-off threshold | $20,000 per asset (small business entities, aggregated turnover < $10M). Legislated for assets first used or installed ready for use to 30 June 2026; the 2026-27 Budget announced permanence from 1 July 2026 -- confirm enactment before relying on it for 2026-27 | ITAA 1997 Div 328; ATO QC 103578 |
+| Instant asset write-off threshold | For 2025–26, eligible small business entities using simplified depreciation can deduct assets costing less than $20,000 when first used or installed ready for taxable use. The permanent threshold was enacted on 26 August 2026; schedule 2 commences on 1 October 2026 and applies to specified first use or installation from 1 July 2026. [Tax Reform No. 2 Act 2026, schedules 1–2](https://www.legislation.gov.au/C2026A00071/asmade/text). | ITAA 1997 Subdivision 328-D |
 | Small business entity threshold | Aggregated turnover < $10M | ITAA 1997 s 328-110 |
 | Cents per km rate (motor vehicle) | 88 cents per km (2024-25 and 2025-26); 91 cents (2026-27) | ATO cents per kilometre method |
 | Cents per km cap | 5,000 business km per car per year | ITAA 1997 s 28-25 |
 | Home office fixed rate | 70 cents per hour (2024-25 through 2026-27; 67c applied 2022-23 and 2023-24) | ATO PCG 2023/1 |
-| Trading stock threshold (change in value) | $5,000 — if the difference between opening and closing stock is < $5,000, the taxpayer can elect not to do a stocktake | ITAA 1997 s 70-35 |
-| Prepaid expenses (SBE) | Immediately deductible if the service period is 12 months or less and ends on or before 30 June of the following year | ITAA 1997 s 328-225 |
+| Trading stock threshold (change in value) | $5,000: if an eligible small business entity reasonably estimates that the difference between opening and closing stock is $5,000 or less, the taxpayer can elect not to do a stocktake | ITAA 1997 s 328-285 |
+| Prepaid expenses (SBE) | Immediately deductible if the service period is 12 months or less and ends on or before 30 June of the following year | ITAA 1936 ss 82KZL and 82KZM |
 
-- **Instant asset write-off threshold** — $20,000 per asset (small business entities, aggregated turnover < $10M), legislated for assets first used or installed ready for use to 30 June 2026. The 2026-27 Budget announced permanence from 1 July 2026 -- confirm enactment before relying on it for 2026-27.  _(ITAA 1997 Div 328; ATO QC 103578)_
+- **Instant asset write-off threshold:** For 2025–26, eligible small business entities using simplified depreciation can deduct assets costing less than $20,000 when first used or installed ready for taxable use. The permanent threshold was enacted on 26 August 2026; schedule 2 commences on 1 October 2026 and applies to specified first use or installation from 1 July 2026. [Tax Reform No. 2 Act 2026, schedules 1–2](https://www.legislation.gov.au/C2026A00071/asmade/text).
 - **Small business entity threshold** — Aggregated turnover < $10M  _(ITAA 1997 s 328-110)_
 - **Cents per km rate (motor vehicle)** — 88 cents per km for 2024-25 and 2025-26; 91 cents per km from 2026-27  _(ATO cents per kilometre method)_
 - **Cents per km cap** — 5,000 business km per car per year  _(ITAA 1997 s 28-25)_
 - **Home office fixed rate** — 70 cents per hour for 2024-25 through 2026-27 (67c applied for 2022-23 and 2023-24)  _(ATO PCG 2023/1)_
-- **Trading stock threshold (change in value)** — $5,000 — if the difference between opening and closing stock is < $5,000, the taxpayer can elect not to do a stocktake  _(ITAA 1997 s 70-35)_
-- **Prepaid expenses (SBE)** — Immediately deductible if the service period is 12 months or less and ends on or before 30 June of the following year  _(ITAA 1997 s 328-225)_
+- **Trading stock threshold (change in value)**: $5,000: if an eligible small business entity reasonably estimates that the difference between opening and closing stock is $5,000 or less, the taxpayer can elect not to do a stocktake  _(ITAA 1997 s 328-285)_
+- **Prepaid expenses (SBE)**: Immediately deductible if the service period is 12 months or less and ends on or before 30 June of the following year  _(ITAA 1936 ss 82KZL and 82KZM)_
 
 ## Section 4 — Computation rules
 
@@ -95,7 +96,7 @@ This skill does NOT cover:
 
 ### 4.2 Cost of sales / Cost of goods sold
 
-- **Cost of goods sold** — Step 1. Opening stock + Purchases - Closing stock = Cost of goods sold. Step 2. Trading stock can be valued at cost, market selling value, or replacement value (ITAA 1997 s 70-45). The method can differ item by item. Step 3. If the total value of trading stock at year-end differs from opening stock by less than $5,000, the taxpayer can elect to use the same value as opening stock (no stocktake required).  _(ITAA 1997 s 70-45)_
+- **Cost of goods sold**: Step 1. Opening stock + Purchases - Closing stock = Cost of goods sold. Step 2. Trading stock can be valued at cost, market selling value, or replacement value (ITAA 1997 s 70-45). The method can differ item by item. Step 3. If an eligible small business entity reasonably estimates that year-end trading stock differs from opening stock by $5,000 or less (s 328-285), the taxpayer can elect to use the same value as opening stock (no stocktake required).  _(ITAA 1997 s 70-45)_
 
 ### 4.3 Allowable deductions
 
@@ -103,14 +104,16 @@ This skill does NOT cover:
 
 **Key deduction categories on the schedule**
 
-| Label | Category | Notes |
+| Schedule area | Category | Notes |
 | --- | --- | --- |
-| P9 | Motor vehicle expenses | See 4.4 below |
-| P10 | Depreciation expenses | See 4.5 below |
-| P11 | Repairs and maintenance | Must be revenue not capital |
-| P12 | Interest (business portion) | Pro-rate if mixed-use loan |
-| P13 | Rent on business premises | Not home office (see P14) |
-| P14 | Other business expenses | Includes home office, travel, subscriptions, professional fees |
+| P8 expenses | Motor vehicle expenses | Use the year-specific expense label and method |
+| P8 expenses | Depreciation | Reconcile to the depreciation schedule |
+| P8 expenses | Repairs and maintenance | Distinguish capital expenditure |
+| P8 expenses | Interest | Use the correct domestic/overseas label and business portion |
+| P8 expenses | Rent | Business premises; assess home occupancy separately |
+| P8 expenses | Other expenses | Classify into specific P8 expense labels where available |
+
+P9 records business loss activity details, not motor expenses. P10 and later items request separate business information, not a sequence of ordinary expense categories. Use the issued year’s form. [ATO 2025 business schedule instructions](https://www.ato.gov.au/api/public/content/5861f7f47efa45d5b76332ef12919ace?v=a0a2f777) establish this P8/P9 distinction. Verify the issued 2026 form before transferring labels.
 
 ### 4.4 Motor vehicle expenses
 
@@ -132,7 +135,7 @@ Two methods available for sole traders:
 
 #### General depreciation (non-SBE or election out of simplified)
 
-- **General depreciation** — Use the effective life determined by the ATO (TR 2024/3) or a self-assessed effective life. Choose diminishing value (rate = 200% / effective life) or prime cost (rate = 100% / effective life). Apply from the date the asset is first used or installed ready for use.  _(ATO TR 2024/3)_
+- **General depreciation**: Use the effective life determined by the ATO (Income Tax Assessment (Effective Life of Depreciating Assets) Determination 2025) or a self-assessed effective life. Choose diminishing value (rate = 200% / effective life) or prime cost (rate = 100% / effective life). Apply from the date the asset is first used or installed ready for use.  _(ATO Income Tax Assessment (Effective Life of Depreciating Assets) Determination 2025)_
 
 ### 4.6 Home office expenses
 
@@ -144,15 +147,15 @@ Two methods available for sole traders:
 
 - **Actual cost method** — Calculate the actual costs of running the home office. Apportion based on floor area of the dedicated work area as a percentage of total home area, and the proportion of the year the area is used for work. Keep receipts and records for every expense claimed.
 
-### 4.7 Net business income or loss (P20)
+### 4.7 Net business income or loss (P8)
 
-- **Net business income or loss (P20)** — Step 1. P20 = P8 (income) - total deductions (P9 through P14 plus any other deductions). Step 2. If P20 is a loss, check the non-commercial business loss rules (ITAA 1997 Div 35): The loss can only be offset against other income if one of four tests is met: assessable income test ($20,000), profits test (3 of last 5 years), real property test ($500,000), or other assets test ($100,000). If no test is met, the loss is deferred to future years (quarantined). Step 3. P20 feeds into the individual tax return at "Business income or loss."  _(ITAA 1997 Div 35)_
+- **Net business income or loss (P8):** Sum the P8 income and deductible expenses using the applicable accounting method and tax adjustments. The established mapping is P8 label Z to supplementary return question 15 label C for non-primary-production net income or loss; confirm those labels against the issued 2026 form. [ATO transfer instructions](https://www.ato.gov.au/api/public/content/0-58fc149a-82af-406a-a4e0-252beb58a86b). If there is a loss, complete P9 and test Division 35: the adjusted-income requirement must be less than $250,000 before relying on the assessable-income, profits, real-property or other-assets tests. Assess statutory exceptions and Commissioner discretion separately. Otherwise defer the loss. [ITAA 1997 s 35-10](https://www.ato.gov.au/law/view/document?docid=PAC/19970038/35-10).
 
 ## Section 5 — Edge cases and special rules
 
 ### 5.1 Personal services income (PSI)
 
-- **Personal services income (PSI)** — If more than 80% of the sole trader's income from a contract is for their personal effort or skills, and no PSI determination has been obtained, the income may be PSI. PSI rules deny certain deductions (home office, entertainment, some car expenses). **Flag for reviewer.**  _(ITAA 1997 Div 84-87)_
+- **Personal services income (PSI):** Screen each amount for whether it is mainly, ordinarily more than half, a reward for personal effort or skills. Then apply the separate personal services business tests. The 80% source-concentration rule is not the definition of PSI; consider the results test and other tests/determination rules in their proper order. Refer uncertain cases for review. [ITAA 1997 s 84-5 and TR 2022/3](https://www.ato.gov.au/law/view/document?docid=TXR/TR20223/NAT/ATO/00001).
 
 ### 5.2 Mixed-use assets
 
@@ -160,7 +163,7 @@ Two methods available for sole traders:
 
 ### 5.3 Prepaid expenses (SBE)
 
-- **Prepaid expenses (SBE)** — Small business entities can immediately deduct prepaid expenses if the service period is 12 months or less and ends by 30 June of the following income year. Example: 12-month insurance premium paid in May 2025 covering May 2025 to April 2026 — fully deductible in 2024-25.
+- **Prepaid expenses (SBE)**: Small business entities can immediately deduct prepaid expenses if the service period is 12 months or less and ends by 30 June of the following income year. Example: 12-month insurance premium paid in May 2026 covering May 2026 to April 2027: deductible in 2025–26 if the statutory conditions are met.
 
 ### 5.4 Capital vs revenue
 
@@ -183,7 +186,7 @@ Before delivering output, verify:
 - [ ] Non-commercial loss rules checked if a loss is reported
 - [ ] PSI risk flagged if applicable
 - [ ] Trading stock valuation method is documented
-- [ ] Rates and thresholds match the 2024-25 income year
+- [ ] Rates and thresholds match the 2025–26 income year
 - [ ] Output format matches the base skill spec
 
 ## Section 7 — Disclaimer

--- a/skills/international/australia/au-super-guarantee.md
+++ b/skills/international/australia/au-super-guarantee.md
@@ -2,23 +2,32 @@
 name: au-super-guarantee
 description: >
   Use this skill whenever asked about Australian Superannuation Guarantee (SG) obligations, payday super deadlines, voluntary super contributions, concessional and non-concessional caps, Division 293 tax, Division 296 large-balance tax, government co-contribution, spouse contribution tax offset, carry-forward rules, or any question about super for sole traders or employers. Trigger on phrases like "how much super do I pay", "SG rate", "super guarantee", "payday super", "7 business days super", "SG shortfall", "concessional cap", "Division 293", "Division 296", "$3 million super tax", "salary sacrifice super", "personal super contribution deduction", "co-contribution", "BPAY super", "super clearing house", "super fund contribution", or any question about Australian superannuation. Also trigger when classifying bank statement transactions showing super fund payments, BPAY super debits, or clearing house payments. ALWAYS read this skill before touching any SG-related work.
-version: 3.1
+version: 3.2
 jurisdiction: AU
-tax_year: 2024
-last_updated: 2026-08-28
+tax_year: 2025
+tax_year_notes: "2025–26 contribution reconciliation; 2026–27 payday SG"
+last_updated: 2026-09-10
 review_status: pending_review
 category: international
 tier: 2
 license: AGPL-3.0-or-later (code) / OpenAccountants Guide License v1.0 (content)
 ---
 
-# Australia Superannuation Guarantee (SG) -- Sole Trader & Employer Skill v3.0
+# Australia Superannuation Guarantee (SG) -- Sole Trader & Employer Skill v3.2
 
-## Australia Superannuation Guarantee (SG) -- Sole Trader & Employer Skill v3.0
+## Australia Superannuation Guarantee (SG) -- Sole Trader & Employer Skill v3.2
 
 > **General reference only.** This skill is general tax/accounting reference material for AI-assisted workflows. It has not been reviewed for any specific person's facts, documents, elections, deadlines, residency, filing status, or local procedures. Do not rely on it to file, pay, amend, or take a tax position without review by a qualified professional in the relevant jurisdiction.
 
 > **Regime change at 1 July 2026 (Payday Super).** SG timing is determined by WHEN earnings are PAID, not when the work was done. Earnings paid from 1 July 2026: payday super rules (SG received by the fund within 7 business days of each payday). Earnings paid up to 30 June 2026: old quarterly rules (final quarterly deadline was 28 July 2026 for the June 2026 quarter). Both regimes appear in 2026 bank statements -- classify by payment date.
+
+## Select the income year before calculating
+
+This guide covers 2025–26 contribution reconciliation and 2026–27 payday SG. Ask for the requested year and fund receipt records; return that year in the output.
+
+For the 2025–26 return-assembly branch, reconcile employer, salary-sacrifice and personal contributions received by the fund during 1 July 2025 to 30 June 2026. Use the $30,000 standard concessional cap, plus eligible carry-forward amounts where the prior 30 June total super balance was less than $500,000. Establish a valid acknowledged personal deduction notice before including a deduction, and test Division 293 using its full income definition. Employer SG is 12% on eligible ordinary time earnings, subject to the 2025–26 maximum contribution base and employment rules; quarterly due dates apply. Do not apply the later payday deadlines or $32,500 cap to this branch. Return the reconciled deduction and cap position to the ITR, then stop this branch.
+
+The remaining payday calculations and indexed figures below concern 2026–27. [ATO super guarantee rates](https://www.ato.gov.au/tax-rates-and-codes/key-superannuation-rates-and-thresholds/super-guarantee); [ITAA 1997 s 290-170](https://www.ato.gov.au/law/view/document?docid=PAC/19970038/290-170).
 
 ## Section 1 -- Quick reference
 
@@ -58,7 +67,7 @@ license: AGPL-3.0-or-later (code) / OpenAccountants Guide License v1.0 (content)
 | Unknown SG rate year | 2024-25 = 11.5%; 2025-26 onwards = 12% |
 | Unknown YTD qualifying earnings vs $270,830 | Assume below cap; flag to confirm before stopping SG |
 | Unknown TSB for carry-forward | Assume >= $500,000 (no carry-forward); ask client |
-| Unknown s 290-150 notice status | Assume NOT lodged; warn about deadline |
+| Unknown s 290-170 notice status | Assume NOT lodged; warn about deadline |
 | Unknown contractor vs employee | Flag for reviewer -- multi-factor test |
 
 ### Required inputs
@@ -67,7 +76,7 @@ license: AGPL-3.0-or-later (code) / OpenAccountants Guide License v1.0 (content)
 
 **Recommended** -- bank statements showing super fund debits, payroll register with per-payday qualifying earnings and YTD totals, TSB at 30 June prior year, taxable income for Division 293.
 
-**Ideal** -- complete STP reporting data, super fund member statements showing receipt dates, s 290-150 notice copies, ATO online account showing contribution caps.
+**Ideal** -- complete STP reporting data, super fund member statements showing receipt dates, s 290-170 notice copies, ATO online account showing contribution caps.
 
 ### Refusal catalogue
 
@@ -163,9 +172,9 @@ Matches "AUSTRALIAN SUPER" (pattern 3.1). Payday was Friday 17 July 2026; $480.0
 `15.05.2027 ; BPAY HOSTPLUS ; DEBIT ; PERSONAL CONTRIBUTION ; -10,000.00 ; AUD`
 
 **Reasoning:**
-Matches "BPAY" + "HOSTPLUS" (pattern 3.2). Sole trader making a personal super contribution. Whether this is concessional (deductible) depends on whether the s 290-150 notice is lodged and acknowledged. If notice lodged: $10,000 concessional contribution, tax-deductible, taxed at 15% in the fund, counts toward the $32,500 cap. If no notice: non-concessional, no deduction.
+Matches "BPAY" + "HOSTPLUS" (pattern 3.2). Sole trader making a personal super contribution. Whether this is concessional (deductible) depends on whether the s 290-170 notice is lodged and acknowledged. If notice lodged: $10,000 concessional contribution, tax-deductible, taxed at 15% in the fund, counts toward the $32,500 cap. If no notice: non-concessional, no deduction.
 
-**Classification:** EXCLUDE -- personal super contribution. Deductibility depends on s 290-150 notice status. Flag: "Has the Notice of Intent to Claim a Deduction been lodged with the fund?"
+**Classification:** EXCLUDE -- personal super contribution. Deductibility depends on s 290-170 notice status. Flag: "Has the Notice of Intent to Claim a Deduction been lodged with the fund?"
 
 ### Example 3 -- Commercial clearing house payment (SBSCH is gone)
 
@@ -211,7 +220,7 @@ Matches "ATO" + "IAS" (pattern 3.6). This is an Instalment Activity Statement (P
 
 ### Rule 1 -- SG formula (payday super)
 
-- **SG formula (payday super)** — ``` remaining_base = max(0, $270,830 - YTD_qualifying_earnings_before_this_payday) SG per payday  = 12% x min(Qualifying_earnings_paid_this_payday, remaining_base) ``` SG applies only to the first $270,830 of qualifying earnings paid in the financial year -- the payday that crosses the base attracts SG only on the portion beneath it, and later paydays attract none. Annual maximum SG per employee: exactly $32,499.60. No $450/month threshold (removed 1 July 2022). All employees eligible.
+- **SG formula (payday super)**: ``` remaining_base = max(0, $270,830 - YTD_qualifying_earnings_before_this_payday) SG per payday  = 12% x min(Qualifying_earnings_paid_this_payday, remaining_base) ``` SG applies only to the first $270,830 of qualifying earnings paid in the financial year -- the payday that crosses the base attracts SG only on the portion beneath it, and later paydays attract none. Annual maximum SG per employee: exactly $32,499.60. No $450/month threshold (removed 1 July 2022). Test employment eligibility separately. The removal of the $450 monthly threshold did not remove exclusions, including employees under 18 who do not work more than 30 hours in a week and the separate private/domestic work exclusion where hours do not exceed 30 in a week. [SGAA 1992 ss 27–29](https://www.ato.gov.au/law/view/document?docid=PAC/19920111/27).
 
 ### Rule 2 -- SG rate
 
@@ -231,7 +240,7 @@ Matches "ATO" + "IAS" (pattern 3.6). This is an Instalment Activity Statement (P
 
 ### Rule 6 -- Concessional contributions cap
 
-- **Concessional contributions cap** — $32,500 (2026-27; indexed up from $30,000 on 1 July 2026). Includes employer SG + salary sacrifice + personal deductible contributions (with s 290-150 notice). Excess included in assessable income at marginal rate (with 15% offset).
+- **Concessional contributions cap**: $32,500 (2026-27; indexed up from $30,000 on 1 July 2026). Includes employer SG + salary sacrifice + personal deductible contributions (with s 290-170 notice). Excess included in assessable income at marginal rate (with 15% offset).
 
 ### Rule 7 -- Carry-forward unused concessional cap
 
@@ -241,17 +250,23 @@ Matches "ATO" + "IAS" (pattern 3.6). This is an Instalment Activity Statement (P
 
 - **Non-concessional cap** — $130,000 (2026-27; 4 x concessional cap). Bring-forward tiers by TSB at 30 June 2026: < $1.84m -> $390,000 over 3 years; $1.84m to < $1.97m -> $260,000 over 2 years; $1.97m to < $2.1m -> $130,000 (no bring-forward); >= $2.1m -> nil.
 
-### Rule 9 -- s 290-150 notice (personal contribution deduction)
+### Rule 9 -- s 290-170 notice (personal contribution deduction)
 
-- **s 290-150 notice (personal contribution deduction)** — - **s 290-150 notice requirement** — Must lodge Notice of Intent to Claim a Deduction with the super fund AND receive acknowledgement BEFORE the earlier of: lodging the tax return, or end of following financial year. If not lodged: contribution stays non-concessional, NO deduction.  _(Rule 8)_
+- **s 290-170 notice (personal contribution deduction)**: - **s 290-170 notice requirement**: Must lodge Notice of Intent to Claim a Deduction with the super fund AND receive acknowledgement BEFORE the earlier of: lodging the tax return, or end of following financial year. If not lodged: contribution stays non-concessional, NO deduction.  _(Rule 8)_
 
 ### Rule 10 -- Division 293 (additional 15% for high earners)
 
-- **Division 293 (additional 15% for high earners)** — - **Division 293 formula** — Div 293 income = taxable income + concessional contributions If > $250,000: Div 293 tax = 15% x lesser of (concessional contributions, excess over $250,000)  _(Rule 9)_ Threshold frozen at $250,000 (not indexed).
+- **Division 293:** Division 293 income is income for surcharge purposes excluding reportable super contributions, plus applicable low-tax contributions. Include the relevant reportable fringe benefits and net investment losses; apply statutory exclusions, including assessable FHSS released amounts. Tax is 15% of the lesser of low-tax contributions and the positive excess over $250,000. Exclude excess concessional contributions from low-tax contributions. [ITAA 1997 ss 293-20 and 293-25](https://www.ato.gov.au/law/view/document?docid=PAC/19970038/293-20).
+
+Example: taxable income $230,000, reportable fringe benefits $20,000 and applicable low-tax contributions $25,000, with no other adjustments, give $275,000 for the threshold test. Division 293 tax is 15% of $25,000 = $3,750.
 
 ### Rule 11 -- Redesigned SGC (QE days from 1 July 2026)
 
 - **Redesigned SGC (QE days from 1 July 2026)** — ATO-assessed per payday (no SG statement is lodged; ATO matches STP against fund reporting). Components: 1. **Final SG shortfall** -- unpaid SG on qualifying earnings at 12% 2. **Notional earnings** -- GIC-rate interest on the shortfall, compounding daily from the day after the deadline 3. **Administrative uplift** -- starts at 60% of (shortfall + notional earnings); reduced 20 points for a clean 2-year history and up to 40 points for voluntary disclosure (0% if disclosed within 30 days with clean history) 4. **Choice loading** -- 25% of contributions where choice-of-fund rules breached, capped at $1,200 per notice period Payment due the day the assessment is made. Unpaid 28 days after assessment -> Notice to Pay -> late payment penalty of 25% or 50% of unpaid SGC. **The new SGC is tax-deductible** (all four components); GIC on late SGC and the late payment penalty are not, and old-regime SGC (quarters before 1 July 2026) remains non-deductible. First-year approach: PCG 2026/1.
+
+## Personal deduction notice validity
+
+Before claiming a personal contribution deduction, verify the notice was valid when given and acknowledged by the fund. Check membership, whether the fund still held the contribution, any rollover/withdrawal, commencement of an income stream and contribution-splitting application. Check the deduction eligibility and age/work-test rules separately. The deadline alone does not establish validity. [ITAA 1997 s 290-170](https://www.ato.gov.au/law/view/document?docid=PAC/19970038/290-170).
 
 ## Section 7 -- Excel working paper template
 
@@ -279,7 +294,7 @@ EMPLOYER SG (PER EMPLOYEE PER PAYDAY)
 
 PERSONAL CONTRIBUTIONS (SOLE TRADER)
   Personal contribution:          AUD [____]
-  s 290-150 notice lodged:        [YES/NO]
+  s 290-170 notice lodged:        [YES/NO]
   Acknowledged by fund:           [YES/NO]
   Classification:                 [Concessional / Non-concessional]
   Tax deduction claimed:          AUD [____]
@@ -338,7 +353,7 @@ If the client provides only a bank statement:
 2. **Identify SG vs personal contributions** -- payday-aligned amounts = likely SG; ad hoc amounts = likely personal
 3. **Check debit cadence against pay cycle** -- SG debits should follow every payday from July 2026
 4. **Sum SG debits per employee** -- compare against expected qualifying earnings x 12% YTD to verify completeness
-5. **Flag:** "Super contribution classification derived from bank statement patterns. Fund receipt dates, qualifying earnings, s 290-150 notice status, and TSB have not been independently verified. Reviewer must confirm before tax return lodgement."
+5. **Flag:** "Super contribution classification derived from bank statement patterns. Fund receipt dates, qualifying earnings, s 290-170 notice status, and TSB have not been independently verified. Reviewer must confirm before tax return lodgement."
 
 ## Section 10 -- Reference material
 
@@ -414,7 +429,7 @@ Sole trader asks about SG to self. -> $0. No obligation. Advise voluntary contri
 - NEVER apply the quarterly maximum contribution base to 2026-27 earnings (annual $270,830 YTD basis applies)
 - NEVER reference the ATO SBSCH as an available payment channel (closed permanently 1 July 2026)
 - NEVER call the new-regime SGC non-deductible (that rule died with the quarterly regime; old-regime SGC stays non-deductible)
-- NEVER allow deduction claim without confirmed s 290-150 notice
+- NEVER allow deduction claim without confirmed s 290-170 notice
 - NEVER apply carry-forward if TSB >= $500,000
 - NEVER present figures as definitive
 - NEVER compute SGC amounts without escalating

--- a/skills/international/australia/australia-bookkeeping.md
+++ b/skills/international/australia/australia-bookkeeping.md
@@ -1,10 +1,11 @@
 ---
 name: australia-bookkeeping
 description: Use this skill whenever asked about Australian bookkeeping for sole traders, partnerships, or small companies. Trigger on phrases like "chart of accounts", "BAS", "GST codes", "bookkeeping", "profit and loss", "balance sheet", "AASB", "simplified disclosures", "Tier 2", "bank reconciliation", "expense categories", "revenue recognition", "depreciation", "instant asset write-off", "small business pool", "ABN", "ATO reporting", "activity statement", "accrual basis", "cash basis", "general ledger", or any question about day-to-day transaction recording, financial statement preparation, or account coding for an Australian business.
-version: 1.0
+version: 1.1
 jurisdiction: AU
 tax_year: 2025
-last_updated: 2026-08-28
+tax_year_notes: "2025–26"
+last_updated: 2026-09-10
 review_status: pending_review
 depends_on:
   - bookkeeping-workflow-base
@@ -147,7 +148,7 @@ Australian software (Xero, MYOB, QuickBooks) typically uses 3–4 digit codes. T
 | 6040 | Insurance — Business | Expense |
 | 6050 | Repairs and Maintenance | Expense |
 | 6100 | Wages and Salaries | Expense |
-| 6110 | Superannuation Guarantee (11.5% from Jul 2025) | Expense |
+| 6110 | Superannuation Guarantee (12% from Jul 2025) | Expense |
 | 6120 | Workers' Compensation Insurance | Expense |
 | 6130 | Payroll Tax (state-based) | Expense |
 | 6140 | Staff Training | Expense |
@@ -160,7 +161,7 @@ Australian software (Xero, MYOB, QuickBooks) typically uses 3–4 digit codes. T
 | 6320 | Motor Vehicle — Repairs | Expense |
 | 6330 | Travel — Domestic | Expense |
 | 6340 | Travel — International | Expense |
-| 6350 | Meals and Entertainment (50% deductible FBT) | Expense |
+| 6350 | Meals and Entertainment (review FBT election and deductibility) | Expense |
 | 6400 | Accounting and Tax Agent Fees | Expense |
 | 6410 | Legal Fees | Expense |
 | 6420 | Bank Charges | Expense |
@@ -205,11 +206,11 @@ Australian software (Xero, MYOB, QuickBooks) typically uses 3–4 digit codes. T
 
 | Criterion | Cash Basis (Sole Traders / Small Business) | Accruals Basis |
 | --- | --- | --- |
-| Eligibility | Aggregated turnover < $10m (small business entity) | All entities; mandatory for reporting entities |
+| Eligibility | For income tax, use the method that correctly reflects income under TR 98/1; small-business status alone does not establish a receipts basis | Apply the appropriate income-tax method and separate financial-reporting requirements |
 | Income recognised | When cash received | When earned (invoice raised or goods delivered) |
 | Expenses recognised | When cash paid | When incurred (liability arises) |
-| Trading stock | Simplified: exempt from stock-take if change < $5,000 | Required: opening/closing stock adjustments |
-| Prepaid expenses | Immediate deduction if < 12 months and under $1,000 or business turnover < $10m | Spread over benefit period |
+| Trading stock | Eligible small business entities can use s 328-285 where the reasonably estimated stock-value change is $5,000 or less | Otherwise apply the required stock adjustments; this is separate from GST cash accounting |
+| Prepaid expenses | Test the 12-month rule and other exceptions under ITAA 1936 ss 82KZL and 82KZM | Apply the relevant tax apportionment and financial-reporting rules separately |
 
 ### AASB 15 Revenue from Contracts with Customers
 
@@ -261,7 +262,7 @@ Small businesses using simplified reporting typically recognise on delivery/comp
 | GST-Free | Food (basic), medical, education, exports | G1 (no 1A) |
 | Input Taxed | Financial supplies, residential rent | G1 (no credit) |
 | BAS Excluded | Wages, drawings, loan principal, private | Not reported |
-| No ABN Withholding | Payments to suppliers without ABN (49% w/h) | Separate |
+| No ABN Withholding | Payments to suppliers without ABN (47% w/h) | Separate |
 
 ## Section 5 -- Asset vs Expense Thresholds
 
@@ -272,7 +273,7 @@ Small businesses using simplified reporting typically recognise on delivery/comp
 | Period | Threshold | Eligibility |
 | --- | --- | --- |
 | 1 Jul 2023 – 30 Jun 2026 | < $20,000 per asset | Aggregated turnover < $10m, using simplified depreciation |
-| Permanent (from 1 Jul 2026) | < $20,000 per asset | Announced in 2026 Budget — made permanent |
+| From 1 Jul 2026 application date | Less than $20,000 per eligible asset | Enacted 26 August 2026; schedule 2 commences 1 October 2026. [Tax Reform No. 2 Act 2026, schedules 1–2](https://www.legislation.gov.au/C2026A00071/asmade/text) |
 
 ### Small Business Pool (Simplified Depreciation)
 
@@ -293,19 +294,20 @@ Small businesses using simplified reporting typically recognise on delivery/comp
 | Diminishing value | rate = days held ÷ 365 × (200% ÷ effective life) |
 | Prime cost (straight-line) | rate = days held ÷ 365 × (100% ÷ effective life) |
 
-### Common Effective Lives (ATO TR 2025/1 basis)
+### Common effective lives (2025 determination, asset-specific)
 
-**Common Effective Lives (ATO TR 2025/1 basis)**  _(ATO TR 2025/1)_
+**Common effective lives (2025 determination, asset-specific)**  ([Income Tax Assessment (Effective Life of Depreciating Assets) Determination 2025, Table B](https://www.legislation.gov.au/F2025L01097/asmade/text)). Choose the determination applicable under s 40-95; the 2025 instrument commenced on 16 September 2025.
 
 | Asset | Effective Life | DV Rate | PC Rate |
 | --- | --- | --- | --- |
 | Desktop computers | 4 years | 50% | 25% |
-| Laptops | 4 years | 50% | 25% |
+| Laptops | 2 years | 100% | 50% |
 | Printers/Scanners | 5 years | 40% | 20% |
-| Office furniture | 10 years | 20% | 10% |
+| Office chairs | 10 years | 20% | 10% |
+| Office desks | 20 years | 10% | 5% |
 | Motor vehicles | 8 years | 25% | 12.5% |
 | Air conditioning | 10 years | 20% | 10% |
-| Buildings (general) | 40 years | 5% | 2.5% |
+| Eligible building capital works | Division 43, subject to use and construction dates | No generic diminishing-value deduction | Commonly 2.5%; verify eligibility and applicable statutory rate |
 
 ### Car Limit
 
@@ -464,7 +466,7 @@ TOTAL EQUITY                                          xxx
 | --- | --- |
 | Simplified depreciation | Instant write-off < $20,000; pool balance at 15%/30% |
 | Simplified trading stock | No stock-take if estimate change ≤ $5,000 |
-| Prepaid expenses | Immediate deduction if < 12 months and service period ends before next year |
+| Prepaid expenses | Test the 12-month rule and other exceptions under ITAA 1936 ss 82KZL and 82KZM |
 | Simpler BAS | Report only G1, 1A, 1B (no G2, G3, G10, G11) |
 | Two-year amendment period | ATO can only amend assessments within 2 years (not 4) |
 | Cash accounting for GST | Report GST when paid/received, not invoiced |
@@ -476,9 +478,9 @@ TOTAL EQUITY                                          xxx
 
 | Tier | Who | Standards | Required Statements |
 | --- | --- | --- | --- |
-| Tier 1 (Full AASB / IFRS) | Large proprietary companies, public companies, registered schemes | Full recognition + full disclosure | All 5 statements + notes |
+| Tier 1 (Full AASB / IFRS) | Entities with public accountability or another Tier 1 requirement | Full recognition and disclosure | Determine requirements under AASB 1053; size alone does not force Tier 1 |
 | Tier 2 (AASB 1060 Simplified) | Non-publicly accountable entities electing Tier 2 | Full recognition, reduced disclosure | All 5 statements + reduced notes |
-| Special Purpose (legacy) | Non-reporting entities (winding down) | Flexible | Varies (being phased out by 30 Jun 2023 for large) |
+| Special purpose | Assess the entity and reporting obligation | The AASB 2020-2 changes apply from periods beginning on or after 1 July 2021 to specified for-profit entities | Use australia-financial-statements-2 and current AASB/ASIC requirements |
 | No statutory reporting | Sole traders, small partnerships (non-company) | None mandated | Prepare for ATO/tax purposes only |
 
 ### Large Proprietary Thresholds (must be reporting entity)
@@ -511,17 +513,17 @@ TOTAL EQUITY                                          xxx
 
 ### Superannuation Guarantee
 
-- Rate: 11.5% of ordinary time earnings (from 1 Jul 2025); rising to 12% from 1 Jul 2026
-- Due: 28 days after end of quarter
+- Rate: 12% from 1 July 2025; 11.5% applied in 2024–25. Use the earnings definition, contribution base and deadline for the pay date. From July 2026 use the payday regime in au-super-guarantee; earlier periods retain the quarterly regime. [ATO super guarantee rates](https://www.ato.gov.au/tax-rates-and-codes/key-superannuation-rates-and-thresholds/super-guarantee).
+- Due for 2025–26: quarterly deadlines. Use the separately cited payday rules for earnings paid from 1 July 2026.
 - Nominal: 6110 (expense) / 2110 (payable)
-- SG Charge: if late, lose deduction and pay additional penalties
+- SG Charge for quarters before 1 July 2026: non-deductible. Apply the separate redesigned rules to later earnings.
 
 ### Fringe Benefits Tax (FBT)
 
 - FBT year: 1 April – 31 March
 - Rate: 47% (top marginal + Medicare levy)
 - Common items: car fringe benefit, entertainment, loan fringe benefit
-- Meals/entertainment: 50/50 method available — 50% deductible for income tax, 50% subject to FBT
+- Meals/entertainment: establish whether an available 50/50 valuation election was made and its scope before applying it. Otherwise use the applicable actual-benefit and deduction rules. Do not default every meal to a 50% deduction. [ATO FBT entertainment](https://www.ato.gov.au/law/view/document?docid=SAV/FBTGEMP/00001).
 
 ## Disclaimer
 

--- a/skills/international/australia/australia-gst.md
+++ b/skills/international/australia/australia-gst.md
@@ -1,10 +1,11 @@
 ---
 name: australia-gst
 description: Use this skill whenever asked to prepare, review, or classify transactions for an Australian GST return (Business Activity Statement / BAS) for any client. Trigger on phrases like "prepare BAS", "do the GST", "fill in BAS", "create the return", "GST return", "Activity Statement", or any request involving Australian GST filing. Also trigger when classifying transactions for GST purposes from bank statements, invoices, or other source data. This skill covers Australia only and covers both Simpler BAS and full BAS reporting. GST groups, margin scheme, partial exemption complex, and going concern are all in the refusal catalogue. ALWAYS read this skill before touching any GST-related work.
-version: 2.1
+version: 2.2
 jurisdiction: AU
 tax_year: 2025
-last_updated: 2026-09-02
+tax_year_notes: "2025–26"
+last_updated: 2026-09-10
 review_status: pending_review
 tier: 2
 license: AGPL-3.0-or-later (code) / OpenAccountants Guide License v1.0 (content)
@@ -28,14 +29,14 @@ license: AGPL-3.0-or-later (code) / OpenAccountants Guide License v1.0 (content)
 | Filing portal | ATO Business Portal (https://bp.ato.gov.au) / myGov (https://my.gov.au) |
 | Authority | Australian Taxation Office (ATO) |
 | Currency | AUD only |
-| Filing frequencies | Monthly (turnover > $20M); Quarterly (standard); Annual (voluntary, turnover < $75K) |
-| Deadline | Monthly: 21st of following month; Quarterly: 28th of month after quarter; Annual: 28 February |
-| Registration threshold | AUD $75,000 (general); AUD $150,000 (non-profit); $1 (taxi/rideshare) |
+| Filing frequencies | Monthly (GST turnover >= $20M or another mandatory/elected monthly case); Quarterly (standard); Annual (voluntary, turnover < $75K) |
+| Deadline | Monthly: 21st of following month; Quarterly: 28th after quarter, except December quarter due 28 February; Annual: income-tax-return due date, or 28 February if no income-tax return is required |
+| Registration threshold | AUD $75,000 (general); AUD $150,000 (non-profit); taxi/ride-sourcing registration regardless of turnover |
 | Primary legislation | A New Tax System (Goods and Services Tax) Act 1999 (GST Act) |
 | Supporting legislation | Taxation Administration Act 1953 (Schedule 1); GST Regulations 2019; LCT Act 1999; WET Act 1999 |
 | Contributor | Open Accounting Skills Registry |
 | Validation date | April 2026 |
-| Skill version | 2.0 |
+| Skill version | 2.2 |
 
 **Read this whole section before classifying anything.**
 
@@ -43,7 +44,7 @@ license: AGPL-3.0-or-later (code) / OpenAccountants Guide License v1.0 (content)
 
 | Label | Meaning |
 | --- | --- |
-| G1 | Total sales (GST-exclusive for taxable sales; include GST-free and input taxed) |
+| G1 | Total sales (GST-inclusive basis in this worksheet; include GST-free and input-taxed sales and indicate the basis on the BAS) |
 | G2 | Export sales (GST-free, Division 38-E) |
 | G3 | Other GST-free sales (food, health, education -- Division 38-A to 38-D, 38-F+) |
 | G4 | Input taxed sales (financial supplies, residential rent -- Division 40) |
@@ -63,7 +64,7 @@ license: AGPL-3.0-or-later (code) / OpenAccountants Guide License v1.0 (content)
 | 1B | GST on purchases (input tax credits) |
 
 - **Simpler BAS reporting scope** — Simpler BAS (turnover < $10M, default since 1 July 2017): Report only G1, 1A, 1B. No need for G2-G18.
-- **Full BAS reporting scope** — Full BAS: Report all G labels plus 1A, 1B, and PAYG/FBT labels as applicable.
+- **Full BAS reporting scope:** Complete the labels required by the issued BAS. G4–G9 and G12–G19 are calculation-worksheet items, not a requirement to lodge every G label. Use G1, G2, G3, G10, G11, 1A and 1B where required, plus other tax labels that apply. [ATO GST reporting](https://www.ato.gov.au/businesses-and-organisations/preparing-lodging-and-paying/business-activity-statements-bas/goods-and-services-tax-gst).
 - **GST calculation formulas** — GST = GST-inclusive price x 1/11; GST = GST-exclusive price x 10%; GST-inclusive = GST-exclusive x 1.1; GST-exclusive = GST-inclusive / 1.1
 
 **Conservative defaults -- Australian-specific**
@@ -74,7 +75,7 @@ license: AGPL-3.0-or-later (code) / OpenAccountants Guide License v1.0 (content)
 | Unknown GST status of a purchase | No input tax credit claimed |
 | Unknown business-use proportion (vehicle, phone, home office) | 0% credit |
 | Unknown whether food is basic or prepared | Taxable at 10% (prepared food) |
-| Unknown counterparty registration status | Unregistered (no GST in price, G14) |
+| Unknown counterparty registration status | Verify registration and supply evidence; withhold unsupported credits and keep the treatment pending |
 | Unknown SaaS billing entity location | Non-resident, reverse charge applies |
 | Unknown insurance type (general vs life) | Input taxed (no credit) |
 | Unknown property type (commercial vs residential) | Residential (input taxed, no credit) |
@@ -93,9 +94,9 @@ license: AGPL-3.0-or-later (code) / OpenAccountants Guide License v1.0 (content)
 
 ### Required inputs
 
-Minimum viable -- bank statement for the period in CSV, PDF, or pasted text. Must cover the full BAS period. Acceptable from any Australian business bank: CBA, Westpac, ANZ, NAB, Macquarie, Bendigo, Suncorp, Bank of Queensland, Up Bank, ING, Revolut AU, Wise, or any other. Recommended -- sales invoices for the period (especially for exports and GST-free supplies), purchase invoices for any input tax credit claim above AUD $500, the client's ABN in writing (11 digits), prior period BAS. Ideal -- complete accounting software export (Xero, MYOB, QuickBooks), tax invoice register, prior period BAS with any credit carried forward.
+Minimum viable -- bank statement for the period in CSV, PDF, or pasted text. Must cover the full BAS period. Acceptable from any Australian business bank: CBA, Westpac, ANZ, NAB, Macquarie, Bendigo, Suncorp, Bank of Queensland, Up Bank, ING, Revolut AU, Wise, or any other. Recommended -- sales invoices for the period (especially for exports and GST-free supplies), tax invoices for purchases above $82.50 including GST, unless a lawful exception applies; evidence for all credit claims, the client's ABN in writing (11 digits), prior period BAS. Ideal -- complete accounting software export (Xero, MYOB, QuickBooks), tax invoice register, prior period BAS with any credit carried forward.
 
-SOFT WARN. If no bank statement is available at all, hard stop. If bank statement only without invoices, proceed but record in the reviewer brief: "This BAS was produced from bank statement alone. The reviewer must verify, before lodging, that input tax credit claims above AUD $500 are supported by valid tax invoices and that all GST-free and reverse-charge classifications match the supplier's invoice."
+If source evidence is incomplete, prepare a provisional transaction list. Withhold unsupported credits from the claimable-credit total and identify them separately for review. A tax invoice is generally required before claiming a purchase above $82.50 including GST; the $500 review-priority flag is not an evidence threshold. A bank statement does not itself establish GST or creditable purpose. [GST Act ss 29-10 and 29-80](https://www.ato.gov.au/law/view/document?docid=PAC/19990055/29-10).
 
 ### Australia-specific refusal catalogue
 
@@ -109,7 +110,7 @@ If any trigger fires, stop, output the refusal message verbatim, end the convers
 
 ## Section 3 -- Supplier pattern library (Australian vendors)
 
-This is the deterministic pre-classifier. When a transaction's counterparty matches a pattern in this table, apply the treatment from the table directly. Do not second-guess. Do not consult Tier 1 rules -- the table is authoritative for patterns it covers.
+Use merchant patterns to identify candidate treatments. Confirm the actual supply, supplier registration, invoice GST and creditable purpose before computing a credit. Resolve conflicts in favour of source documents and law. A merchant name alone cannot establish taxability or business use.
 
 **How to read this table.** Match by case-insensitive substring on the counterparty name as it appears in the bank statement. If multiple patterns match, use the most specific. If none match, fall through to Tier 1 rules in Section 5.
 
@@ -160,7 +161,7 @@ This is the deterministic pre-classifier. When a transaction's counterparty matc
 | TPG, TPG TELECOM, VODAFONE AU, IINET | Domestic 10% | G11 | Telecommunications/broadband -- overhead |
 | NBN CO, NBN | Domestic 10% | G11 | National Broadband Network -- overhead |
 | ALINTA ENERGY, RED ENERGY, SIMPLY ENERGY | Domestic 10% | G11 | Electricity, gas -- overhead |
-| SYDNEY WATER, MELBOURNE WATER, SA WATER | Domestic 10% | G11 | Water/sewerage -- overhead (some water supply is GST-free but metered charges are taxable) |
+| SYDNEY WATER, MELBOURNE WATER, SA WATER | GST-free, subject to actual supply | G11 | Piped water and associated metering are generally GST-free; distinguish separate installation/repair services. GST Act ss 38-285 and 38-290; GSTR 2000/25 |
 
 ### 3.4 Australian insurance (mixed treatment)
 
@@ -174,7 +175,7 @@ This is the deterministic pre-classifier. When a transaction's counterparty matc
 | ALLIANZ AUSTRALIA | Domestic 10% | General insurance -- taxable |
 | CGU, ZURICH AUSTRALIA | Domestic 10% | General insurance -- taxable |
 | AMP LIFE, MLC LIFE, TAL LIFE | EXCLUDE | Life insurance -- input taxed, Division 40 |
-| HEALTH INSURANCE, MEDIBANK, BUPA, HCF, NIB | EXCLUDE | Private health insurance -- input taxed financial supply |
+| HEALTH INSURANCE, MEDIBANK, BUPA, HCF, NIB | GST-free; no GST credit | Private health insurance is generally GST-free under s 38-55; check actual policy and private use |
 | WORKCOVER, WORKSAFE, ICARE | Domestic 10% | Workers comp premium is taxable at 10% |
 
 ### 3.5 Australian transport (taxable 10%)
@@ -192,7 +193,7 @@ This is the deterministic pre-classifier. When a transaction's counterparty matc
 | QANTAS, QANTAS AIRWAYS (domestic) | Domestic 10% | G11 | Domestic flights -- taxable at 10% |
 | VIRGIN AUSTRALIA (domestic) | Domestic 10% | G11 | Domestic flights -- taxable |
 | JETSTAR (domestic) | Domestic 10% | G11 | Domestic flights -- taxable |
-| QANTAS (international), VIRGIN (international) | GST-free | G14 | International flights -- GST-free export (Division 38-E). Check ticket destination. |
+| QANTAS (international), VIRGIN (international) | GST-free | G11 | International flights -- GST-free export (Division 38-E). Check ticket destination. |
 | TOLL, LINKT, TRANSURBAN, CITYLINK, EASTLINK | Domestic 10% | G11 | Toll road charges -- taxable |
 
 ### 3.6 Australian food (basic food GST-free, prepared food 10%)
@@ -201,7 +202,7 @@ This is the deterministic pre-classifier. When a transaction's counterparty matc
 
 | Pattern | Treatment | Notes |
 | --- | --- | --- |
-| WOOLWORTHS, WOOLWORTHS METRO | TIER 2 -- split required | Supermarket: basic food items GST-free, non-food/prepared food at 10%. Default: treat as mixed, ask for receipt breakdown. If no receipt: 50% GST-free / 50% taxable conservative split. |
+| WOOLWORTHS, WOOLWORTHS METRO | TIER 2 -- split required | Supermarket: basic food items GST-free, non-food/prepared food at 10%. Default: treat as mixed, ask for receipt breakdown. If evidence is missing, leave any unsupported credit unclaimed pending review; do not invent a 50/50 split. |
 | COLES, COLES EXPRESS | TIER 2 -- split required | Same as Woolworths |
 | IGA, FOODWORKS, ALDI | TIER 2 -- split required | Same -- basic food GST-free, other items 10% |
 | HARRIS FARM, FRUIT MARKET, GREENGROCER | GST-free | Basic food (fruit, vegetables) -- Division 38-A |
@@ -230,19 +231,17 @@ This is the deterministic pre-classifier. When a transaction's counterparty matc
 
 - **Non-resident digital supplies note** — Since 1 July 2017, many non-resident digital suppliers (Netflix, Spotify, Google, etc.) have registered for Australian GST and charge 10% on B2C supplies. For B2B supplies where the recipient provides an ABN, the supplier may not charge GST -- reverse charge may apply on the recipient if the acquisition is not fully creditable. Always check the actual invoice.
 
-### 3.8 Payment processors (financial supply -- input taxed)
+### 3.8 Payment processors (classify the actual service)
 
 **Payment processors table**
 
 | Pattern | Treatment | Notes |
 | --- | --- | --- |
-| STRIPE AU, STRIPE PAYMENTS AUSTRALIA | EXCLUDE for transaction fees | Payment processing fees are financial supply, input taxed. No GST credit. |
-| STRIPE (monthly platform fee) | Check invoice | Platform subscription fee (separate from transaction fees) may be taxable at 10% if invoiced by AU entity. |
-| PAYPAL, PAYPAL AUSTRALIA | EXCLUDE for transaction fees | Financial supply, input taxed |
-| SQUARE AU, SQUARE AUSTRALIA | EXCLUDE for transaction fees | Financial supply, input taxed |
-| TYRO, TYRO PAYMENTS | EXCLUDE for transaction fees | Financial supply, input taxed |
-| AFTERPAY, ZIP PAY, ZIP MONEY | EXCLUDE | BNPL fees -- financial supply, input taxed |
-| EFTPOS, MERCHANT FEE | EXCLUDE | Card processing fee -- financial supply, input taxed |
+| STRIPE AU, STRIPE PAYMENTS AUSTRALIA | Check invoice and service | Merchant payment processing is not automatically input-taxed credit; claim only verified GST for creditable use |
+| PAYPAL, SQUARE AU, TYRO, EFTPOS, MERCHANT FEE | Check invoice and service | Distinguish processing services, cross-border supplies and financial supplies |
+| AFTERPAY, ZIP PAY, ZIP MONEY | Check contract and invoice | Classify merchant services separately from lending and other financial supplies |
+
+[GSTR 2019/2](https://www.ato.gov.au/law/view/document?docid=GST/GSTR20192/NAT/ATO/00001) distinguishes credit supplied to a cardholder from payment services supplied to a merchant.
 
 ### 3.9 Professional services (taxable 10%)
 
@@ -268,8 +267,8 @@ This is the deterministic pre-classifier. When a transaction's counterparty matc
 | RETAIL LEASE, SHOP RENT, INDUSTRIAL RENT | Domestic 10% | Commercial lease -- taxable |
 | RESIDENTIAL RENT, HOME RENT, APARTMENT RENT | EXCLUDE | Residential rent -- input taxed (Division 40). No GST, no credit on related costs. |
 | REAL ESTATE AGENT (rental management fee) | TIER 2 | If managing commercial property: 10% taxable, credit claimable. If managing residential property: 10% taxable, but NO credit (cost relates to input taxed supply). |
-| STRATA, BODY CORPORATE, OWNERS CORP | TIER 2 | Commercial strata levies: 10%, credit claimable. Residential strata: no GST (input taxed). |
-| AIRBNB, STAYZ, BOOKING.COM (income) | Domestic 10% | Short-stay accommodation is commercial, not residential -- taxable at 10% if registered. [T2] if ambiguous duration. |
+| STRATA, BODY CORPORATE, OWNERS CORP | Review supply and registration | G11 | A registered body corporate’s supplies to members can be taxable. Residential accommodation being input taxed does not make the levy automatically input taxed. GSTR 2015/3 |
+| AIRBNB, STAYZ, BOOKING.COM (income) | Review premises and supply | G1 or G4 as applicable | Residential premises may remain input taxed for short stays; commercial residential premises require their own test. GST Act ss 40-35 and 195-1; GSTR 2012/5 |
 
 ### 3.11 Superannuation (not a supply -- exclude)
 
@@ -311,7 +310,7 @@ Google Asia Pacific Pte Ltd is a Singapore entity (non-resident). The client is 
 
 | Date | Counterparty | Gross | Net | GST | Rate | BAS Label | Default? | Question? | Excluded? |
 | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
-| 05.04.2026 | GOOGLE ASIA PACIFIC | -21.60 | -21.60 | 0 | N/A | G14 | N | -- | -- |
+| 05.04.2026 | GOOGLE ASIA PACIFIC | -21.60 | 21.60 | 0 | N/A | G11 | N | -- | -- |
 
 ### Example 2 -- Local utility, standard 10%
 
@@ -319,13 +318,13 @@ Google Asia Pacific Pte Ltd is a Singapore entity (non-resident). The client is 
 `10.04.2026 ; TELSTRA CORP LTD ; DEBIT ; Monthly plan Apr 2026 ; AUD 99.00`
 
 **Reasoning:**
-Telstra is an Australian GST-registered entity (Section 3.3). Telecommunications are taxable at 10%. The $99.00 is GST-inclusive. GST = 99.00 / 11 = $9.00. Net = $90.00. Full input tax credit claimable for business use. If mixed personal/business use, apportion -- but default for a business-only phone line is 100% credit.
+For this example, a valid tax invoice confirms $9 GST in the $99 charge and the evidence establishes wholly creditable business use. Net expense is $90 and the positive credit is $9. If use is mixed, apportion the credit. Without the required invoice, keep it pending.
 
 **Example 2 output**
 
 | Date | Counterparty | Gross | Net | GST | Rate | BAS Label | Default? | Question? | Excluded? |
 | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
-| 10.04.2026 | TELSTRA CORP LTD | -99.00 | -90.00 | -9.00 | 10% | G11 | N | -- | -- |
+| 10.04.2026 | TELSTRA CORP LTD | -99.00 | 90.00 | 9.00 | 10% | G11 | N | -- | -- |
 
 ### Example 3 -- Supermarket purchase (mixed GST-free and taxable)
 
@@ -339,7 +338,7 @@ Woolworths sells a mix of basic food (GST-free under Division 38-A) and taxable 
 
 | Date | Counterparty | Gross | Net | GST | Rate | BAS Label | Default? | Question? | Excluded? |
 | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
-| 12.04.2026 | WOOLWORTHS 1234 | -87.50 | -87.50 | 0 | -- | G14 | Y | Q1 | "Supermarket: provide receipt to split GST-free food vs taxable items" |
+| 12.04.2026 | WOOLWORTHS 1234 | -87.50 | 87.50 pending | 0 | -- | G11 | Y | Q1 | "Supermarket: provide receipt to split GST-free food vs taxable items" |
 
 ### Example 4 -- Bank fee (input taxed financial supply)
 
@@ -347,13 +346,13 @@ Woolworths sells a mix of basic food (GST-free under Division 38-A) and taxable 
 `15.04.2026 ; CBA ACCOUNT FEE ; DEBIT ; Monthly account keeping fee ; AUD 10.00`
 
 **Reasoning:**
-CBA bank fees are a financial supply under Division 40. Financial supplies are input taxed -- no GST is charged, and no input tax credit is available. Exclude from BAS input claims entirely. Note: some bank "account-keeping fees" may technically include a taxable component if the bank issues a tax invoice showing GST -- but the default for bank charges is input taxed / excluded unless the tax invoice explicitly shows GST.
+In this example, the statement and fee terms establish an input-taxed account-keeping service. Record the $10 business purchase at G11 with zero GST credit. Classify other bank services from their actual terms and invoice; the bank name alone does not settle GST.
 
 **Example 4 output**
 
 | Date | Counterparty | Gross | Net | GST | Rate | BAS Label | Default? | Question? | Excluded? |
 | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
-| 15.04.2026 | CBA ACCOUNT FEE | -10.00 | -- | -- | -- | -- | N | -- | "Input taxed financial supply" |
+| 15.04.2026 | CBA ACCOUNT FEE | -10.00 | 10.00 | 0 | -- | G11 | N | -- | "Input taxed financial supply" |
 
 ### Example 5 -- Export service sale (GST-free)
 
@@ -367,21 +366,17 @@ Incoming payment from a New Zealand company for IT consulting services. Services
 
 | Date | Counterparty | Gross | Net | GST | Rate | BAS Label | Default? | Question? | Excluded? |
 | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
-| 20.04.2026 | ACME CORP NZ | +8,500.00 | +8,500.00 | 0 | 0% | G1, G2 | Y | Q2 (HIGH) | "Verify NZ recipient and offshore consumption" |
+| 20.04.2026 | ACME CORP NZ | +8,500.00 | +8,500.00 | 0 | 0% | G2 | Y | Q2 (HIGH) | "Verify NZ recipient and offshore consumption" |
 
-### Example 6 -- Stripe transaction fee (financial supply)
+### Example 6 -- Merchant transaction fee
 
-**Input line:**
-`25.04.2026 ; STRIPE PAYMENTS AU ; DEBIT ; Transaction fees April ; AUD 145.20`
+Input: `25.04.2026 ; STRIPE PAYMENTS AU ; DEBIT ; Transaction fees April ; AUD 145.20`.
 
-**Reasoning:**
-Stripe payment processing fees are a financial supply (payment facilitation). Financial supplies are input taxed under Division 40. No GST credit claimable on transaction fees. Exclude. Note: Stripe's monthly platform subscription fee (if billed separately by an Australian entity with a tax invoice showing GST) IS taxable at 10% and credit IS claimable -- but the transaction processing fees themselves are a financial supply.
+The name does not settle the GST treatment. In this example a valid Australian tax invoice establishes a taxable processing service with $13.20 GST, wholly for creditable business use. The cash debit is $145.20, net expense $132.00 and positive GST credit $13.20. If that evidence is absent, show a pending treatment and no verified credit until resolved. A supply of credit or a different cross-border arrangement may have a different result. [GSTR 2019/2](https://www.ato.gov.au/law/view/document?docid=GST/GSTR20192/NAT/ATO/00001).
 
-**Example 6 output**
-
-| Date | Counterparty | Gross | Net | GST | Rate | BAS Label | Default? | Question? | Excluded? |
-| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
-| 25.04.2026 | STRIPE PAYMENTS AU | -145.20 | -- | -- | -- | -- | N | -- | "Financial supply, input taxed" |
+| Date | Counterparty | Bank amount | Net expense | GST credit | Label | Evidence |
+| --- | --- | --- | --- | --- | --- | --- |
+| 25.04.2026 | STRIPE PAYMENTS AU | -145.20 | 132.00 | 13.20 | G11 | Valid tax invoice and wholly creditable use |
 
 ## Section 5 -- Tier 1 classification rules
 
@@ -423,7 +418,7 @@ Each rule states the legal source and the BAS label mapping. Apply silently if t
 | Baby food, infant formula | GST-free | Basic food |
 | Bottled water (plain) | GST-free | Basic food |
 | Tea, coffee (unbrewed) | GST-free | Basic food |
-| Plain biscuits (not chocolate) | GST-free | Basic food |
+| Ordinary plain biscuits (not chocolate) | Taxable 10% | GST Act Schedule 1 item 32; specified breakfast-cereal biscuits and infant/invalid rusks have exceptions |
 | Raw, unprocessed nuts | GST-free | Basic food |
 | Confectionery (chocolate, lollies) | Taxable 10% | Schedule 1 exclusion |
 | Soft drinks, energy drinks | Taxable 10% | Schedule 1 exclusion |
@@ -457,7 +452,7 @@ Each rule states the legal source and the BAS label mapping. Apply silently if t
 | Sale of existing residential premises | Input taxed |
 | Sale of NEW residential premises | Taxable 10% (first sale after construction/substantial renovation) |
 | Commercial rent (office, retail, warehouse) | Taxable 10% |
-| Short-stay accommodation (hotel, Airbnb <3 months) | Taxable 10% (commercial, not residential) [T2 if ambiguous] |
+| Short-stay accommodation | Classify the premises and supply | Hotels may be commercial residential premises; an ordinary residential Airbnb stay does not become taxable because it lasts under three months |
 
 ### 5.4 Out-of-scope transactions (not on BAS)
 
@@ -480,7 +475,7 @@ Each rule states the legal source and the BAS label mapping. Apply silently if t
 
 ### 5.6 Input tax credit entitlement (Division 11)
 
-- **Entitlement conditions** — A registered entity is entitled to an input tax credit if ALL conditions are met (s 11-5): 1. Acquisition is for a creditable purpose (related to taxable or GST-free supplies); 2. Supply was a taxable supply (GST in the price); 3. Entity provides consideration; 4. Entity is registered for GST; AND 5. Entity holds a valid tax invoice (or can obtain one within 4 years).  _(s 11-5)_
+- **Entitlement conditions:** Establish the s 11-5 creditable acquisition conditions, including taxable supply, consideration, registration and creditable purpose. Apply the attribution rules: generally hold a valid tax invoice before claiming, subject to the $82.50 including-GST exception and other lawful exceptions/discretion. The four-year claim limit is not permission to claim before obtaining required evidence. [GST Act ss 11-5, 29-10, 29-80 and 93-5](https://www.ato.gov.au/law/view/document?docid=PAC/19990055/29-10).
 - **Blocked credits** — No credit for acquisitions relating to input taxed supplies (s 11-15), private/domestic use (s 11-15), entertainment where FBT exempt (s 69-5), non-deductible fines/penalties (s 69-5).  _(s 11-15, s 69-5)_
 - **Car limit** — Input tax credit for a car is capped at car limit / 11. For 2024-25 and 2025-26: $69,674 / 11 = ~$6,334 maximum credit; for 2026-27: $69,883 / 11 = ~$6,353. No outright block on cars (unlike Malta).  _(s 69-10)_
 
@@ -497,7 +492,7 @@ Each rule states the legal source and the BAS label mapping. Apply silently if t
 | GST amount (or "price includes GST") | Yes | Yes |
 | Recipient identity (name, ABN) | No | Yes |
 
-- **No ABN withholding** — If supplier does not quote ABN, payer must withhold 47% (top marginal + Medicare levy). Reported at BAS label W3. Exceptions for supplies < $75 (excl GST).  _(TAA Schedule 1)_
+- **No ABN withholding:** Where required, withhold 47% and report at W4, subject to the entity’s withholding reporting class. Apply exceptions, including payments of $75 or less excluding GST and valid supplier statements where relevant. [ATO PAYG withholding](https://www.ato.gov.au/businesses-and-organisations/preparing-lodging-and-paying/business-activity-statements-bas/pay-as-you-go-payg-withholding).
 
 ## Section 6 -- Tier 2 catalogue
 
@@ -513,7 +508,7 @@ Pattern: Origin Energy, AGL, Telstra on a residential address; home internet. Wh
 
 ### 6.3 Food purchases (Woolworths -- basic food GST-free or prepared?)
 
-Pattern: Woolworths, Coles, IGA, Aldi, any supermarket. Why insufficient: a single supermarket receipt may contain GST-free basic food and taxable prepared food, confectionery, soft drinks, and non-food items. The receipt total alone cannot determine the split. Default: no credit claimed (treat as no GST in price, G14). Question: "Could you provide the receipt? I need to split GST-free food items from taxable items to claim the correct credit."
+Pattern: Woolworths, Coles, IGA, Aldi, any supermarket. Why insufficient: a single supermarket receipt may contain GST-free basic food and taxable prepared food, confectionery, soft drinks, and non-food items. The receipt total alone cannot determine the split. Default: no credit claimed (pending evidence; G11 purchase with no verified credit). Question: "Could you provide the receipt? I need to split GST-free food items from taxable items to claim the correct credit."
 
 ### 6.4 Cash withdrawals
 
@@ -521,7 +516,7 @@ Pattern: ATM, cash withdrawal, CBA cash, Westpac cash. Why insufficient: unknown
 
 ### 6.5 Insurance (some taxable, some input taxed -- which policy?)
 
-Pattern: insurance premium, policy payment, Suncorp, QBE, AMP. Why insufficient: general insurance (business, motor, property) is taxable at 10% with GST credit. Life insurance and private health insurance are input taxed (no credit). The bank statement description rarely identifies the policy type. Default: input taxed, no credit (conservative). Question: "Is this general insurance (business/property/vehicle), life insurance, or health insurance? General insurance has GST; life and health do not."
+Pattern: insurance premium or policy payment. Identify the policy and the invoice components. General insurance can contain GST, stamp duty and other amounts; use the actual GST component. Life insurance is generally input taxed; private health insurance is generally GST-free. Pending identification, show no verified credit. GST Act ss 38-55 and 40-5.
 
 ### 6.6 Mixed personal/business subscriptions
 
@@ -529,31 +524,50 @@ Pattern: Netflix, Spotify, Apple, Amazon Prime, gym membership. Why insufficient
 
 ### 6.7 Airbnb income (short-stay accommodation -- residential or commercial?)
 
-Pattern: Airbnb payouts, Stayz payouts, short-term rental income. Why insufficient: short-stay accommodation (typically under 3 months) is treated as commercial accommodation, taxable at 10%. Long-term residential rental (over 3 months) is input taxed. The bank statement shows only an Airbnb payout amount. Also: if total Airbnb turnover is below $75,000, the host may not be required to register for GST. Default: [T2] flag for reviewer. Question: "Is this short-term rental (under 3 months per guest)? What is your total annual Airbnb income? Are you GST-registered for this activity?"
+Pattern: Airbnb or Stayz income. Determine whether the supply is residential premises or commercial residential accommodation from the premises and arrangement, not the booking channel or a three-month threshold. Check registration, taxable turnover and any platform fee separately. An ordinary residential letting is generally input taxed. GST Act ss 40-35 and 195-1; GSTR 2012/5.
 
 ### Sheet "Transactions"
 
 Columns:
-- A: Date
-- B: Counterparty (as per bank statement)
-- C: Type (DEBIT/CREDIT)
-- D: Description
-- E: Gross amount (AUD, from bank statement -- blue font, hardcoded)
-- F: Net amount (formula: if taxable, = E / 1.1; if GST-free or excluded, = E)
-- G: GST amount (formula: if taxable, = E / 11; if GST-free or excluded, = 0)
-- H: BAS label code (G1, G2, G3, G4, G10, G11, G13, G14, G15, or blank for excluded)
-- I: Default applied? (Y/N)
-- J: Question for client (text, or blank)
-- K: Excluded? (text reason, or blank)
-- L: Notes
+- A–D: Date, counterparty, bank direction and description.
+- E: Signed bank amount in AUD, retained unchanged for bank reconciliation.
+- F: Net amount for accounting, based on the invoice and verified GST component.
+- G: GST liability for a sale or verified GST credit for a purchase. Use positive amounts for ordinary transactions and negative amounts for supported reversals. For a wholly taxable GST-inclusive amount, G = M * ABS(E)/11, multiplied by the creditable-use proportion for a purchase. For mixed or specially valued supplies, use the invoice’s actual GST component with the reporting sign and creditable proportion instead. GST-free/input-taxed supplies and unsupported credits contribute zero. Record any pending credit in notes.
+- H: One primary category: G1 for taxable sales, G2 for export sales, G3 for other GST-free sales, G4 for input-taxed sales, G10 for capital purchases, G11 for non-capital purchases, or EXCLUDED. Split genuinely mixed transactions into supported components without duplicating the bank amount.
+- I–L: Provisional flag, question, exclusion reason and notes/evidence.
+- M: Reporting sign, 1 for ordinary sales/purchases and -1 for a supported refund or reversal. Infer this from the transaction, not bank direction alone.
+- N: GST-inclusive reporting amount = ABS(E) * M. This is positive for ordinary purchases despite the negative bank debit.
+
+For H, use the primary categories above. Earlier G13/G14/G15 references describe calculation-worksheet exclusions and must not replace a G10/G11 purchase category. Keep the exclusion and creditability evidence in I–L. Retain the signed bank amount separately from positive reporting amounts.
 
 ### Sheet "BAS Summary" (Full BAS)
 
-One row per BAS label. Column A is the label, column B is the description, column C is the value computed via formula. ``` Sales: | G1  | Total sales                    | =SUMIFS(Transactions!F:F, Transactions!C:C, "CREDIT") | | G2  | Export sales                   | =SUMIFS(Transactions!F:F, Transactions!H:H, "G2") | | G3  | Other GST-free sales           | =SUMIFS(Transactions!F:F, Transactions!H:H, "G3") | | G4  | Input taxed sales              | =SUMIFS(Transactions!F:F, Transactions!H:H, "G4") | | G5  | GST-free + input taxed (derived)| =G2+G3+G4 | | G6  | Taxable sales (derived)        | =G1-G5 | Purchases: | G10 | Capital purchases              | =SUMIFS(Transactions!E:E, Transactions!H:H, "G10") | | G11 | Non-capital purchases          | =SUMIFS(Transactions!E:E, Transactions!H:H, "G11") | | G12 | Total purchases (derived)      | =G10+G11 | | G13 | Purchases for input taxed      | =SUMIFS(Transactions!E:E, Transactions!H:H, "G13") | | G14 | Purchases with no GST          | =SUMIFS(Transactions!E:E, Transactions!H:H, "G14") | | G15 | Private use purchases          | =SUMIFS(Transactions!E:E, Transactions!H:H, "G15") | | G16 | Non-creditable (derived)       | =G13+G14+G15 | | G17 | Creditable purchases (derived) | =G12-G16 | Tax: | 1A  | GST on sales                   | =G6/11 | | 1B  | GST on purchases               | =G17/11 | Net: | GST payable / (refundable)      | =1A-1B | ```
+Use GST-inclusive reporting amounts consistently. Populate named cells with:
+
+| Label | Formula / rule |
+| --- | --- |
+| G1 | Sum N for H equal to G1, G2, G3 or G4; exclude loans, transfers and other EXCLUDED credits |
+| G2, G3 | Sum N for the corresponding H category |
+| G10, G11 | Sum N for the corresponding purchase category, including purchases without credits where required by the BAS instructions |
+| 1A | Sum G for sales categories, plus supported GST adjustments |
+| 1B | Sum G for G10 and G11, plus supported credit adjustments |
+| Net GST | 1A - 1B |
+
+For example, G10 = SUMIFS(Transactions!N:N,Transactions!H:H,"G10"). G1 combines four such SUMIFS for its sales categories. 1B sums the verified credits in G for G10 and G11. Do not subtract non-creditable purchases again from a total of credits. G4–G9 and G12–G19 may support a separate calculation worksheet but are not all lodged BAS labels.
 
 ### Sheet "Simpler BAS"
 
-For Simpler BAS clients (turnover < $10M), only three fields: ``` | G1  | Total sales    | =SUMIFS(Transactions!F:F, Transactions!C:C, "CREDIT") | | 1A  | GST on sales   | =SUM of GST from taxable sales transactions | | 1B  | GST on purchases | =SUM of GST from creditable purchase transactions | | Net | GST payable / (refundable) | =1A-1B | ```
+For eligible businesses with GST turnover below $10 million, report G1, 1A and 1B using the same definitions and formulas; complete any other tax obligations on the issued statement. Confirm the G1 GST-inclusive indicator.
+
+### Worksheet checks
+
+- A taxable sale of $1,100 gives G1 $1,100 and 1A $100.
+- A wholly creditable taxable purchase of $110 gives 1B $10 even though the bank amount is -$110. Together with the sale, net GST is $90.
+- A $110 purchase with 50% creditable use gives a $5 credit if all other requirements are met. Do not exclude its private portion twice.
+- A $1,000 loan deposit contributes zero to G1 and 1A. A supported $110 sales refund reduces reported sales by $110 and output GST by $10.
+- GST-free purchases contribute no GST credit; unsupported acquisitions remain pending until entitlement and evidence are established.
+
+[ATO GST reporting](https://www.ato.gov.au/businesses-and-organisations/preparing-lodging-and-paying/business-activity-statements-bas/goods-and-services-tax-gst); GST Act ss 9-70, 11-20 and 29-10.
 
 ### Color and formatting conventions
 
@@ -591,7 +605,7 @@ Inference rule: sole trader names match account holder; company names end in "Pt
 
 ### 9.2 GST registration status
 
-Inference rule: if asking for a BAS, they are registered. If turnover clearly below $75,000, may be voluntary. Fallback question: "Are you registered for GST? If so, since what date?"
+Verify GST registration and its effective date on the ABR, supported by the ATO account. A request for a BAS does not establish registration. Check PAYG activity statements separately.
 
 ### 9.3 ABN
 
@@ -636,13 +650,13 @@ Inference rule: foreign currency credits, overseas counterparty names. Fallback 
 | Q3 | 1 January -- 31 March | 28 April |
 | Q4 | 1 April -- 30 June | 28 July |
 
-- **Other deadline notes** — Monthly: 21st of the following month. Annual: 28 February following financial year (FY ends 30 June). If due date falls on weekend/public holiday, next business day.
+- **Other deadline notes:** Monthly GST is generally due on the 21st of the next month. Annual GST is generally due with the income-tax return, or 28 February after the year where no return is required. Check the actual statement, extensions and next-business-day rule. [ATO annual GST](https://www.ato.gov.au/businesses-and-organisations/gst-excise-and-indirect-taxes/gst/lodging-your-bas-or-annual-gst-return).
 
 ### Penalties
 
-- **Failure to lodge (FTL)** — 1 penalty unit per 28-day period for small entities (turnover < $1M), up to 5 periods. Penalty unit: $330 (2024-25, indexed annually).
-- **General Interest Charge (GIC)** — 90-day Bank Accepted Bill rate + 7% per annum. Calculated daily, compounded. Tax deductible.
-- **Shortfall penalties** — Reasonable care not taken: 25%. Recklessness: 50%. Intentional disregard: 75%. Reduced 20% for voluntary disclosure before audit.
+- **Failure to lodge (FTL):** The base penalty is one unit per 28-day period or part, capped at five units. Apply the relevant entity multipliers, dates and remission rules. The penalty unit is $364 from 1 July 2026. [Crimes (Amount of a Penalty Unit) Instrument 2026](https://www.legislation.gov.au/F2026N00424/asmade/text).
+- **General Interest Charge (GIC):** Use the published quarterly ATO rate and applicable daily compounding. GIC and SIC incurred on or after 1 July 2025 are not deductible; preserve the earlier rule only for earlier-incurred interest. [ATO interest](https://www.ato.gov.au/individuals-and-families/income-deductions-offsets-and-records/deductions-you-can-claim/cost-of-managing-tax-affairs/interest-charged-by-the-ato).
+- **Shortfall penalties:** Base rates can be 25%, 50% or 75% according to the conduct. A qualifying pre-notification voluntary disclosure generally reduces the penalty by 80% where the shortfall is at least $1,000 and 100% below that amount. The qualifying post-notification reduction is 20%. Apply the statutory conditions and any other adjustments. [TAA Schedule 1 s 284-225](https://www.ato.gov.au/law/view/document?docid=PAC/19530001/SCH1-284-225).
 
 ### Registration thresholds
 
@@ -652,7 +666,7 @@ Inference rule: foreign currency credits, overseas counterparty names. Fallback 
 | --- | --- | --- |
 | General business | $75,000/year | GST Act, s 23-5 |
 | Non-profit | $150,000/year | GST Act, s 23-5 |
-| Taxi/rideshare | $1 (must register) | GST Act, s 144-5 |
+| Taxi/rideshare | Registration regardless of turnover | GST Act, s 144-5 |
 | Non-resident digital supplier (B2C) | $75,000 Australian turnover | Division 83-5 |
 
 - **GST turnover composition** — GST turnover includes taxable + GST-free supplies. Excludes input taxed, not connected with Australia, capital asset sales (unless regularly dealing).
@@ -663,8 +677,8 @@ Inference rule: foreign currency credits, overseas counterparty names. Fallback 
 
 | Feature | Cash | Accrual |
 | --- | --- | --- |
-| GST on sales reported | When payment received | When invoice issued |
-| Input credits claimed | When payment made | When invoice received |
+| GST on sales reported | To the extent payment is received | Generally the earlier of any consideration or an invoice, subject to special rules |
+| Input credits claimed | To the extent payment is made, with required evidence | Generally the earlier of any consideration or an invoice, with required evidence and applicable attribution rules |
 | Who can use | Turnover < $2M (or $10M SBE) | Anyone |
 
 ### Key thresholds summary
@@ -679,8 +693,8 @@ Inference rule: foreign currency credits, overseas counterparty names. Fallback 
 | Car limit (2024-25) | $69,674 | s 69-10 |
 | LCT threshold (2025-26, general / other vehicles) | $80,567 | LCT Act / ATO car thresholds |
 | LCT threshold (2024-25, fuel-efficient) | $91,387 | LCT Act |
-| No ABN withholding exemption | Supplies < $75 excl GST | TAA Schedule 1 |
-| Monthly reporting | Turnover > $20M | TAA Schedule 1, s 31-5 |
+| No ABN withholding exemption | Payments of $75 or less excluding GST, subject to applicable rules | TAA Schedule 1 |
+| Monthly reporting | GST turnover >= $20M or another mandatory/elected monthly case | GST Act Division 27 |
 | Tax invoice -- simplified | Supplies < $1,000 | s 29-70 |
 
 ### Comparison with EU VAT (for practitioners familiar with EU systems)
@@ -730,7 +744,7 @@ This skill is v2.0, rewritten in April 2026 to align with the Malta v2.0 structu
 - **v2.0 (April 2026):** Full rewrite to align with Malta v2.0 structure. Ten sections: quick reference (1), inputs and refusals (2), supplier pattern library with 12 sub-tables (3), six worked examples from CBA NetBank format (4), Tier 1 rules compressed (5), Tier 2 catalogue with 7 items (6), Excel template (7), bank statement reading guide (8), onboarding fallback with inference rules (9), reference material (10). Five Australia-specific refusals (R-AU-1 through R-AU-5).
 - **v1.1 (April 2026):** Monolithic skill with classification rules, BAS labels, reverse charge, thresholds, edge cases, and test suite. Comprehensive but not aligned with v2.0 architecture.
 
-### Self-check (v2.0)
+### Self-check (v2.2)
 
 1. Quick reference at top with BAS label table and conservative defaults: yes (Section 1).
 2. Supplier library as literal lookup tables: yes (Section 3, 12 sub-tables).
@@ -748,7 +762,7 @@ This skill is v2.0, rewritten in April 2026 to align with the Malta v2.0 structu
 14. Payment processor fees as financial supply explicit: yes (Section 3.8 + Example 6).
 15. Supermarket split (GST-free food vs taxable items) explicit: yes (Section 3.6 + Example 3).
 
-## End of Australia GST Return Preparation Skill v2.0
+## End of Australia GST Return Preparation Skill v2.2
 
 ## Disclaimer
 

--- a/skills/international/australia/australia-payroll.md
+++ b/skills/international/australia/australia-payroll.md
@@ -11,23 +11,24 @@ description: >
   "activity statement", "annual leave", "long service leave",
   "minimum wage Australia", or any question about running payroll in Australia.
   ALWAYS read this skill before processing any Australian payroll work.
-version: 2.1
+version: 2.3
 jurisdiction: AU
-tax_year: 2025
-last_updated: 2026-09-02
+tax_year: 2026
+tax_year_notes: "2026–27"
+last_updated: 2026-09-10
 review_status: pending_review
 category: payroll
 tier: 2
 license: AGPL-3.0-or-later (code) / OpenAccountants Guide License v1.0 (content)
 ---
 
-# Australia -- Payroll Skill v2.2
+# Australia -- Payroll Skill v2.3
 
-## Australia -- Payroll Skill v2.2
+## Australia -- Payroll Skill v2.3
 
-## Australia -- Payroll Skill v2.2
+## Australia -- Payroll Skill v2.3
 
-## Australia -- Payroll Skill v2.2
+## Australia -- Payroll Skill v2.3
 
 ## Section 1 -- Quick Reference
 
@@ -45,7 +46,7 @@ license: AGPL-3.0-or-later (code) / OpenAccountants Guide License v1.0 (content)
 | Pay frequency | Weekly, fortnightly, monthly (fortnightly most common) |
 | Employer registration | ABN + PAYG withholding registration via ATO |
 | Validated by | Pending -- requires sign-off by an Australian CPA, CA, or registered tax agent |
-| Skill version | 2.2 |
+| Skill version | 2.3 |
 
 ## Section 2 -- Income Tax Withholding (PAYG)
 
@@ -53,7 +54,7 @@ PAYG withholding is calculated per pay period using ATO tax tables (Schedule 1 -
 
 ### Resident Individual Tax Rates (2026--27)
 
-**Resident Individual Tax Rates (2025--26)**
+**Resident Individual Tax Rates (2026--27)**
 
 | Taxable Income (AUD) | Rate | Tax on This Income |
 | --- | --- | --- |
@@ -97,17 +98,41 @@ Australia does not have a separate employee social security contribution. The Me
 | Deduction | Rate | Ceiling | Notes |
 | --- | --- | --- | --- |
 | PAYG income tax | Progressive (see above) | No ceiling | Includes Medicare levy in tax tables |
-| STSL repayment | 1%--10% (income-based) | No ceiling | Only if employee has HELP/STSL debt |
+| STSL repayment | Current marginal repayment and pay-period withholding tables | Check year and income measure | Only for relevant study/training loan debts |
 | Salary sacrifice (super) | Voluntary | Concessional cap $32,500/year (2026-27) | Pre-tax; reduces PAYG withholding base |
 
 There is no employee-paid social insurance premium equivalent to NIC (UK) or social security tax (US).
 
+## Section 4 -- Employer contributions
+
 **Superannuation Guarantee summary**
+
+| Item | Detail |
+| --- | --- |
+| Payment deadline (earnings paid from 1 Jul 2026) | Received by the employee's fund within **7 business days of each payday** (clearing house receipt does not count) |
+| New employee / new fund | 20 business days for the first contribution |
+
+- **Deadline exceptions**: new employee / new fund -- 20 business days for the first contribution; out-of-cycle payments (bonuses) ride with the next regular payday's deadline; ATO exceptional-circumstances determinations -- 20 business days.
+- **Legacy**: quarterly due dates (28 Oct/28 Jan/28 Apr/28 Jul) apply only to earnings paid up to 30 June 2026; the final quarterly deadline was 28 July 2026. The ATO Small Business Super Clearing House closed permanently on 1 July 2026 -- small employers now use payroll-software super payments or commercial clearing houses.
+- **Final scheduled SG rate**: 12% is the final scheduled SG rate (reached 1 July 2025). No further increases are scheduled.
+
+### Superannuation Guarantee Charge (SGC) -- redesigned from 1 July 2026
+
+- **SGC redesign components**: For earnings paid from 1 July 2026, SGC is **ATO-assessed per payday** (no SGC statement is lodged; the ATO matches STP data against fund reporting). Components: - The final SG shortfall (12% of qualifying earnings unpaid) - Notional earnings (GIC-rate interest, compounding daily from the day after the deadline) - An administrative uplift (starts at 60% of shortfall + notional earnings; reduced for clean history and voluntary disclosure, to 0% if disclosed within 30 days with a clean 2-year record) - Choice loading (25%, capped at $1,200 per notice period) where choice-of-fund rules were breached  _(PCG 2026/1)_
+- **SGC deductibility and penalties**: The redesigned SGC **is tax-deductible** (GIC on late SGC and the late payment penalty are not). Old-regime SGC for quarters before 1 July 2026 remains non-deductible. Unpaid SGC 28 days after assessment triggers a Notice to Pay, then a 25% or 50% late payment penalty. First-year ATO approach: PCG 2026/1.  _(PCG 2026/1)_
+
+### Workers' Compensation Insurance
+
+- **Workers' compensation insurance**: Mandatory in all states/territories. Premium rates vary by industry, state, and claims history. Typically 1%--5% of wages for office-based roles.
+
+### Payroll Tax (State/Territory)
+
+**Payroll Tax (State/Territory)**
 
 | State/Territory | Threshold (Annual) | Rate |
 | --- | --- | --- |
-| NSW | $1,200,000 | 4.85% |
-| VIC | $900,000 | 4.85% |
+| NSW | $1,200,000 | 5.45% |
+| VIC | $1,000,000 maximum annual deduction | 4.85%; regional rate, phase-out and surcharges can apply |
 | QLD | $1,300,000 | 4.75% |
 | WA | $1,000,000 | 5.50% |
 | SA | $1,500,000 | Varies (0%--4.95%) |
@@ -115,36 +140,25 @@ There is no employee-paid social insurance premium equivalent to NIC (UK) or soc
 | ACT | $2,000,000 | 6.85% |
 | NT | $1,500,000 | 5.50% |
 
-- **Deadline exceptions** — new employee / new fund -- 20 business days for the first contribution; out-of-cycle payments (bonuses) ride with the next regular payday's deadline; ATO exceptional-circumstances determinations -- 20 business days.
-- **Legacy** — quarterly due dates (28 Oct/28 Jan/28 Apr/28 Jul) apply only to earnings paid up to 30 June 2026; the final quarterly deadline was 28 July 2026. The ATO Small Business Super Clearing House closed permanently on 1 July 2026 -- small employers now use payroll-software super payments or commercial clearing houses.
-- **Final scheduled SG rate** — 12% is the final scheduled SG rate (reached 1 July 2025). No further increases are planned. %
-
-### Superannuation Guarantee Charge (SGC) -- redesigned from 1 July 2026
-
-- **SGC redesign components** — For earnings paid from 1 July 2026, SGC is **ATO-assessed per payday** (no SGC statement is lodged; the ATO matches STP data against fund reporting). Components: - The final SG shortfall (12% of qualifying earnings unpaid) - Notional earnings (GIC-rate interest, compounding daily from the day after the deadline) - An administrative uplift (starts at 60% of shortfall + notional earnings; reduced for clean history and voluntary disclosure, to 0% if disclosed within 30 days with a clean 2-year record) - Choice loading (25%, capped at $1,200 per notice period) where choice-of-fund rules were breached  _(PCG 2026/1)_
-- **SGC deductibility and penalties** — The redesigned SGC **is tax-deductible** (GIC on late SGC and the late payment penalty are not). Old-regime SGC for quarters before 1 July 2026 remains non-deductible. Unpaid SGC 28 days after assessment triggers a Notice to Pay, then a 25% or 50% late payment penalty. First-year ATO approach: PCG 2026/1.  _(PCG 2026/1)_
-
-### Workers' Compensation Insurance
-
-- **Workers' compensation insurance** — Mandatory in all states/territories. Premium rates vary by industry, state, and claims history. Typically 1%--5% of wages for office-based roles.
-
-### Payroll Tax (State/Territory)
-
-**Payroll Tax (State/Territory)**
-
-| Category | Rate |
-| --- | --- |
-| Adult (full-time, 38 hrs/week) | $24.95/hour ($948.10/week) |
-| Junior rates | Percentage of adult rate by age (under awards) |
-| Casual loading | 25% on top of base rate (in lieu of leave entitlements) |
-
-- **Payroll tax nature** — Payroll tax is a state/territory tax on total Australian wages above the threshold. Interstate employers must register in each jurisdiction where they have employees.
+- **Payroll tax nature**: Payroll tax is a state/territory tax on total Australian wages above the threshold. Interstate employers must register in each jurisdiction where they have employees.
 
 ## Section 5 -- Minimum Wage and Overtime
 
-### National Minimum Wage (from 1 July 2025)
+### National Minimum Wage (from the first full pay period on or after 1 July 2026)
 
-**National Minimum Wage (from 1 July 2025)**
+**National Minimum Wage (from the first full pay period on or after 1 July 2026)**
+
+| Category | Rate |
+| --- | --- |
+| Adult (full-time, 38 hrs/week) | $26.44/hour ($1,004.90/week) |
+| Junior rates | Percentage of adult rate by age (under awards) |
+| Casual loading | 25% on top of base rate (in lieu of leave entitlements) |
+
+- **Modern award coverage**: Most employees are covered by a modern award, which sets higher minimum rates by classification level.
+
+### Overtime (Under Awards)
+
+**Overtime (Under Awards)**
 
 | Period | Typical Award Rate |
 | --- | --- |
@@ -153,44 +167,46 @@ There is no employee-paid social insurance premium equivalent to NIC (UK) or soc
 | Sunday work | 200% |
 | Public holiday work | 250% |
 
-- **Modern award coverage** — Most employees are covered by a modern award, which sets higher minimum rates by classification level.
-
-### Overtime (Under Awards)
-
-**Overtime (Under Awards)**
-
-| Type | Duration | Payment |
-| --- | --- | --- |
-| Government Paid Parental Leave | Up to 22 weeks (increasing to 26 weeks by Jul 2026) | National minimum wage rate |
-| Unpaid parental leave | Up to 12 months (can request additional 12 months) | Nil (job-protected) |
-
-- **Overtime rate variability** — Exact rates depend on the applicable modern award or enterprise agreement. The Fair Work Act does not prescribe a single universal overtime rate.  _(Fair Work Act)_
+- **Overtime rate variability**: Exact rates depend on the applicable modern award or enterprise agreement. The Fair Work Act does not prescribe a single universal overtime rate.  _(Fair Work Act)_
 
 ### Maximum Ordinary Hours
 
-- **Maximum ordinary hours** — 38 hours/week under the NES. Can be averaged over up to 26 weeks if permitted by the award or agreement.  _(NES)_
+- **Maximum ordinary hours**: 38 hours/week under the NES. Can be averaged over up to 26 weeks if permitted by the award or agreement.  _(NES)_
 
 ## Section 6 -- Mandatory Benefits
 
 ### Annual Leave
 
-- **Annual leave entitlement** — 4 weeks per year (pro-rata for part-time). Accrues progressively. Shift workers may receive 5 weeks. 17.5% annual leave loading is common under awards (paid on top of base rate when leave is taken).
+- **Annual leave entitlement**: 4 weeks per year (pro-rata for part-time). Accrues progressively. Shift workers may receive 5 weeks. 17.5% annual leave loading is common under awards (paid on top of base rate when leave is taken).
 
 ### Personal / Carer's Leave (Sick Leave)
 
-- **Personal/Carer's leave entitlement** — 10 days per year for full-time employees (pro-rata for part-time). Accumulates year to year with no cap. Paid at the base rate of pay.
+- **Personal/Carer's leave entitlement**: 10 days per year for full-time employees (pro-rata for part-time). Accumulates year to year with no cap. Paid at the base rate of pay.
 
 ### Compassionate / Bereavement Leave
 
-- **Compassionate/bereavement leave entitlement** — 2 days per occasion (paid for permanent employees).
+- **Compassionate/bereavement leave entitlement**: 2 days per occasion (paid for permanent employees).
 
 ### Long Service Leave
 
-- **Long service leave entitlement** — Governed by state/territory legislation. Typically 8.67 weeks after 10 years of continuous service. Some states allow pro-rata access after 5--7 years.
+- **Long service leave entitlement**: Governed by state/territory legislation. Typically 8.67 weeks after 10 years of continuous service. Some states allow pro-rata access after 5--7 years.
 
 ### Parental Leave
 
 **Parental Leave**
+
+| Type | Duration | Payment |
+| --- | --- | --- |
+| Government Paid Parental Leave | Up to 130 days (26 weeks on a five-day basis) for eligible births/adoptions from 1 July 2026 | National minimum wage rate |
+| Unpaid parental leave | Up to 12 months (can request additional 12 months) | Nil (job-protected) |
+
+### Public Holidays
+
+- **Public holidays entitlement**: 8 national public holidays. Additional state/territory-specific holidays. Employees (except casuals) are entitled to be absent on public holidays without loss of pay.
+
+### Redundancy Pay (NES)
+
+**Redundancy Pay (NES)**
 
 | Years of Service | Weeks of Pay |
 | --- | --- |
@@ -204,22 +220,6 @@ There is no employee-paid social insurance premium equivalent to NIC (UK) or soc
 | 8--9 years | 14 weeks |
 | 9--10 years | 16 weeks |
 | 10+ years | 12 weeks |
-
-### Public Holidays
-
-- **Public holidays entitlement** — 8 national public holidays. Additional state/territory-specific holidays. Employees (except casuals) are entitled to be absent on public holidays without loss of pay.
-
-### Redundancy Pay (NES)
-
-**Redundancy Pay (NES)**
-
-| Item | Detail |
-| --- | --- |
-| Reporting frequency | Each pay event (each time employees are paid) |
-| Method | STP-enabled payroll software submits to ATO |
-| Content | Gross payments, PAYG withheld, super liability, employee details, income types, country codes |
-| Finalisation deadline | 14 July following end of financial year |
-| Closely held payees | May report quarterly; finalise by 14 July |
 
 - **Small business exemption** — Small business employers (< 15 employees) are exempt from NES redundancy pay.  _(NES)_
 
@@ -252,8 +252,11 @@ Not strictly required on payslips but must be provided to employees on request. 
 
 | Item | Detail |
 | --- | --- |
-| Payment deadline (earnings paid from 1 Jul 2026) | Received by the employee's fund within **7 business days of each payday** (clearing house receipt does not count) |
-| New employee / new fund | 20 business days for the first contribution |
+| Reporting frequency | Each pay event (each time employees are paid) |
+| Method | STP-enabled payroll software submits to ATO |
+| Content | Gross payments, PAYG withheld, super liability, employee details, income types, country codes |
+| Finalisation deadline | 14 July following end of financial year |
+| Closely held payees | Check eligibility for quarterly reporting and the applicable closely-held finalisation concession; do not assume the general 14 July deadline |
 
 ### PAYG Withholding Remittance
 
@@ -263,7 +266,7 @@ Not strictly required on payslips but must be provided to employees on request. 
 | --- | --- | --- |
 | Small withholders (< $25,000 annual PAYG) | Quarterly BAS | 28 days after quarter end |
 | Medium withholders ($25,000--$1M) | Monthly IAS | 21st of following month |
-| Large withholders (> $1M) | Monthly IAS + may need to pay more frequently | 21st of following month |
+| Large withholders (> $1M) | Follow the applicable large-withholder reporting rules, including STP | Pay electronically on the six-to-eight-day timetable determined by the withholding day; the monthly 21st is not the default payment deadline |
 
 ### Superannuation Remittance
 
@@ -300,6 +303,14 @@ Not strictly required on payslips but must be provided to employees on request. 
 | au-gst-bas | PAYG withholding (W1/W2) reported on BAS/IAS; GST does not apply to wages |
 | au-payg-instalments | Instalment obligations sit alongside withholding on the same activity statement |
 
+## Sources for current rates and reporting
+
+- [ATO pay-period tax tables](https://softwaredevelopers.ato.gov.au/PAYGWTaxtables): choose the payment date and employee circumstances.
+- [ATO large-withholder rules](https://www.ato.gov.au/businesses-and-organisations/preparing-lodging-and-paying/business-activity-statements-bas/pay-as-you-go-payg-withholding): distinguish payment timing from activity-statement reporting.
+- [Revenue NSW](https://www.revenue.nsw.gov.au/taxes-duties-levies-royalties/payroll-tax/lodge-and-pay-returns/thresholds-and-rates) and [SRO Victoria](https://www.sro.vic.gov.au/about-us/rates-and-statistics/current-rates/payroll-tax-current-rates): apply grouping, interstate allocation, threshold phase-out and surcharges. The other state rows are starting points requiring current verification before calculation.
+- [Fair Work Commission](https://fwc.gov.au/work-conditions/minimum-wages-and-conditions/national-minimum-wage): national minimum wage; determine any applicable award/agreement separately.
+- [Services Australia](https://www.servicesaustralia.gov.au/paid-parental-leave-scheme-changes): Parental Leave Pay days depend on the birth/adoption date. Check eligibility and the separate government-funded super payment.
+
 ## Section 9 -- Common Payroll Patterns
 
 ### Pattern 1 -- Full-Time Monthly Employee
@@ -331,7 +342,7 @@ Annual salary $120,000. Sacrifices $10,000/year to super.
 
 ### Pattern 4 -- STSL Repayment
 
-Employee earning $65,000 with HELP debt. STSL repayment rate from Schedule 8 tables: approximately 4.5%. Annual repayment: $65,000 × 4.5% = $2,925, withheld progressively via PAYG.
+Employee with annual repayment income of $65,000 in 2025–26 and a HELP debt: compulsory repayment is nil because income is below $67,000. Use the applicable year’s Schedule 8 table for pay-period withholding, including irregular payments. [Department of Education](https://www.education.gov.au/higher-education-loan-program/help-students/help-indexation-and-debt-reduction).
 
 ## Section 10 -- Interaction with Other Skills
 

--- a/skills/international/australia/australia-transfer-pricing.md
+++ b/skills/international/australia/australia-transfer-pricing.md
@@ -1,10 +1,11 @@
 ---
 name: australia-transfer-pricing
 description: Use this skill whenever asked about Australia transfer pricing rules, documentation requirements, or ATO transfer pricing compliance. Trigger on phrases like "transfer pricing Australia", "Australian TP documentation", "ATO transfer pricing", "master file Australia", "local file Australia", "CbCR Australia", "APA Australia", "Subdivision 815", "International Dealings Schedule", "IDS", "significant global entity", or any question about intercompany pricing for Australian entities.
-version: 1.0
+version: 1.2
 jurisdiction: AU
 tax_year: 2025
-last_updated: 2026-08-28
+tax_year_notes: "2025–26"
+last_updated: 2026-09-10
 review_status: pending_review
 depends_on:
   - transfer-pricing-workflow-base
@@ -15,9 +16,9 @@ license: AGPL-3.0-or-later (code) / OpenAccountants Guide License v1.0 (content)
 
 # Australia Transfer Pricing
 
-## Australia Transfer Pricing Skill v1.1
+## Australia Transfer Pricing Skill v1.2
 
-Australia Transfer Pricing Skill v1.1
+Australia Transfer Pricing Skill v1.2
 
 ## Section 1 -- Quick Reference
 
@@ -28,13 +29,13 @@ Australia Transfer Pricing Skill v1.1
 | Country | Australia (Commonwealth of Australia) |
 | Tax authority | Australian Taxation Office (ATO) |
 | Key TP legislation | Subdivision 815-B, Income Tax Assessment Act 1997 (ITAA 1997) |
-| Documentation | Subdivision 815-D ITAA 1997; Division 284-E, Schedule 1, Tax Administration Act 1953 (TAA 1953) |
-| CbCR legislation | Division 815-E ITAA 1997 |
+| Documentation | Subdivision 284-E, Schedule 1, Taxation Administration Act 1953 (TAA 1953) |
+| CbCR legislation | Subdivision 815-E ITAA 1997 |
 | OECD member? | Yes |
 | BEPS signatory? | Yes |
 | Currency | AUD |
 | Documentation language | English |
-| Skill version | 1.1 |
+| Skill version | 1.2 |
 
 ## Section 2 -- Documentation Requirements
 
@@ -48,9 +49,9 @@ Australia Transfer Pricing Skill v1.1
 | Timing | Contemporaneous -- prepared before lodging income tax return |
 | Penalty relevance | Without contemporaneous documentation, cannot establish "reasonably arguable position" (RAP) |
 
-### 2.2 Three-Tier Documentation (Significant Global Entities)
+### 2.2 Three-Tier Documentation (Country-by-Country Reporting Entities)
 
-**Three-Tier Documentation (Significant Global Entities)**
+**Three-Tier Documentation (Country-by-Country Reporting Entities)**
 
 | Document | Detail |
 | --- | --- |
@@ -60,7 +61,7 @@ Australia Transfer Pricing Skill v1.1
 | Filing deadline | Within 12 months of end of income year |
 | Filing method | Electronic lodgment with ATO |
 
-- **Significant Global Entity threshold** — Applies to entities in groups with consolidated annual global income ≥ AUD 1 billion AUD
+- **CbC reporting scope:** Establish whether the entity is a CbC reporting entity for the relevant period under s 815-370, including group-income and accounting-consolidation rules, exclusions and any reporting exemption. SGE status alone does not settle CbC obligations. [ITAA 1997 s 815-370](https://www.ato.gov.au/law/view/document?docid=PAC/19970038/815-370).
 
 ### 2.3 International Dealings Schedule (IDS)
 
@@ -74,7 +75,7 @@ Australia Transfer Pricing Skill v1.1
 
 ### 2.4 Short Form Local File
 
-- **Short Form Local File availability** — Available for entities with lower-risk or less material international related-party dealings that still meet the AUD 1 billion threshold.
+- **Short Form Local File:** Determine CbC reporting-entity status and apply the reporting-period ATO local-file instructions to identify which parts are required. Do not infer a reduced filing obligation from revenue or a general low-risk description alone. [ATO CbC reporting](https://www.ato.gov.au/businesses-and-organisations/international-tax-for-business/in-detail/transfer-pricing/country-by-country-reporting).
 
 ## Section 3 -- Arm's Length Standard
 
@@ -110,9 +111,9 @@ Australia Transfer Pricing Skill v1.1
 | Obligation | Detail |
 | --- | --- |
 | International Dealings Schedule (IDS) | Filed with income tax return |
-| Master File (SGEs) | Electronic lodgment within 12 months of year-end |
-| Local File (SGEs) | Electronic lodgment within 12 months of year-end |
-| CbC Report (SGEs) | Electronic lodgment within 12 months of year-end |
+| Master File (CbC reporting entities) | Electronic lodgment within 12 months of year-end |
+| Local File (CbC reporting entities) | Electronic lodgment within 12 months of year-end |
+| CbC Report (CbC reporting entities) | Electronic lodgment within 12 months of year-end |
 | Reportable Tax Position (RTP) | Large taxpayers must disclose TP positions |
 | Income tax return | Annual self-assessment |
 
@@ -123,9 +124,9 @@ Australia Transfer Pricing Skill v1.1
 | Item | Deadline |
 | --- | --- |
 | TP documentation preparation | Before lodging income tax return |
-| IDS filing | With income tax return (varies by entity type; generally 15 January for large) |
+| IDS filing | With income tax return (use the entity’s actual return due date) |
 | Master/Local/CbC Report | 12 months after end of income year |
-| Income tax return (companies) | Generally due by 15 January following year (for 30 June year-end) with extensions |
+| Income tax return (companies) | Use the ATO lodgement programme for the entity, agent status and compliance history; no universal 15 January date |
 
 ## Section 6 -- Penalties
 
@@ -135,11 +136,14 @@ Australia Transfer Pricing Skill v1.1
 
 | Scenario | Penalty Rate |
 | --- | --- |
-| Reasonably arguable position (RAP) established | No penalty |
+| RAP established, no dominant tax purpose | 10% of scheme shortfall, before applicable adjustments |
+| RAP established, dominant tax purpose | 25% of scheme shortfall, before applicable adjustments |
 | No RAP, no dominant tax purpose | 25% of tax shortfall |
 | No RAP, dominant tax purpose | 50% of tax shortfall |
 | Uplift for repeat behaviour | Additional 20% |
-| SGE multiplier | Doubled penalties for SGEs |
+| SGE adjustments | Apply the relevant statutory penalty provision; do not automatically double every transfer-pricing scheme-shortfall rate |
+
+[ATO PS LA 2014/2](https://www.ato.gov.au/law/view/document?docid=PSR/PS20142/NAT/ATO/00001) explains transfer-pricing scheme-shortfall penalties. Contemporaneous documents are necessary for the statutory RAP treatment but do not guarantee a RAP or nil liability.
 
 ### 6.2 Documentation Impact
 
@@ -151,18 +155,18 @@ Australia Transfer Pricing Skill v1.1
 
 | Offence | Penalty |
 | --- | --- |
-| Failure to lodge Local File, Master File, or CbC Report | Up to AUD 825,000 per failure |
+| Failure to lodge Local File, Master File, or CbC Report | Up to $910,000 at the $364 penalty-unit value from 1 July 2026 where the five-unit, 500-times SGE rule applies; check dates, obligation and remission. [Crimes (Amount of a Penalty Unit) Instrument 2026](https://www.legislation.gov.au/F2026N00424/asmade/text) |
 | Shortfall interest charge | Applies on underpaid tax |
 
 ## Section 7 -- Advance Pricing Agreements (APA)
 
-**Advance Pricing Agreements (APA)**  _(TR 95/23; PCG 2019/1)_
+**Advance Pricing Agreements (APA)**  _(PS LA 2015/4)_
 
 | Item | Detail |
 | --- | --- |
 | Availability | Yes (well-established program) |
 | Types | Unilateral, Bilateral, Multilateral |
-| Governing guidance | TR 95/23; Practical Compliance Guideline PCG 2019/1 |
+| Governing guidance | [PS LA 2015/4](https://www.ato.gov.au/law/view/document?docid=PSR/PS20154/NAT/ATO/00001) |
 | Application | To ATO; Expression of Interest followed by formal application |
 | Duration | Typically 3-5 years prospective; rollback possible |
 | Fees | No formal fee |
@@ -192,7 +196,7 @@ ATO publishes Practical Compliance Guidelines indicating risk zones for various 
 | --- | --- |
 | 2024-2025 | Updated Local File instructions (Part A and Part B) |
 | 2024 | Enhanced ATO compliance focus on intangibles and financial transactions |
-| 2023 | Pillar Two (GloBE) legislation enacted |
+| 2024 | Australian global and domestic minimum-tax legislation enacted; use the separate minimum-tax rules and application dates |
 | 2022 | Multinational Tax Integrity Package -- increased penalties for SGEs |
 | Ongoing | ATO PCGs on profit allocation to permanent establishments |
 | Ongoing | OECD Amount B: Australia participating in design; implementation timeline TBC |

--- a/skills/orchestrator/au-freelance-intake.md
+++ b/skills/orchestrator/au-freelance-intake.md
@@ -1,10 +1,11 @@
 ---
 name: au-freelance-intake
 description: ALWAYS USE THIS SKILL when a user asks for help preparing their Australian tax returns AND mentions freelancing, self-employment, contracting, sole trading, or ABN-based work. Trigger on phrases like "help me do my taxes", "prepare my ITR", "I'm a sole trader in Australia", "I'm a freelancer in Australia", "do my taxes as a contractor", "prepare my BAS and income tax", or any similar phrasing where the user is an Australian-resident self-employed individual needing tax return preparation. This is the REQUIRED entry point for the Australian self-employed tax workflow -- every other skill in the stack (australia-gst, au-individual-return, au-super-guarantee, au-medicare-levy, au-payg-instalments, au-return-assembly) depends on this skill running first to produce a structured intake package. Uses upload-first workflow -- the user dumps all their documents and the skill infers as much as possible before asking questions. Uses ask_user_input_v0 for structured questions instead of one-at-a-time prose. Built for speed. Australian full-year residents only; sole traders only.
-version: 0.1
+version: 0.3
 jurisdiction: AU
 tax_year: 2025
-last_updated: 2026-08-28
+tax_year_notes: "2025–26"
+last_updated: 2026-09-10
 review_status: pending_review
 tier: 2
 license: AGPL-3.0-or-later (code) / OpenAccountants Guide License v1.0 (content)
@@ -12,7 +13,7 @@ license: AGPL-3.0-or-later (code) / OpenAccountants Guide License v1.0 (content)
 
 # AU Freelance Intake
 
-## Australia Sole Trader Intake Skill v0.2
+## Australia Sole Trader Intake Skill v0.3
 
 ## What this file is
 
@@ -47,6 +48,10 @@ Target: intake completes in 5 minutes for a prepared user, 15 minutes for a user
 **Be terse but complete.** No hedging, no "let me know if you have questions," no "I hope this helps."
 
 **Exception for blocking decisions.** If a single question determines whether the user is in-scope or out-of-scope, ask it standalone.
+
+## Income-year handoff
+
+This intake prepares 2025–26. Include `tax_year: "2025-26"` in every handoff. Each receiving guide must confirm that year before using its rates. A guide covering only 2026–27 cannot supply historical rates. Keep missing-year support as an unresolved calculation requirement and withhold final totals until resolved.
 
 ## Section 1 -- The opening
 
@@ -86,7 +91,7 @@ Q3: "Do you have an ABN?"
 
 - **Q1 evaluation** — Q1 = Full year -> continue. Q1 = Part year or did not live in Australia -> stop. "I'm set up for full-year Australian residents only. Part-year or non-residents have different rules around foreign income and dual residency. You need a registered tax agent who handles non-resident returns."
 - **Q2 evaluation** — Q2 = Sole trader -> continue. Q2 = Partnership -> stop. "Partnerships lodge a separate partnership return and distribute income to partners. The australia-company-trust workflow (workflows/australia-company-trust.md) covers partnership, company and trust engagements end to end; if it is not available, you need a registered tax agent familiar with partnership returns." Q2 = Company (Pty Ltd) -> stop. "Company returns follow different rules. The australia-company-trust workflow covers them; if it is not available, you need a registered tax agent." Q2 = Trust -> stop. "Trust returns have separate distribution and reporting requirements. The australia-company-trust workflow covers them; if it is not available, you need a registered tax agent familiar with trust returns." Q2 = Not sure -> ask one follow-up: "Do you operate under your own name (or a registered business name) with an individual ABN? Or do you have a registered company with ASIC? If you invoice under your own ABN, you're a sole trader. If you have an ACN and Pty Ltd, you're a company."
-- **Q3 evaluation** — Q3 = Yes -> continue. Q3 = No -> stop. "You need an ABN to operate as a sole trader. Apply at abr.gov.au. Once you have your ABN, come back and we can prepare your returns." Q3 = Applied but not yet received -> continue with a flag: ABN pending, will need to confirm before lodging.
+- **Q3 evaluation:** Record the ABN or application status and confirm entitlement. An ABN is not universally compulsory to conduct a business. Check GST registration and no-ABN withholding separately; do not reject an otherwise valid income-tax engagement solely because no ABN is quoted. [ABR eligibility](https://www.abr.gov.au/business-super-funds-charities/applying-abn/abn-entitlement).
 
 **Second batch of scope questions**
 
@@ -102,7 +107,7 @@ Q6: "Industry?"
 ```
 
 - **GST registration turnover threshold** — 75000 AUD (turnover above which GST registration required or voluntary registration applies)
-- **Q4 evaluation** — Yes -> continue. Standard quarterly BAS lodgement. No -> continue. No BAS required unless turnover crosses $75K threshold. Will check after inference. Not sure -> ask one follow-up: "Do you charge GST on your invoices (i.e., your prices include a 10% GST component)? If yes, you're registered. If your invoices say 'no GST' or you've never dealt with BAS, you're likely not registered. Check your ABN registration at abr.gov.au."
+- **Q4 evaluation:** Verify GST registration and effective dates on the ABR, supported by the ATO account where available. Charging GST on an invoice does not establish registration. Determine the GST reporting cycle from the issued statement. Separately check PAYG instalments and withholding even when the client is not GST-registered. [ATO registration](https://www.ato.gov.au/businesses-and-organisations/gst-excise-and-indirect-taxes/gst/registering-for-gst).
 - **Q5 evaluation** — All options -> note for Medicare levy surcharge and tax offset calculations. Continue.
 - **Q6 evaluation** — All options -> note for expense classification context. Continue.
 
@@ -119,7 +124,7 @@ Once the refusal sweep passes, immediately ask for the document dump. Single mes
 > - Business bank statement(s) for all of 2025-26 (1 July 2025 - 30 June 2026) (CSV or PDF)
 > - Sales invoices issued in 2025-26
 > - Purchase invoices / receipts for business expenses
-> - Prior year tax return (2023-24 ITR, or at least last year's notice of assessment)
+> - Prior year tax return (2024-25 ITR, or at least last year's notice of assessment)
 > - PAYG payment summary / income statement from any employer (if also employed)
 > - Private health insurance statement (from your insurer)
 > - HELP/HECS statement (if applicable)
@@ -248,7 +253,7 @@ After inference, present a single compact summary message. Use a structured form
 > - Accounting fees: $1,500
 > - Phone / internet: $1,800 (TBD -- need business use %)
 > - Motor vehicle: $4,200 fuel + maintenance (TBD -- method and business use %)
-> - Equipment: MacBook Pro $3,200 (Nov 2024) -- instant asset write-off eligible (under $20K)
+> - Equipment: MacBook Pro $3,200 (Nov 2024). Confirm first-use date, business use and prior deductions. If first used in 2024–25, do not claim its cost again in 2025–26. Record any available decline in value or pool treatment.
 > - GST credits on purchases: ~$1,100 (claimable)
 >
 > **Super Contributions (from super statement)**
@@ -264,7 +269,7 @@ After inference, present a single compact summary message. Use a structured form
 >
 > **Private Health Insurance (from insurer statement)**
 > - Combined hospital + extras, full year cover
-> - Rebate tier: Base tier (under 65, income under $97K single -- TBD after final taxable income)
+> - Rebate tier: Base tier (under 65, income under $101K single -- TBD after final taxable income)
 > - Rebate claimed as premium reduction
 >
 > **HELP Debt**
@@ -274,7 +279,7 @@ After inference, present a single compact summary message. Use a structured form
 > **Flags I already see:**
 > 1. Phone / internet -- need business use percentage
 > 2. Motor vehicle -- need method (cents-per-km or logbook) and business use %
-> 3. MacBook Pro $3,200 -- eligible for instant asset write-off under $20K threshold
+> 3. MacBook Pro $3,200: deduction pending first-use and prior-claim evidence; no automatic current-year write-off.
 > 4. Super contributions well within $30K concessional cap -- no excess issue
 > 5. PHI rebate tier may shift depending on final taxable income
 > 6. HELP compulsory repayment to be calculated from repayment income
@@ -446,13 +451,13 @@ The downstream skill (`au-return-assembly`) consumes a JSON structure. It is int
   "home_office": {
     "method": "fixed_rate | actual_cost | none",
     "hours_worked_from_home": 0,
-    "rate_per_hour": 0.67,
+    "rate_per_hour": 0.70,
     "floor_area_pct": 0
   },
   "motor_vehicle": {
     "method": "cents_per_km | logbook | none",
     "business_km": 0,
-    "rate_per_km": 0.85,
+    "rate_per_km": 0.88,
     "logbook_business_pct": 0,
     "total_car_expenses": 0
   },
@@ -553,7 +558,7 @@ For an unprepared user (has to go fetch documents):
 
 - **v0.1 (April 2026):** Initial draft. Upload-first, inference-then-confirm pattern modelled on mt-freelance-intake v0.1.
 
-## End of Intake Skill v0.2
+## End of Intake Skill v0.3
 
 ## Disclaimer
 

--- a/skills/orchestrator/au-return-assembly.md
+++ b/skills/orchestrator/au-return-assembly.md
@@ -1,10 +1,11 @@
 ---
 name: au-return-assembly
 description: Final orchestrator skill that assembles the complete Australian filing package for Australian-resident sole traders. Consumes outputs from all Australian content skills (australia-gst for BAS, au-individual-return for ITR, au-super-guarantee for voluntary contributions, au-medicare-levy for levy and surcharge, au-payg-instalments for instalment schedule) to produce a single unified reviewer package containing every worksheet, every form, every brief section, all cross-skill reconciliations, and the final action list with payment instructions, filing instructions, and next-year planning. This is the capstone skill that runs last and produces the final deliverable. MUST be loaded alongside all Australian content skills listed above. Australian full-year residents only. Sole traders only.
-version: 0.2
+version: 0.4
 jurisdiction: AU
 tax_year: 2025
-last_updated: 2026-08-28
+tax_year_notes: "2025–26"
+last_updated: 2026-09-10
 review_status: pending_review
 tier: 2
 license: AGPL-3.0-or-later (code) / OpenAccountants Guide License v1.0 (content)
@@ -14,7 +15,7 @@ license: AGPL-3.0-or-later (code) / OpenAccountants Guide License v1.0 (content)
 
 ## AU Return Assembly
 
-## Australia Return Assembly Skill v0.3
+## Australia Return Assembly Skill v0.4
 
 ## CRITICAL EXECUTION DIRECTIVE -- READ FIRST
 
@@ -27,7 +28,7 @@ Specifically:
 - **Do NOT ask which deliverables to prioritise.** Produce all deliverables listed in Section 4. If you run out of context mid-execution, finish the computation work first (numbers, positions, flags) then produce whatever formatted outputs you can, and at the very end state clearly which deliverables were not produced and why.
 - **Do NOT re-validate scope that intake already validated.** If `au-freelance-intake` produced an intake package, trust it. You can cross-check specific numbers during reconciliation but do not re-interrogate the user about residency, business structure, or anything else intake already captured.
 - **Do NOT pause between content skills to check in.** Run them in dependency order (Section 2) without prose status updates between each one. A single status message at the end is fine.
-- **Self-checks are targets, not blockers.** If a self-check fails, note it in the reviewer brief's open flags section and continue. Do NOT halt the entire workflow because one self-check had an ambiguous answer.
+- **Completion gate:** Resolve failed calculation checks, unsupported years and omitted taxable items before issuing a final taxable-income, refund or payable figure. Continue unaffected working papers and label the package incomplete while those matters remain open.
 - **Primary source citations go in the final reviewer brief, not in intermediate computation steps.**
 
 **The user has already been told (by the intake skill) that the final package requires registered tax agent signoff before lodging. State it once in the final output and move on.**
@@ -42,42 +43,40 @@ This skill coordinates execution of the content skills, verifies cross-skill con
 
 ## Section 1 -- Scope
 
-- **Scope of package** — Produces the complete Australian filing package for: Full-year Australian residents; Sole traders; Tax year 2024-25 (1 July 2024 - 30 June 2025); Lodging BAS (if GST registered), individual tax return (ITR), super reconciliation, Medicare levy calculation, PAYG instalment schedule  _(Section 1 -- Scope)_
+- **Scope of package**: Produces the complete Australian filing package for: Full-year Australian residents; Sole traders; Tax year 2025-26 (1 July 2025 - 30 June 2026); Lodging BAS (if GST registered), individual tax return (ITR), super reconciliation, Medicare levy calculation, PAYG instalment schedule  _(Section 1 -- Scope)_
+
+## Required year
+
+This assembly supports 2025–26. Match the intake year and every upstream output before computing. Keep later-year planning separate. The former 2024–25 MLS base thresholds were $97,000/$194,000; those historical figures must not be substituted for the 2025–26 thresholds. [ATO MLS income and rates](https://www.ato.gov.au/individuals-and-families/medicare-and-private-health-insurance/medicare-levy-surcharge/medicare-levy-surcharge-income-thresholds-and-rates).
 
 ## Section 2 -- Execution order and dependency chain
 
-0. **Run australia-gst first** — BAS return (quarterly, if GST registered). Runs first because GST turnover figures feed into the ITR. For GST-registered: prepare any outstanding quarterly BAS; verify previously lodged quarters. Output: BAS box values (1A GST on sales, 1B GST on purchases), net GST position, turnover (ex-GST). Status check: australia-gst is currently a Q2 skill. If it has substantive computation content, use it. If it is still a placeholder, compute BAS figures from the intake package data and flag in the reviewer brief that the dedicated skill was not available.
-0. **Run au-individual-return second** — Individual tax return (ITR). Depends on BAS output: business income must use ex-GST turnover for GST-registered traders. Depends on BAS output: GST credits are excluded from deductible expenses (net amounts only). Output: ITR label values, taxable income, tax on taxable income, tax offsets, tax liability. Status check: au-individual-return is currently a Q2 skill. If it has substantive computation content, use it. If it is still a placeholder, compute ITR figures from the intake package data and flag in the reviewer brief that the dedicated skill was not available.
-0. **Run au-super-guarantee third** — Voluntary super contributions reconciliation. Depends on ITR: personal deductible contributions reduce taxable income. Verifies contributions are within the $30,000 concessional cap. Output: contribution amounts, cap utilisation, any excess contributions. Status check: au-super-guarantee is currently a Q2 skill. If it has substantive computation content, use it. If it is still a placeholder, compute super figures from the intake package data and flag in the reviewer brief that the dedicated skill was not available.
-0. **Run au-medicare-levy fourth** — Medicare levy and surcharge. Depends on ITR: levy is 2% of taxable income; surcharge applies if no PHI and income above threshold. Checks PHI status from intake package. Output: Medicare levy amount, surcharge amount (if applicable), PHI rebate adjustment. Status check: au-medicare-levy is currently a Q2 skill. If it has substantive computation content, use it. If it is still a placeholder, compute Medicare figures from the intake package data and flag in the reviewer brief that the dedicated skill was not available.
-0. **Run au-payg-instalments fifth** — PAYG instalment schedule (next year). Depends on ITR: instalment income and rate for 2025-26 based on 2024-25 return. Reconciles instalments paid during 2024-25 against final tax liability. Output: instalment credit for current year, next-year instalment schedule. Status check: au-payg-instalments is currently a Q4 stub. If the stub has substantive computation content, use it. If it is still a placeholder, compute PAYG instalment figures using the ATO's instalment rate method and flag in the reviewer brief that the dedicated skill was not available.
+1. **Run australia-gst first:** Prepare or verify the 2025–26 BAS and reconcile its sales to the income-tax ledger. Output the completed labels, GST position, accounting basis and reconciling items. Require supported calculations for the requested year.
+2. **Run au-individual-return second:** Prepare the 2025–26 ITR and business schedule from the reconciled ledger. Deduct only the GST credits to which the taxpayer is entitled when determining deductible expenses. Hold final totals until the super reconciliation and all required schedules are complete.
+3. **Run au-super-guarantee third:** Use its explicit 2025–26 reconciliation branch and $30,000 standard cap plus eligible carry-forward amounts. Reconcile fund receipts and valid acknowledged notices. Feed personal deductions back into the ITR before calculating Medicare, HELP and final tax.
+4. **Run au-medicare-levy fourth:** Use the completed 2025–26 ITR, spouse/dependent details and cover evidence. Calculate the levy, reductions, exemptions and surcharge using their separate income measures. Require supported calculations for the requested year.
+5. **Run au-payg-instalments-2 fifth:** Reconcile the 2025–26 instalment credit against the ATO account and notices. Show any 2026–27 forecast separately; the actual notice determines the method, rate, amount and dates.
 
-- **Upstream failure handling** — If any upstream content skill fails to produce validated output, the assembly skill notes the failure in the reviewer brief and continues with available data rather than halting entirely.  _(Section 2 -- Execution order and dependency chain)_
+- **Upstream failure handling:** Require every calculation output to identify 2025–26, its inputs, evidence and unresolved items. An unsupported year, unavailable module or unvalidated amount blocks final totals. Do not substitute an unverified calculation; prepare only the unaffected working papers until the missing amount is resolved.
 
-### Cross-check 1: BAS G1 taxable sales = ITR business income (ex-GST)
+### Cross-check 1: Reconcile BAS sales to assessable business income
 
-**If mismatch:** Flag for reviewer. Common causes: timing differences (cash vs accrual), private sales included in bank deposits, GST-free supplies, input-taxed supplies.
+Start with annual BAS sales on their stated GST basis. Bridge to the income-tax ledger through GST removal, GST-free and input-taxed sales, cash/accrual timing, capital receipts, excluded deposits and other tax adjustments. Reconcile the adjusted result, not an assumed equality between G1 and ITR income. Check 1A against actual taxable supplies and GST adjustments rather than 10% of all income. Explain each reconciling item and resolve unexplained differences. [ATO completing the GST labels](https://www.ato.gov.au/businesses-and-organisations/preparing-lodging-and-paying/business-activity-statements-bas/goods-and-services-tax-gst).
 
-**Cross-check 1 table**  _(Cross-check 1: BAS G1 taxable sales = ITR business income (ex-GST))_
-
-| BAS Output | ITR Input | Rule |
-| --- | --- | --- |
-| BAS 1A total GST on sales (annual) | Implied from ITR business income x 10% | Must reconcile |
-| BAS G1 total sales (ex-GST, annual sum) | ITR business income label | Must match within $1 |
-| Non-GST registered: gross receipts | ITR business income label | Direct match (no GST separation) |
+Example: $10,000 of qualifying GST-free business income can be assessable income with no output GST. A loan deposit is not sales merely because it is a bank credit.
 
 ### Cross-check 2: Super contributions within the concessional cap
 
-**If excess:** Flag for reviewer. Excess concessional contributions are included in assessable income and taxed at marginal rate (plus excess concessional contributions charge). Division 293 tax applies if income + super > $250,000.
+**If excess:** Test the applicable cap including eligible carry-forward amounts. Include excess concessional contributions in assessable income with the relevant 15% offset; consider release and non-concessional-cap effects. The excess concessional contributions charge does not apply to contributions made from 1 July 2021. Division 293 income is income for surcharge purposes excluding reportable super contributions, plus applicable low-tax contributions. Include the relevant reportable fringe benefits and net investment losses; apply statutory exclusions, including assessable FHSS released amounts. Tax is 15% of the lesser of low-tax contributions and the positive excess over $250,000. Exclude excess concessional contributions from low-tax contributions. [ITAA 1997 ss 293-20 and 293-25](https://www.ato.gov.au/law/view/document?docid=PAC/19970038/293-20).
 
-**Cross-check 2 table**  _(Cross-check 2 table -- $30,000 for 2025-26, $32,500 for 2026-27)_
+**Cross-check 2 table**  _(Cross-check 2 table -- $30,000 for 2025–26; use the requested year before considering later caps)_
 
 | Super Input | Source | Rule |
 | --- | --- | --- |
 | Employer contributions (if also employed) | PAYG summary / income statement | Counted toward cap |
 | Salary sacrifice (if any) | PAYG summary | Counted toward cap |
 | Personal deductible contributions | Super fund statement + s290-170 notice | Counted toward cap |
-| Total concessional | Sum of above | Must not exceed $30,000 |
+| Total concessional | Sum of above | Compare with $30,000 plus eligible carry-forward amounts |
 
 ### Cross-check 3: Medicare levy surcharge only if no PHI and income above threshold
 
@@ -89,8 +88,8 @@ This skill coordinates execution of the content skills, verifies cross-skill con
 | --- | --- | --- |
 | Income for MLS purposes | ITR taxable income + reportable fringe benefits + total net investment loss + reportable super | Combined figure |
 | PHI status | Insurer statement | If adequate hospital cover for full year, no MLS |
-| MLS thresholds (2024-25) | Single: $93,000; Family: $186,000 | Below threshold = no MLS regardless of PHI |
-| MLS rates | Tier 1: 1%; Tier 2: 1.25%; Tier 3: 1.5% | Applied to taxable income |
+| MLS thresholds (2025–26) | Single: $101,000; family: $202,000 | Add $1,500 for each dependent child after the first; apply individual liability and coverage rules. [ATO MLS income and rates](https://www.ato.gov.au/individuals-and-families/medicare-and-private-health-insurance/medicare-levy-surcharge/medicare-levy-surcharge-income-thresholds-and-rates) |
+| MLS rates | Tier 1: 1%; Tier 2: 1.25%; Tier 3: 1.5% | Select the tier using income for surcharge purposes, then apply it to each person’s statutory surcharge base and uncovered days. [ATO MLS income and rates](https://www.ato.gov.au/individuals-and-families/medicare-and-private-health-insurance/medicare-levy-surcharge/medicare-levy-surcharge-income-thresholds-and-rates) |
 
 ### Cross-check 4: PAYG instalments credit against final tax
 
@@ -100,7 +99,7 @@ This skill coordinates execution of the content skills, verifies cross-skill con
 
 | PAYG Input | Source | Rule |
 | --- | --- | --- |
-| Instalments paid during 2024-25 | BAS PAYG instalment labels (T7/T8) or ATO records | Credit against final tax |
+| Instalments paid during 2025-26 | ATO income-tax account and issued instalment notices, reconciled to payments, variations and credits | Credit against final tax |
 | Tax withheld by employer (if any) | PAYG summary | Additional credit |
 | Final tax liability | ITR computation | Total tax - credits = balance due or refund |
 
@@ -110,11 +109,11 @@ This skill coordinates execution of the content skills, verifies cross-skill con
 
 **Cross-check 5 table**  _(Cross-check 5: Instant asset write-off consistency)_
 
-| System | Threshold (2024-25) | Treatment |
+| System | Threshold (2025-26) | Treatment |
 | --- | --- | --- |
 | GST-registered | Asset cost ex-GST < $20,000 | Immediate deduction; GST credit claimed separately |
 | Non-GST-registered | Asset cost inc-GST < $20,000 | Immediate deduction on gross cost |
-| Above threshold | Depreciate using effective life | ITR depreciation schedule |
+| At or above threshold | Apply the relevant small business pool or other depreciation rules | ITR depreciation schedule |
 
 ### Documents
 
@@ -132,7 +131,7 @@ This skill coordinates execution of the content skills, verifies cross-skill con
 ### Reviewer brief contents
 
 ```markdown
-# Complete Return Package: [Client Name] -- Tax Year 2024-25
+# Complete Return Package: [Client Name] -- Tax Year 2025-26
 
 ## Executive Summary
 - Filing status: [Single / Married / etc.]
@@ -150,7 +149,7 @@ This skill coordinates execution of the content skills, verifies cross-skill con
 - PAYG withholding credit: $X
 - Balance due / refund: $X
 - HELP compulsory repayment: $X / nil
-- 2025-26 PAYG instalment amount: $X
+- 2026-27 PAYG instalment amount: $X
 
 ## BAS / GST Return
 [Content from australia-gst output]
@@ -183,16 +182,16 @@ This skill coordinates execution of the content skills, verifies cross-skill con
 - Asset register with cost, purchase date, effective life, method (prime cost / diminishing value)
 - Instant asset write-off items (under $20K threshold)
 - Continuing depreciation from prior years
-- Written-down values carried forward to 2025-26
+- Written-down values carried forward to 2026-27
 
 ## Super Contributions
 [Content from au-super-guarantee output]
 - Personal deductible contributions (s290-170 notice required)
 - Employer contributions (if also employed)
-- Total concessional: $X of the year's concessional cap ($30,000 for 2025-26; $32,500 for 2026-27)
+- Total concessional: $X of the year's concessional cap ($30,000 for 2025–26 plus eligible carry-forward amounts)
 - Excess concessional: $X / nil
 - Non-concessional contributions: $X
-- Division 293 check: income + super vs $250,000 threshold
+- Division 293 check: statutory surcharge income excluding reportable super, plus applicable low-tax contributions; apply exclusions and the $250,000 threshold.
 - Total super balance (for carry-forward cap calculation)
 
 ## Medicare Levy and Surcharge
@@ -206,19 +205,19 @@ This skill coordinates execution of the content skills, verifies cross-skill con
 - PHI rebate tier and adjustment: $X / nil
 
 ## PAYG Instalments
-[Content from au-payg-instalments output]
-- 2024-25 instalments paid: $X (credit against final tax)
-- 2024-25 instalment rate used: X%
-- 2025-26 instalment income (from 2024-25 return): $X
-- 2025-26 instalment rate (from NOA): X%
-- 2025-26 quarterly instalment amounts:
-  - Q1 (Jul-Sep): due 28 Oct 2025
-  - Q2 (Oct-Dec): due 28 Feb 2026
-  - Q3 (Jan-Mar): due 28 Apr 2026
-  - Q4 (Apr-Jun): due 28 Jul 2026
+[Content from au-payg-instalments-2 output]
+- 2025-26 instalments paid: $X (credit against final tax)
+- 2025-26 instalment rate used: X%
+- 2026-27 instalment income for each actual reporting period: $X
+- 2026-27 notified method and amount/rate (from ATO notice): $X / X%
+- 2026-27 quarterly instalment amounts:
+  - Q1 (Jul-Sep): due 28 Oct 2026
+  - Q2 (Oct-Dec): due 1 Mar 2027
+  - Q3 (Jan-Mar): due 28 Apr 2027
+  - Q4 (Apr-Jun): due 28 Jul 2027
 
 ## Cross-skill Reconciliation
-- BAS G1 vs ITR business income: [pass/fail]
+- BAS-to-income reconciliation bridge: [pass/fail with reconciling items]
 - Super within concessional cap: [pass/fail]
 - MLS correctly assessed: [pass/fail]
 - PAYG credits reconciled: [pass/fail]
@@ -239,40 +238,40 @@ This skill coordinates execution of the content skills, verifies cross-skill con
 ## Positions Taken
 [List with legislation citations]
 - e.g., "Home office deduction claimed at 70c/hr for X hours -- Practical Compliance Guideline PCG 2023/1"
-- e.g., "Motor vehicle cents-per-km at 88c/km (2025-26) for X km -- s 28-25 ITAA 1997"
+- e.g., "Motor vehicle cents-per-km at 88c/km (2025–26) for X km -- s 28-25 ITAA 1997"
 - e.g., "MacBook Pro instant asset write-off -- ITAA 1997 Div 328, $20,000 threshold" (temporary full expensing ENDED 30 June 2023 -- never cite it for a current year)
 - e.g., "Personal super contribution deduction -- s290-150 ITAA 1997, s290-170 notice lodged"
 
-## Planning Notes for 2025-26
+## Planning Notes for 2026-27
 - PAYG instalment schedule (quarterly amounts and dates)
 - Super contribution strategy (remaining cap, carry-forward unused cap from prior years)
 - GST registration threshold monitoring (if approaching $75K)
-- Depreciation schedule continuing into 2025-26 (WDV schedule)
+- Depreciation schedule continuing into 2026-27 (WDV schedule)
 - PHI rebate tier based on projected income
-- Any legislative changes affecting 2025-26 (budget measures, rate changes)
+- Any legislative changes affecting 2026-27 (budget measures, rate changes)
 
 ## Client Action List
 
-### Immediate (before 31 October 2025 -- ITR lodgement deadline for self-lodgers):
+### Immediate (before 2 November 2026 -- ITR lodgement deadline for self-lodgers):
 1. Review this return package with your registered tax agent
 2. Lodge ITR via myTax or through tax agent (tax agent clients have extended deadline)
 3. Pay balance due of $X to ATO (or receive refund of $X)
 4. Lodge any outstanding BAS quarters
 
 ### Note on lodgement deadlines:
-- Self-lodgers: 31 October 2025
-- Tax agent lodgement: extended deadlines apply (typically March-May 2026 depending on category)
+- Self-lodgers: 2 November 2026
+- Tax agent lodgement: extended deadlines apply (use the client’s applicable 2026–27 lodgement programme)
 
-### Quarterly obligations for 2025-26:
-- BAS Q1 (Jul-Sep): lodge and pay by 28 October 2025
-- BAS Q2 (Oct-Dec): lodge and pay by 28 February 2026
-- BAS Q3 (Jan-Mar): lodge and pay by 28 April 2026
-- BAS Q4 (Apr-Jun): lodge and pay by 28 July 2026
+### Quarterly obligations for 2026-27:
+- BAS Q1 (Jul-Sep): lodge and pay by 28 October 2026
+- BAS Q2 (Oct-Dec): lodge and pay by 1 March 2027
+- BAS Q3 (Jan-Mar): lodge and pay by 28 April 2027
+- BAS Q4 (Apr-Jun): lodge and pay by 28 July 2027
 
 ### Super obligations:
-- If you have employees: SG due quarterly (28 days after quarter end)
+- If you have employees: reconcile 2025–26 quarterly SG separately; use au-super-guarantee for the payday rules applying from 1 July 2026.
 - Personal deductible contributions: lodge s290-170 notice with super fund BEFORE lodging ITR
-- Monitor the concessional cap for the income year being assembled ($30,000 for 2025-26; $32,500 for 2026-27) across all contribution sources
+- Monitor the concessional cap for the income year being assembled ($30,000 for 2025–26 plus eligible carry-forward amounts) across all contribution sources
 
 ### Ongoing:
 1. Issue tax invoices for all sales (if GST registered)
@@ -289,17 +288,17 @@ This skill coordinates execution of the content skills, verifies cross-skill con
 - **R-AU-2** — Upstream self-check failed. Name the specific check and note it in the reviewer brief. Continue.  _(Section 5 -- Refusals)_
 - **R-AU-3** — Cross-skill reconciliation failed. Name the specific reconciliation and describe the discrepancy. Flag for reviewer but continue.  _(Section 5 -- Refusals)_
 - **R-AU-4** — Intake incomplete. Specific missing intake items prevent computation. List what is missing and ask the user for the specific data point.  _(Section 5 -- Refusals)_
-- **R-AU-5** — Out-of-scope item discovered during assembly. E.g., rental income requiring rental schedule, capital gains requiring CGT schedule, foreign income requiring FITO. Flag and exclude from computation.  _(Section 5 -- Refusals)_
+- **R-AU-5: Missing schedule.** If rental, CGT, foreign income or another required schedule is outside scope, record it and obtain a reviewer-completed schedule. Continue unaffected working papers, but withhold final taxable-income, tax, refund and payable figures until all required amounts are included.
 
 ## Section 6 -- Self-checks
 
 - **Check AU1 -- All upstream skills executed** — australia-gst, au-individual-return, au-super-guarantee, au-medicare-levy all produced output. au-payg-instalments produced output or was computed from ITR figures.  _(Section 6 -- Self-checks)_
-- **Check AU2 -- BAS G1 matches ITR business income** — Within $1 tolerance.  _(Section 6 -- Self-checks)_
+- **Check AU2:** The BAS-to-income bridge explains GST treatment, timing, capital and other adjustments; any unexplained difference blocks final totals.
 - **Check AU3 -- Super within concessional cap** — Total concessional contributions do not exceed $30,000 (or cap plus carry-forward unused amounts).  _(Section 6 -- Self-checks)_
 - **Check AU4 -- Medicare levy surcharge correctly assessed** — MLS applied only if no adequate PHI and income above threshold; MLS not applied if PHI held for full year.  _(Section 6 -- Self-checks)_
-- **Check AU5 -- PAYG instalments correctly credited** — Total instalments paid during 2024-25 credited against final tax liability.  _(Section 6 -- Self-checks)_
+- **Check AU5 -- PAYG instalments correctly credited**: Total instalments paid during 2025-26 credited against final tax liability.  _(Section 6 -- Self-checks)_
 - **Check AU6 -- GST treatment correct for registered traders** — Business income reported ex-GST; input tax credits excluded from deductible expenses; GST credits claimed on BAS.  _(Section 6 -- Self-checks)_
-- **Check AU7 -- GST treatment correct for unregistered traders** — Business income reported gross; all expenses reported gross (GST-inclusive); no BAS required.  _(Section 6 -- Self-checks)_
+- **Check AU7:** Unregistered traders use the appropriate GST-inclusive income and deductible expenses; separately check PAYG instalments and withholding activity statements.
 - **Check AU8 -- Instant asset write-off threshold correct** — Assets under $20,000 (on correct GST basis) claimed as immediate deduction; assets above threshold depreciated.  _(Section 6 -- Self-checks)_
 - **Check AU9 -- Personal super deduction s290-170 notice flagged** — Reviewer brief notes that the taxpayer must lodge a notice of intent to claim with the super fund before the ITR is lodged.  _(Section 6 -- Self-checks)_
 - **Check AU10 -- Tax rate table correct for residency** — Resident tax rates applied (including tax-free threshold of $18,200).  _(Section 6 -- Self-checks)_
@@ -308,9 +307,9 @@ This skill coordinates execution of the content skills, verifies cross-skill con
 
 ## Section 7 -- Output files
 
-- **Output file 1: master workbook** — `[client_slug]_2024-25_australia_master.xlsx` -- Single master workbook containing every worksheet and form. Sheets include: Cover, BAS Summary (quarterly), ITR (label-by-label), Depreciation Schedule, Expense Detail, Super Reconciliation, Medicare Levy, PAYG Instalments, Cross-Check Summary. Use live formulas where possible -- e.g., ITR business income references the BAS turnover cell; Medicare levy references ITR taxable income; PAYG credit references BAS instalment totals. Verify no `#REF!` errors. Verify computed values match the computation model within $1 before shipping.  _(Section 7 -- Output files)_
+- **Output file 1: master workbook**: `[client_slug]_2025-26_australia_master.xlsx` -- Single master workbook containing every worksheet and form. Sheets include: Cover, BAS Summary (quarterly), ITR (label-by-label), Depreciation Schedule, Expense Detail, Super Reconciliation, Medicare Levy, PAYG Instalments, Cross-Check Summary. Use live formulas where possible -- e.g., ITR business income references the reconciled income-tax ledger and BAS-to-income bridge; Medicare levy references ITR taxable income; PAYG credit references BAS instalment totals. Verify no `#REF!` errors. Verify computed values match the computation model within $1 before shipping.  _(Section 7 -- Output files)_
 - **Output file 2: reviewer brief** — `reviewer_brief.md` -- Single markdown file covering all sections from Section 4 above: executive summary, BAS, ITR, super, Medicare, PAYG, cross-skill reconciliation, flags, positions, planning notes.  _(Section 7 -- Output files)_
-- **Output file 3: client action list** — `client_action_list.md` -- Single markdown file with step-by-step actions: immediate lodgements and payments, quarterly calendar for 2025-26, ongoing compliance reminders.  _(Section 7 -- Output files)_
+- **Output file 3: client action list**: `client_action_list.md` -- Single markdown file with step-by-step actions: immediate lodgements and payments, quarterly calendar for 2026-27, ongoing compliance reminders.  _(Section 7 -- Output files)_
 
 **If execution runs out of context mid-build:** produce whatever is complete, then state at the end which of the three files were not produced or are partial.
 
@@ -339,7 +338,7 @@ This skill coordinates execution of the content skills, verifies cross-skill con
 7. Multi-year depreciation tracking assumes the prior year schedule is provided. If not, only current-year acquisitions are depreciated.
 8. au-payg-instalments is a Q4 stub. Until it is fleshed out, PAYG instalments are computed using the ATO's instalment rate method from the NOA. This is a redundancy, not a gap -- the rules are deterministic.
 9. Several upstream content skills (australia-gst, au-individual-return, au-super-guarantee, au-medicare-levy) are Q2 skills. If any are still stubs, the assembly skill computes the figures directly and flags the gap.
-10. The package is complete only for the 2024-25 tax year; 2025-26 appears only as prospective planning.
+10. The package is complete only for the 2025-26 tax year; 2026-27 appears only as prospective planning.
 
 ### Change log
 


### PR DESCRIPTION
## What this PR does

Correct Australian guide calculations and tax-year handling. The sole-trader workflow now assembles 2025–26, holds final totals for missing schedules, and reconciles BAS amounts to the income-tax ledger. GST worksheet signs, supply classifications, PAYG variations, Medicare/MLS income measures, super rules, payroll figures, depreciation and statutory references are corrected across 14 source guides.

Examples now cover a positive GST purchase credit, loan exclusion, refund reversal, third-quarter PAYG variation, distinct MLS income measures and Division 293 fringe benefits. Source dates, versions and year labels are aligned. All guides remain source-cited drafts pending professional review.

## Country/jurisdiction affected

Australia: individual returns and business schedules, BAS/PAYG, Medicare, super, payroll, bookkeeping, FBT and transfer pricing.

## Verification

Python 3.11.15: 83 repository tests and 33 MCP tests passed. The MCP package built successfully. Changed-guide validation and strict sync-integrity checks passed for all 14 guides with no warnings. `git diff --check` passed. Targeted local checks covered the corrected examples, workflow guards and preserved review status/CTAs. All five hosted checks passed for commit `c9231936`: CLA, guide validation, generated-tree guard, sync comparison and unit tests.

## Limits and deployment

No end-to-end LLM upload test or accountant sign-off has been verified. The exact 2026 business schedule and M2 instructions were not retrievable; annual form verification remains required. This patch does not certify every unmodified guide statement.

Only source guides changed. Maintainer ingestion and verification on the platform are required after merge and before the next outbound export. Generated bundles, `index.json` and `llms-full.txt` are intentionally left to that sync.

## Legal: Contributor License Agreement (CLA)

- [x] **I have read [CLA.md](https://github.com/openaccountants/openaccountants/blob/main/CLA.md) and agree to the Contributor License Agreement** for everything included in this pull request.

## Checklist

- [x] Files are under `skills/**`; jurisdiction is AU.
- [x] Generated files are unchanged.
- [x] Attribution: Ryan Duguid.
- [x] Corrected rates and thresholds cite primary sources.
- [x] Worked examples and disclaimers are retained.
- [ ] Tested by uploading the complete workflow to an LLM and checking its output.

Existing inline tier tags and unrelated guide structure remain outside this correction patch. No claim of completed accountant review is made.
