### PR TITLE
Correct Australian super eligibility, receipt evidence and R&D extensions

### DIFF
--- a/skills/international/australia/au-rd-incentive.md
+++ b/skills/international/australia/au-rd-incentive.md
@@ -2,18 +2,18 @@
 name: au-rd-incentive
 description: >
   Use this skill whenever asked about the Australian R&D Tax Incentive (R&DTI) -- the Division 355 tax offset for eligible research and development, who can claim (incorporated R&D entities only), the refundable offset for companies under $20m aggregated turnover, the non-refundable offset with intensity tiers for larger companies, core vs supporting R&D activities, excluded activities, registration with AusIndustry/DISR within 10 months of year end, the $20,000 expenditure threshold, the $150 million cap, feedstock and clawback adjustments, aggregated turnover grouping, and record-keeping. Trigger on phrases like "R&D tax incentive", "R&DTI", "R&D offset", "research and development tax", "43.5% offset", "refundable R&D", "Division 355", "AusIndustry registration", "core R&D activities", "feedstock adjustment", or "R&D intensity". ALWAYS read this skill before touching any R&D tax offset work.
-version: 1.0
+version: 1.1
 jurisdiction: AU
 tax_year: 2026
 tax_year_notes: "2026-27"
-last_updated: 2026-08-20
+last_updated: 2026-09-11
 review_status: pending_review
 category: international
 tier: 2
 license: AGPL-3.0-or-later (code) / OpenAccountants Guide License v1.0 (content)
 ---
 
-# Australia R&D Tax Incentive Skill v1.0
+# Australia R&D Tax Incentive Skill v1.1
 
 > **General reference only.** This skill is general tax/accounting reference material for AI-assisted workflows. It has not been reviewed for any specific person's facts, documents, elections, deadlines, residency, filing status, or local procedures. Do not rely on it to file, pay, amend, or take a tax position without review by a qualified professional in the relevant jurisdiction.
 
@@ -38,7 +38,7 @@ license: AGPL-3.0-or-later (code) / OpenAccountants Guide License v1.0 (content)
 | Non-refundable offset | Aggregated turnover >= $20m OR exempt-controlled: company tax rate + 8.5% premium (R&D up to 2% intensity); company tax rate + 16.5% premium (R&D above 2% intensity) |
 | Expenditure cap | $150m notional deductions per year; offset rate drops to the bare company tax rate above it |
 | Minimum spend | $20,000 notional deductions, UNLESS via a registered Research Service Provider (RSP) or CRC contribution |
-| Registration deadline | With DISR, every income year, within 10 months of year end, BEFORE claiming in the return |
+| Registration deadline | With DISR each income year, normally within 10 months of year end; extensions under Rule 7. Valid registration required before claiming |
 | Amendment window | 4 years (generally), tied to DISR findings |
 | Contributor | Open Accountants |
 | Validated by | Pending |
@@ -72,7 +72,7 @@ R&DTI work starts with the general ledger and the project/time records, not the 
 | GL pattern | Likely issue | Action |
 |---|---|---|
 | R&D expense / "R&D project" cost centres | Candidate notional deduction | Map each account to a registered DISR activity; confirm it is core or supporting, not BAU |
-| Project codes / job codes linked to a DISR registration number | Expenditure linked to registered activities | Trace to the registration (IISA number) for the correct income year; confirm 10-month deadline met |
+| Project codes / job codes linked to a DISR registration number | Expenditure linked to registered activities | Trace to the registration (IISA number) for the correct income year; confirm the statutory or approved extended deadline was met |
 | Payroll allocations / timesheet-coded wages to R&D projects | Salary notional deduction | Substantiate time via timesheets/job cards; apportion between R&D and non-R&D on a reasonable, documented basis |
 | Contractor / RSP invoices for R&D | External R&D expenditure | Confirm the RSP is registered with DISR; if under $20k total, the RSP pathway is what preserves eligibility |
 | Depreciation on assets used in R&D | Asset cost is NOT notionally deductible | Use decline-in-value notional deductions instead; do not claim the asset's acquisition cost |
