### PR TITLE
Read guide ingestion paths from the Commits API

### DIFF
--- a/.github/workflows/ingest-to-platform.yml
+++ b/.github/workflows/ingest-to-platform.yml
@@ -15,6 +15,9 @@ on:
     paths:
       - "skills/**"
 
+permissions:
+  contents: read
+
 jobs:
   ring:
     runs-on: ubuntu-latest
@@ -25,18 +28,26 @@ jobs:
           SECRET: ${{ secrets.PLATFORM_INGEST_SECRET }}
           PAYLOAD: ${{ toJson(github.event.commits) }}
           HEAD_SHA: ${{ github.sha }}
+          GH_TOKEN: ${{ github.token }}
         run: |
           set -euo pipefail
           if [ -z "$SECRET" ]; then
             echo "PLATFORM_INGEST_SECRET not set — doorbell inert."; exit 0
           fi
-          BODY=$(jq -cn --arg sha "$HEAD_SHA" --argjson commits "$PAYLOAD" '
+          # Actions omits file lists from push commits. Fetch each human
+          # commit's paginated files before preparing the ingestion request.
+          PATHS=$(
+            jq -r '.[] | select(.author.email != "sync@openaccountants.com") | .id' <<< "$PAYLOAD" |
+            while IFS= read -r commit; do
+              gh api --paginate "repos/$GITHUB_REPOSITORY/commits/$commit" \
+                --jq '[.files[] | select(.status != "removed") | .filename]' || exit 1
+            done |
+            jq -sc 'add // [] | map(select(startswith("skills/") and endswith(".md"))) | unique'
+          )
+          BODY=$(jq -cn --arg sha "$HEAD_SHA" --argjson commits "$PAYLOAD" --argjson paths "$PATHS" '
             {
               headSha: $sha,
-              paths: ([ $commits[] | select(.author.email != "sync@openaccountants.com")
-                        | ((.added // []) + (.modified // []))[] ]
-                      | map(select(startswith("skills/") and endswith(".md")))
-                      | unique),
+              paths: $paths,
               authors: ([ $commits[] | {name: .author.name, email: .author.email,
                                         login: (.author.username // null)} ]
                         | unique)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -36,7 +36,7 @@ Every skill in `skills/` that should appear on [openaccountants.com](https://www
 1. Live in a **recognized country folder** (`skills/international/<country>/`, `skills/federal/`, `skills/us-states/<code>/`), **or**
 2. Include **`jurisdiction:` in YAML frontmatter** (e.g. `MT`, `GB`, `US`, `US-CA`, `GLOBAL`, `INTL`)
 
-Guide changes made on openaccountants.com land here through the scheduled sync, committed under the responsible accountant's name. A merged pull request must be ingested and verified in the platform before the next outbound export; until automated inbound ingestion ships, a maintainer performs that step manually. The exporter must fail closed if its stored Git blob does not match the current source guide. Frontmatter uses `reviewed_by` + `review_status` (the legacy `verified_by` key is being retired automatically). Want your platform edits credited to your GitHub account? Set your GitHub username in your accountant profile on openaccountants.com.
+Guide changes made on openaccountants.com land here through the scheduled sync, committed under the responsible accountant's name. A merged pull request must be ingested and verified in the platform before the next outbound export. The ingestion workflow notifies the platform when configured; a maintainer handles failed notifications and backfills. The exporter must fail closed if its stored Git blob does not match the current source guide. Frontmatter uses `reviewed_by` + `review_status` (the legacy `verified_by` key is being retired automatically). Want your platform edits credited to your GitHub account? Set your GitHub username in your accountant profile on openaccountants.com.
 
 Full details: [docs/WEBSITE-SYNC.md](docs/WEBSITE-SYNC.md)
 

--- a/docs/WEBSITE-SYNC.md
+++ b/docs/WEBSITE-SYNC.md
@@ -5,10 +5,15 @@ website guide content. This repository is its public projection, and merged
 external changes to `skills/**` must be ingested back into the platform before
 the next outbound export.
 
-> **Current limitation:** automated repository-to-platform ingestion has not
-> shipped. A maintainer must run and verify the private platform ingest after
-> every merge that changes `skills/**`. Public GitHub Actions run after a push;
-> they can detect a stale export but cannot undo or prevent one.
+The `ingest-to-platform.yml` workflow notifies the private platform after a human
+guide change reaches `main`, when its repository secret is configured. It reads
+changed files from the paginated Commits API because Actions push payloads omit
+file lists. A successful notification still requires verified ingestion and
+export; the public workflow cannot confirm the platform's stored guide state.
+
+Earlier runs that reported `No human-edited guide files in this push.` while
+guides changed need maintainer backfill. This includes the three Australian
+guides merged in PR 157 at `e48c2f96909cb9ddd5e90324dc19fdf553ef6326`.
 
 ## Outbound (platform → repo), daily
 
@@ -36,7 +41,8 @@ attribution. A substantive edit supersedes any professional review of the
 previous text and therefore sets the guide back to `pending_review` until it is
 reviewed again.
 
-Until automated ingestion ships, the maintainer sequence is:
+If notification or ingestion fails, or a prior merge needs backfill, the
+maintainer sequence is:
 
 1. Identify every changed `skills/**` path in the merge commit.
 2. Pause outbound writes for those paths.

--- a/tests/test_ingest_workflow.py
+++ b/tests/test_ingest_workflow.py
@@ -1,0 +1,71 @@
+"""Exercise the ingestion shell with the file-free Actions push payload."""
+import json
+import os
+from pathlib import Path
+import shutil
+import subprocess
+import unittest
+
+import yaml
+
+
+@unittest.skipUnless(shutil.which("bash") and shutil.which("jq"), "requires bash and jq")
+class IngestWorkflowTests(unittest.TestCase):
+    def run_workflow(self, api_failure=False):
+        workflow = Path(__file__).resolve().parents[1] / ".github/workflows/ingest-to-platform.yml"
+        script = yaml.safe_load(workflow.read_text(encoding="utf-8"))["jobs"]["ring"]["steps"][0]["run"]
+        commits = [
+            {"id": "human", "author": {"name": "Contributor", "email": "person@example.test", "username": "contributor"}},
+            {"id": "bot", "author": {"name": "Sync", "email": "sync@openaccountants.com"}},
+        ]
+        pages = [
+            {"files": [{"filename": "skills/example.md", "status": "modified"},
+                       {"filename": "skills/removed.md", "status": "removed"},
+                       {"filename": "README.md", "status": "modified"}]},
+            {"files": [{"filename": "skills/example.md", "status": "modified"},
+                       {"filename": "skills/new.md", "status": "added"},
+                       {"filename": "skills/renamed.md", "status": "renamed"}]},
+        ]
+        # Stub only network boundaries. Run the workflow's Bash and jq unchanged.
+        stubs = r'''
+        gh() {
+          [ "$API_FAILURE" = "0" ] || return 1
+          [ "$3" = "repos/example/guides/commits/human" ] || return 2
+          printf '%s\n' "$API_PAGES" | jq "$5"
+        }
+        curl() {
+          while [ "$#" -gt 0 ]; do
+            if [ "$1" = "-d" ]; then printf 'CAPTURED_BODY=%s\n' "$2" >&2; printf '{}'; return; fi
+            shift
+          done
+          return 3
+        }
+        '''
+        if os.name == "nt":
+            # Match the Ubuntu runner's LF output when using native Windows jq.
+            stubs = 'jq() { command jq --binary "$@"; }\n' + stubs
+        env = {**os.environ, "SECRET": "synthetic-test-value", "PAYLOAD": json.dumps(commits),
+               "HEAD_SHA": "head", "GITHUB_REPOSITORY": "example/guides",
+               "API_PAGES": "\n".join(json.dumps(page) for page in pages),
+               "API_FAILURE": "1" if api_failure else "0"}
+        return subprocess.run([shutil.which("bash"), "--noprofile", "--norc"],
+                              input=stubs + script, env=env, text=True, capture_output=True)
+
+    def test_human_commit_without_file_attributes_reaches_platform(self):
+        result = self.run_workflow()
+        self.assertEqual(result.returncode, 0, result.stderr)
+        bodies = [line.removeprefix("CAPTURED_BODY=") for line in result.stderr.splitlines()
+                  if line.startswith("CAPTURED_BODY=")]
+        self.assertEqual(len(bodies), 1, result.stdout)
+        body = json.loads(bodies[0])
+        self.assertEqual(body["headSha"], "head")
+        self.assertEqual(body["paths"], ["skills/example.md", "skills/new.md", "skills/renamed.md"])
+
+    def test_commit_lookup_failure_does_not_send_partial_ingestion(self):
+        result = self.run_workflow(api_failure=True)
+        self.assertNotEqual(result.returncode, 0)
+        self.assertNotIn("CAPTURED_BODY=", result.stderr)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
The ingestion run after #157 reported no changed guides and sent no request. GitHub Actions omits `added`, `modified` and `removed` from push commit objects, so the current path collector always returns an empty list.

Fetch paginated file lists for each human commit with the read-only GitHub token. Keep the sync-bot filter, exclude deleted and non-guide paths, deduplicate paths and stop before notifying the platform if a lookup fails. Update the sync instructions to distinguish notification from verified ingestion.

All 85 repository tests pass locally, including two regressions that failed on the previous workflow. The tests run its Bash and jq with network boundaries stubbed, covering absent payload file lists, pagination, duplicate paths, additions, renames, deletions and API failure. The real Commits API returns all three changed guide paths for the #157 merge. All five hosted checks pass; the Linux job ran both new regressions, all 85 repository tests and all 33 MCP tests.

The maintainer still needs to backfill the three Australian guides from `e48c2f96909cb9ddd5e90324dc19fdf553ef6326` and verify the stored content and export. This workflow fix does not replay earlier merges. No generated guide files are changed; private ingestion and hosted delivery remain unverified.

Reference: [GitHub Actions push payload documentation](https://docs.github.com/en/actions/reference/workflows-and-actions/events-that-trigger-workflows#push).

- [x] **I have read [CLA.md](https://github.com/openaccountants/openaccountants/blob/main/CLA.md) and agree to the Contributor License Agreement** for everything included in this pull request.