@@ -199,7 +199,11 @@ The following CANNOT be core R&D activities (though some may qualify as supporti
 
 ### Rule 7 -- Registration and the 10-month deadline
 
-Activities must be registered with DISR **for every income year**, **within 10 months of the end of the income year** (e.g. 30 April 2027 for a 30 June 2026 year end), and **before** the offset is claimed in the return. The DISR IISA registration number must appear on the R&D schedule and match the income year. Failure to register in time is fatal to the claim -- there is no discretion to backdate. Registration is self-assessment: the number does not certify eligibility.
+Register activities with DISR for each income year before claiming the offset. The normal deadline is 10 months after year end, for example 30 April 2027 for a 30 June 2026 year end. The IISA registration number on the R&D schedule must match the income year. Registration does not certify activity eligibility.
+
+If the deadline cannot be met or has passed, refer the entity to DISR or its R&D adviser to request an extension through the R&DTI customer portal, with reasons and supporting evidence. Approval is discretionary. Extensions generally cannot exceed 92 days after the statutory deadline; a related pending decision is the exception. Confirm valid registration within the statutory or approved extended period before claiming. A late application alone does not establish entitlement.
+
+DISR cannot extend the application deadline for an advance or overseas finding or accept those applications late. See [DISR: request an extension or variation](https://business.gov.au/grants-and-programs/research-and-development-tax-incentive/request-an-extension-or-variation) and Part 3 of the Industry Research and Development Decision-making Principles 2022.
 
 ### Rule 8 -- The $20,000 threshold and the RSP exception
 
@@ -256,7 +260,7 @@ These are deliberate refusal-and-escalate zones. Do NOT answer them from this sk
 | Code | Trigger | Message |
 |---|---|---|
 | R-AU-RD-1 | Whether a specific activity qualifies as a core or supporting R&D activity | "Whether an activity is R&D is a technical/engineering judgement about scientific uncertainty and the knowledge threshold under s 355-25, not an accounting judgement. This needs a competent professional in the field and, for certainty, an AusIndustry/DISR advance finding. I can help organise the project documentation but cannot classify the activity." |
-| R-AU-RD-2 | Preparing or lodging the DISR registration application | "Registration is a self-assessed application to AusIndustry/DISR describing the activities against the legislative criteria. I can't draft or lodge it. Refer to AusIndustry (13 28 46) or a registered R&D tax adviser; the registration must be lodged within 10 months of year end." |
+| R-AU-RD-2 | Preparing or lodging the DISR registration application | "Registration is a self-assessed application to AusIndustry/DISR describing the activities against the legislative criteria. I can't draft or lodge it. Refer to AusIndustry (13 28 46) or a registered R&D tax adviser. The normal deadline is 10 months after year end; assess the Rule 7 extension route if late." |
 | R-AU-RD-3 | Advance findings, overseas findings, or binding certainty on eligibility | "Only DISR can make an advance finding (activity eligibility) or an overseas finding (s 28D IR&D Act). These are binding decisions for your specific facts. Refer to AusIndustry; I can help assemble the supporting records." |
 | R-AU-RD-4 | Overseas R&D activities | "Activities conducted overseas are claimable only with a positive DISR overseas finding, and only where conducted for the claimant (not a foreign related entity). This needs the finding in place before claiming. Refer to AusIndustry." |
 | R-AU-RD-5 | Aggregated expenditure/turnover across connected or affiliated groups | "Aggregated turnover across connected and affiliated entities (including foreign ones) determines refundable vs non-refundable, and group structuring can attract Part IVA. Compute the group position with the client's adviser; I can prepare the underlying turnover figures per entity." |
@@ -265,7 +269,7 @@ These are deliberate refusal-and-escalate zones. Do NOT answer them from this sk
 
 ## Section 8 -- Reading guide
 
-1. Registration first: no valid, in-time DISR registration for the income year means no claim, regardless of how good the R&D is.
+1. Registration first: confirm valid DISR registration for the income year within the statutory or approved extended period (Rule 7) before claiming.
 2. Entity test second: only a corporation (R&D entity) can claim. A sole trader or trust "doing R&D" has no R&DTI pathway.
 3. Activity test third: core activities must clear all three limbs (unknowable outcome, systematic progression, new knowledge) -- and that is a technical judgement this skill refuses to make.
 4. Rate test fourth: aggregated turnover and exempt-entity control choose refundable vs non-refundable; intensity tiers set the non-refundable premium.
@@ -297,7 +301,7 @@ If the client provides only financial statements:
 | R&D intensity | Notional R&D deductions / total expenditure for the year |
 | Expenditure cap | $150m notional deductions; offset drops to bare company tax rate above it |
 | Minimum notional deduction | $20,000 (waived for registered RSP / CRC) |
-| Registration deadline | Within 10 months of income year end, before claiming, every year |
+| Registration deadline | Normally 10 months after income year end, each year; Rule 7 covers extensions. Register before claiming |
 | Amendment period | Generally 4 years; special rules give effect to DISR findings |
 | Tobacco/gambling | Ineligible for income years from 1 July 2025 unless sole-purpose harm minimisation |
 
@@ -313,6 +317,7 @@ If the client provides only financial statements:
 | Clawback/feedstock | ato.gov.au -- Clawback of R&D tax incentive offset (QC 70876, 70889); TR 2013/3 (feedstock); TR 2021/5 (at-risk rule) |
 | Compliance | ato.gov.au -- Helping you get R&D claims right (QC 70873); TA 2017/3 (ordinary business activities); TA 2023/4 (associates) |
 | Amendments | ato.gov.au -- Correcting mistakes and disputing decisions (QC 70877) |
+| Registration extensions (checked 11 September 2026) | [DISR: request an extension or variation](https://business.gov.au/grants-and-programs/research-and-development-tax-incentive/request-an-extension-or-variation); Industry Research and Development Decision-making Principles 2022, Part 3 |
 
 ### Test suite
 
@@ -328,7 +333,7 @@ If the client provides only financial statements:
 
 **Test 6:** Software built to run the claimant's own payroll. -> Internal-administration software; excluded from core R&D activities.
 
-**Test 7:** Registration lodged 11 months after year end. -> Late; claim fails for that year (no backdating).
+**Test 7:** Registration lodged 11 months after year end without an approved extension. -> Late under the normal deadline. Refer for an extension request with reasons and evidence; keep the claim pending until valid registration is confirmed. Approval is not automatic. Apply the 92-day limit and related-pending-decision exception in Rule 7. A late advance or overseas finding application has no extension route.
 
 **Test 8:** Feedstock revenue $9,000, feedstock expenditure $10,000, 43.5% offset, 25% CTR. -> $6,660 added to assessable income (Example 5).
 
@@ -342,7 +347,7 @@ If the client provides only financial statements:
 - NEVER classify an activity as core/supporting R&D -- that is a technical/engineering judgement (R-AU-RD-1); escalate
 - NEVER prepare or lodge the DISR registration application -- refer to AusIndustry (R-AU-RD-2)
 - NEVER advise on advance or overseas findings -- DISR only (R-AU-RD-3, R-AU-RD-4)
-- NEVER compute the offset without first confirming a valid, in-time DISR registration for the income year
+- NEVER compute the offset without confirming valid DISR registration for the income year within the statutory or approved extended period
 - NEVER choose refundable vs non-refundable without computing aggregated turnover across connected/affiliated entities (R-AU-RD-5)
 - NEVER claim amounts incurred to an associate before they are paid
 - NEVER claim the cost of a depreciating asset -- use decline-in-value notional deductions

--- a/skills/international/australia/au-super-guarantee.md
+++ b/skills/international/australia/au-super-guarantee.md
@@ -2,21 +2,18 @@
 name: au-super-guarantee
 description: >
   Use this skill whenever asked about Australian Superannuation Guarantee (SG) obligations, payday super deadlines, voluntary super contributions, concessional and non-concessional caps, Division 293 tax, Division 296 large-balance tax, government co-contribution, spouse contribution tax offset, carry-forward rules, or any question about super for sole traders or employers. Trigger on phrases like "how much super do I pay", "SG rate", "super guarantee", "payday super", "7 business days super", "SG shortfall", "concessional cap", "Division 293", "Division 296", "$3 million super tax", "salary sacrifice super", "personal super contribution deduction", "co-contribution", "BPAY super", "super clearing house", "super fund contribution", or any question about Australian superannuation. Also trigger when classifying bank statement transactions showing super fund payments, BPAY super debits, or clearing house payments. ALWAYS read this skill before touching any SG-related work.
-version: 3.2
+version: 3.3
 jurisdiction: AU
-tax_year: 2024
-last_updated: 2026-09-10
+tax_year: 2026
+tax_year_notes: "2026-27"
+last_updated: 2026-09-11
 review_status: pending_review
 category: international
 tier: 2
 license: AGPL-3.0-or-later (code) / OpenAccountants Guide License v1.0 (content)
 ---
 
-# Australia Superannuation Guarantee (SG) -- Sole Trader & Employer Skill v3.2
-
-## Australia Superannuation Guarantee (SG) -- Sole Trader & Employer Skill v3.2
-
-## Australia Superannuation Guarantee (SG) -- Sole Trader & Employer Skill v3.2
+# Australia Superannuation Guarantee (SG) -- Sole Trader & Employer Skill v3.3
 
 > **General reference only.** This skill is general tax/accounting reference material for AI-assisted workflows. It has not been reviewed for any specific person's facts, documents, elections, deadlines, residency, filing status, or local procedures. Do not rely on it to file, pay, amend, or take a tax position without review by a qualified professional in the relevant jurisdiction.
 
@@ -73,9 +70,9 @@ The remaining payday calculations and indexed figures below concern 2026–27. [
 
 ### Required inputs
 
-**Minimum viable** -- entity structure (sole trader / company / trust / partnership), whether client has employees, pay frequency and payday dates, qualifying earnings per payday (for employers), and voluntary contribution intent (for sole traders).
+**Minimum viable** -- entity structure (sole trader / company / trust / partnership), worker eligibility under Rule 1 (including age and actual weekly hours), pay frequency and payday dates, qualifying earnings per payday (for employers), and voluntary contribution intent (for sole traders).
 
-**Recommended** -- bank statements showing super fund debits, payroll register with per-payday qualifying earnings and YTD totals, TSB at 30 June prior year, taxable income for Division 293.
+**Recommended** -- bank statements showing super fund debits, payroll register with per-payday qualifying earnings and YTD totals, TSB at 30 June prior year, and the Rule 10 income components and fund-reported contributions for Division 293. Taxable income alone is insufficient.
 
 **Ideal** -- complete STP reporting data, super fund member statements showing receipt dates, s 290-170 notice copies, ATO online account showing contribution caps.
 
@@ -163,9 +160,9 @@ Six classifications for a hypothetical Australian employer with 2 employees, for
 `24.07.2026 ; AUSTRALIAN SUPER ; DEBIT ; SUPER PPE 17/07 EMPLOYEE A ; -480.00 ; AUD`
 
 **Reasoning:**
-Matches "AUSTRALIAN SUPER" (pattern 3.1). Payday was Friday 17 July 2026; $480.00 = $4,000 qualifying earnings x 12%. Fund receipt on 24 July is 5 business days after payday -- inside the 7-business-day window. Tax-deductible for the employer.
+Matches "AUSTRALIAN SUPER" (pattern 3.1), so this is a candidate employee super contribution. The bank debit proves neither fund receipt nor the actual payday: "PPE 17/07" may identify the pay period end. Although $480 equals 12% of $4,000, the amount does not establish qualifying earnings. Obtain the payroll record, employee eligibility, actual payday and fund receipt confirmation, then apply the relevant Rule 3 deadline. Confirm the contribution's purpose and receipt before determining the employer's deduction and its income year.
 
-**Classification:** EXCLUDE -- SG contribution for employee, on time under payday super. Tax-deductible business expense.
+**Classification:** EXCLUDE -- candidate employee super contribution. Amount, timeliness and deductibility remain unverified from this bank line alone.
 
 ### Example 2 -- Personal voluntary super contribution (sole trader)
 
@@ -183,9 +180,9 @@ Matches "BPAY" + "HOSTPLUS" (pattern 3.2). Sole trader making a personal super c
 `21.08.2026 ; SUPERCHOICE CLEARING ; DEBIT ; SUPER PPE 14/08 ALL EMPLOYEES ; -960.00 ; AUD`
 
 **Reasoning:**
-Commercial clearing house debit covering both employees for the 14 August payday (pattern 3.3). The ATO Small Business Super Clearing House closed permanently on 1 July 2026, so any post-June-2026 clearing house payment is a commercial provider or payroll-software-integrated service. On-time test = fund receipt within 7 business days of the 14 August payday, NOT the clearing house debit date -- flag if fund receipt confirmation is unavailable.
+Matches the commercial clearing house pattern (3.3). "PPE 14/08" suggests a pay period end; obtain payroll records to identify the actual payday, employees and qualifying earnings. Apply the Rule 3 deadline to confirmed fund receipt. The clearing house debit alone cannot establish timeliness or the employer's deduction and its income year.
 
-**Classification:** EXCLUDE -- SG contributions via commercial clearing house. Tax-deductible. Flag fund-receipt timing for confirmation.
+**Classification:** EXCLUDE -- candidate employee super contributions via a commercial clearing house. Confirm payroll allocation, fund receipt and deductibility.
 
 ### Example 4 -- Annual maximum contribution base reached
 
@@ -221,7 +218,14 @@ Matches "ATO" + "IAS" (pattern 3.6). This is an Instalment Activity Statement (P
 
 ### Rule 1 -- SG formula (payday super)
 
-- **SG formula (payday super)** — remaining_base = max(0, $270,830 - YTD_qualifying_earnings_before_this_payday) SG per payday = 12% x min(Qualifying_earnings_paid_this_payday, remaining_base). SG applies only to the first $270,830 of qualifying earnings paid in the financial year -- the payday that crosses the base attracts SG only on the portion beneath it, and later paydays attract none. Annual maximum SG per employee: exactly $32,499.60. No $450/month threshold (removed 1 July 2022). Test employment eligibility separately. The removal of the $450 monthly threshold did not remove exclusions, including employees under 18 who do not work more than 30 hours in a week and the separate private/domestic work exclusion where hours do not exceed 30 in a week.  _(SGAA 1992 ss 27–29 (https://www.ato.gov.au/law/view/document?docid=PAC/19920111/27))_
+Establish SG eligibility before calculating. The $450 monthly earnings threshold ended on 1 July 2022, but employee exclusions still apply. An employee under 18 must work **more than 30 actual hours in the week**: exactly 30 does not qualify. Assess each week, including within a fortnightly pay cycle. Some contractors are employees for SG purposes, including qualifying labour contracts under SGAA s 12(3); refer uncertain cases to T2-1. Work wholly or principally of a domestic or private nature for 30 hours or less a week is excluded under s 12(11). Check any separate award or agreement obligation. See [business.gov.au: superannuation](https://business.gov.au/finance/superannuation) and [SGAA s 12](https://www.ato.gov.au/law/view/print?DocID=PAC%2F19920111%2F12&PiT=99991231235958).
+
+```
+remaining_base = max(0, $270,830 - YTD_qualifying_earnings_before_this_payday)
+SG per payday  = 12% x min(Qualifying_earnings_paid_this_payday, remaining_base)
+```
+
+SG applies only to the first $270,830 of qualifying earnings paid in the financial year -- the payday that crosses the base attracts SG only on the portion beneath it, and later paydays attract none. Annual maximum SG per employee: exactly $32,499.60.
 
 ### Rule 2 -- SG rate
 
@@ -257,7 +261,20 @@ Matches "ATO" + "IAS" (pattern 3.6). This is an Instalment Activity Statement (P
 
 ### Rule 10 -- Division 293 (additional 15% for high earners)
 
-- **Division 293** — Division 293 income is income for surcharge purposes excluding reportable super contributions, plus applicable low-tax contributions. Include the relevant reportable fringe benefits and net investment losses; apply statutory exclusions, including assessable FHSS released amounts. Tax is 15% of the lesser of low-tax contributions and the positive excess over $250,000. Exclude excess concessional contributions from low-tax contributions. Example: taxable income $230,000, reportable fringe benefits $20,000 and applicable low-tax contributions $25,000, with no other adjustments, give $275,000 for the threshold test. Division 293 tax is 15% of $25,000 = $3,750.  _(ITAA 1997 ss 293-20 and 293-25 (https://www.ato.gov.au/law/view/document?docid=PAC/19970038/293-20))_
+Use the tax return and fund-reported amounts:
+
+1. Division 293 income is taxable income plus reportable fringe benefits, net financial investment loss, net rental property loss and the net amount subject to family trust distribution tax. Subtract taxed super lump sum elements subject to a zero tax rate and assessable First Home Super Saver released amounts. Do not add reportable super contributions to this income subtotal.
+2. Low-tax contributions generally comprise concessional contributions, including SG, salary sacrifice and deductible personal contributions, less excess concessional contributions. Contributions covered by carried-forward caps still count. Apply the special roll-over rules where relevant; defined benefit and constitutionally protected funds remain outside scope. ATO discretion to disregard or reallocate excess contributions does not remove those contributions from Division 293.
+3. Calculate:
+
+```
+threshold_excess = max(0, Division_293_income + low_tax_contributions - $250,000)
+Division_293_tax = 15% x min(low_tax_contributions, threshold_excess)
+```
+
+For $210,000 taxable income, $20,000 reportable fringe benefits, $30,000 low-tax contributions and no other adjustments, the combined amount is $260,000. Tax is 15% x $10,000 = **$1,500**.
+
+Sources: [ATO: Division 293](https://www.ato.gov.au/individuals-and-families/super-for-individuals-and-families/super/growing-and-keeping-track-of-your-super/caps-limits-and-tax-on-super-contributions/division-293-tax-on-concessional-contributions-by-high-income-earners), ITAA 1997 ss 293-20 to 293-30. Threshold: $250,000, not indexed.
 
 ### Rule 11 -- Redesigned SGC (QE days from 1 July 2026)
 
@@ -283,6 +300,7 @@ ENTITY AND STRUCTURE
 
 EMPLOYER SG (PER EMPLOYEE PER PAYDAY)
   Employee name:                  [____]
+  SG eligibility / age / weekly hours: [____]  (Rule 1)
   Payday (QE day):                [____]
   Qualifying earnings this payday: AUD [____]
   YTD qualifying earnings:        AUD [____]  (SG only on QE up to $270,830 YTD; prorate the crossing payday per Rule 1)
@@ -308,8 +326,11 @@ CONTRIBUTION CAP CHECK
 
 DIVISION 293
   Taxable income:                 AUD [____]
-  Concessional contributions:     AUD [____]
-  Div 293 income:                 AUD [____]
+  Income additions (Rule 10):     AUD [____]  (itemise each component)
+  Income subtractions (Rule 10):  AUD [____]  (itemise each component)
+  Div 293 income subtotal:        AUD [____]
+  Low-tax contributions:          AUD [____]  (Rule 10; reconcile to fund reports)
+  Combined amount above $250,000: AUD [____]  (minimum zero)
   Div 293 tax (if applicable):    AUD [____]
 
 REVIEWER FLAGS
@@ -406,7 +427,7 @@ If the client provides only a bank statement:
 
 **Test 3:** Sole trader contributes $25,000, lodges s 290-150. TSB $200,000. -> $25,000 concessional. Deduction $25,000. Within $32,500 cap.
 
-Taxable income $260,000, concessional $30,000. -> Div 293 income $290,000. Div 293 tax = 15% x $30,000 = $4,500.
+**Test 4:** Taxable income $260,000, low-tax contributions $30,000, no other income adjustments. -> Combined amount $290,000. Div 293 tax = 15% x $30,000 = $4,500. With $210,000 taxable income, $20,000 reportable fringe benefits and the same contributions, tax is $1,500 (Rule 10).
 
 **Test 5:** TSB $400,000. Unused cap: $5,000 (2023-24) + $10,000 (2024-25) + $15,000 (2025-26). -> Available 2026-27 cap = $32,500 + $30,000 = $62,500.
 
@@ -419,6 +440,10 @@ Sole trader asks about SG to self. -> $0. No obligation. Advise voluntary contri
 **Test 9:** Payday Friday 4 Sep 2026; contribution received by fund Wednesday 16 Sep 2026 (8 business days). -> LATE. ATO-assessed SGC per Rule 11; new-regime SGC deductible.
 
 **Test 10:** New employee starts, first payday 10 Jul 2026, no fund details yet. -> First contribution due within 20 business days of the QE day; subsequent paydays revert to 7.
+
+**Test 11:** Employee aged 17 works exactly 30 hours in one week and 31 in the next. -> The first week fails the SG hours test; the second meets it. Check separate award or agreement obligations and the qualifying earnings attributable to each week.
+
+**Test 12:** Only the bank debit in Example 1 is available. -> Candidate super contribution; actual payday, qualifying earnings, fund receipt, timeliness and deduction remain unverified.
 
 ### Prohibitions
 

--- a/skills/international/australia/australia-payroll.md
+++ b/skills/international/australia/australia-payroll.md
@@ -11,25 +11,17 @@ description: >
   "activity statement", "annual leave", "long service leave",
   "minimum wage Australia", or any question about running payroll in Australia.
   ALWAYS read this skill before processing any Australian payroll work.
-version: 2.3
+version: 2.4
 jurisdiction: AU
 tax_year: 2025
-last_updated: 2026-09-10
+last_updated: 2026-09-11
 review_status: pending_review
 category: payroll
 tier: 2
 license: AGPL-3.0-or-later (code) / OpenAccountants Guide License v1.0 (content)
 ---
 
-# Australia — Payroll Skill v2.3
-
-## Australia -- Payroll Skill v2.3
-
-## Australia -- Payroll Skill v2.3
-
-## Australia -- Payroll Skill v2.3
-
-## Australia -- Payroll Skill v2.3
+# Australia -- Payroll Skill v2.4
 
 ## Section 1 -- Quick Reference
 
@@ -47,7 +39,7 @@ license: AGPL-3.0-or-later (code) / OpenAccountants Guide License v1.0 (content)
 | Pay frequency | Weekly, fortnightly, monthly (fortnightly most common) |
 | Employer registration | ABN + PAYG withholding registration via ATO |
 | Validated by | Pending -- requires sign-off by an Australian CPA, CA, or registered tax agent |
-| Skill version | 2.3 |
+| Skill version | 2.4 |
 
 ## Section 2 -- Income Tax Withholding (PAYG)
 
@@ -105,6 +97,8 @@ Australia does not have a separate employee social security contribution. The Me
 There is no employee-paid social insurance premium equivalent to NIC (UK) or social security tax (US).
 
 ## Section 4 -- Employer contributions
+
+An under-18 employee must work more than 30 actual hours in the week to qualify for SG; exactly 30 does not qualify. Apply the hours test each week, including within a fortnightly pay cycle. Some labour contractors qualify for SG; domestic/private work and other statutory exclusions need separate assessment. Check award or agreement obligations too. See Rule 1 in [au-super-guarantee](au-super-guarantee.md) and [business.gov.au: superannuation](https://business.gov.au/finance/superannuation).
 
 **Superannuation Guarantee summary**
 


### PR DESCRIPTION
## What this PR does

Correct three Australian source guides. Division 293 now lists the income adjustments and low-tax contribution rules, with the $1,500 counterexample. SG eligibility uses actual weekly hours for under-18 employees, including the exactly-30 boundary. Bank-debit examples require payroll and fund-receipt evidence before determining timeliness or deductions. R&D guidance includes the discretionary registration-extension route and its limits.

## Country/jurisdiction affected

Australia: employer SG, personal super contributions, Division 293, payroll and R&D registration.

## Verification and limits

Repository and MCP unit suites, guide validation, strict source metadata audit and `git diff --check` pass locally. The validator retains the existing missing-jurisdiction warning group. Worked examples, statutory references and review status were reread. No new full LLM evaluation or professional sign-off is claimed.

The guides remain pending professional review. Confirm platform ingestion of the merged source and verify the generated and hosted bodies afterwards. The patch changes source guides only.

## Legal: Contributor License Agreement (CLA)

- [x] **I have read [CLA.md](https://github.com/openaccountants/openaccountants/blob/main/CLA.md) and agree to the Contributor License Agreement** for everything included in this pull request.

## Checklist

- [x] Files are under `skills/**`; jurisdiction is AU.
- [x] Generated files are unchanged.
- [x] Attribution: Ryan Duguid.
- [x] Corrected rates and thresholds cite primary sources.
- [x] Worked examples and disclaimers are retained.
- [ ] Tested by uploading the complete workflow to an LLM and checking its output.
